### PR TITLE
Consolidate component testing helper

### DIFF
--- a/internal/modules/configuration/plugin_describer_test.go
+++ b/internal/modules/configuration/plugin_describer_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/hashicorp/go-plugin"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	configFake "github.com/vmware/octant/internal/config/fake"
@@ -65,11 +64,8 @@ func TestPluginDescriber(t *testing.T) {
 
 	list.Add(table)
 
-	expected := component.ContentResponse{
-		Components: []component.Component{list},
-	}
-
-	assert.Equal(t, expected, cResponse)
+	require.Len(t, cResponse.Components, 1)
+	component.AssertEqual(t, list, cResponse.Components[0])
 }
 
 func newFakePluginClient(name string, controller *gomock.Controller) *fakePluginClient {

--- a/internal/modules/overview/printer/clusterrole_test.go
+++ b/internal/modules/overview/printer/clusterrole_test.go
@@ -49,7 +49,7 @@ func Test_ClusterRoleListHandler(t *testing.T) {
 		"Age":  component.NewTimestamp(now),
 	})
 
-	assertComponentEqual(t, expected, got)
+	component.AssertEqual(t, expected, got)
 }
 
 func Test_printClusterRoleConfig(t *testing.T) {
@@ -65,7 +65,7 @@ func Test_printClusterRoleConfig(t *testing.T) {
 	sections.AddText("Name", clusterRole.Name)
 	expected := component.NewSummary("Configuration", sections...)
 
-	assertComponentEqual(t, expected, observed)
+	component.AssertEqual(t, expected, observed)
 }
 
 func Test_printClusterRolePolicyRule(t *testing.T) {

--- a/internal/modules/overview/printer/clusterrolebinding_test.go
+++ b/internal/modules/overview/printer/clusterrolebinding_test.go
@@ -61,7 +61,7 @@ func Test_ClusterRoleBindingListHandler(t *testing.T) {
 		"Role name": component.NewLink("", "role-name", "/cluster-role-path"),
 	})
 
-	assertComponentEqual(t, expected, observed)
+	component.AssertEqual(t, expected, observed)
 }
 
 func Test_printClusterRoleBindingSubjects(t *testing.T) {
@@ -91,7 +91,7 @@ func Test_printClusterRoleBindingSubjects(t *testing.T) {
 
 	expected.Add(row)
 
-	assertComponentEqual(t, expected, observed)
+	component.AssertEqual(t, expected, observed)
 }
 
 func Test_printClusterRoleBindingConfig(t *testing.T) {
@@ -117,5 +117,5 @@ func Test_printClusterRoleBindingConfig(t *testing.T) {
 
 	expected := component.NewSummary("Configuration", sections...)
 
-	assertComponentEqual(t, expected, observed)
+	component.AssertEqual(t, expected, observed)
 }

--- a/internal/modules/overview/printer/configmap_test.go
+++ b/internal/modules/overview/printer/configmap_test.go
@@ -60,7 +60,7 @@ func Test_ConfigMapListHandler(t *testing.T) {
 		"Age":    component.NewTimestamp(now),
 	})
 
-	assertComponentEqual(t, expected, got)
+	component.AssertEqual(t, expected, got)
 }
 
 func Test_describeConfigMapConfiguration(t *testing.T) {

--- a/internal/modules/overview/printer/container_test.go
+++ b/internal/modules/overview/printer/container_test.go
@@ -295,7 +295,7 @@ func Test_ContainerConfiguration(t *testing.T) {
 			}
 			require.NoError(t, err)
 
-			assertComponentEqual(t, tc.expected, summary)
+			component.AssertEqual(t, tc.expected, summary)
 		})
 	}
 }

--- a/internal/modules/overview/printer/cronjob_test.go
+++ b/internal/modules/overview/printer/cronjob_test.go
@@ -72,7 +72,7 @@ func Test_CronJobListHandler(t *testing.T) {
 		"Age":      component.NewTimestamp(now),
 	})
 
-	assertComponentEqual(t, expected, got)
+	component.AssertEqual(t, expected, got)
 }
 
 func TestCronJobConfiguration(t *testing.T) {

--- a/internal/modules/overview/printer/customresource_test.go
+++ b/internal/modules/overview/printer/customresource_test.go
@@ -57,7 +57,7 @@ func Test_CustomResourceListHandler(t *testing.T) {
 			},
 		})
 
-	assertComponentEqual(t, expected, got)
+	component.AssertEqual(t, expected, got)
 }
 
 func Test_CustomResourceListHandler_custom_columns(t *testing.T) {
@@ -99,7 +99,7 @@ func Test_CustomResourceListHandler_custom_columns(t *testing.T) {
 			},
 		})
 
-	assertComponentEqual(t, expected, got)
+	component.AssertEqual(t, expected, got)
 }
 
 func Test_printCustomResourceConfig(t *testing.T) {

--- a/internal/modules/overview/printer/deployment_test.go
+++ b/internal/modules/overview/printer/deployment_test.go
@@ -172,7 +172,7 @@ func Test_deploymentConfiguration(t *testing.T) {
 			}
 			require.NoError(t, err)
 
-			assertComponentEqual(t, tc.expected, summary)
+			component.AssertEqual(t, tc.expected, summary)
 		})
 	}
 }
@@ -308,7 +308,7 @@ func Test_deploymentPods(t *testing.T) {
 		},
 	})
 
-	assertComponentEqual(t, expected, got)
+	component.AssertEqual(t, expected, got)
 }
 
 func Test_editDeploymentAction(t *testing.T) {

--- a/internal/modules/overview/printer/event_test.go
+++ b/internal/modules/overview/printer/event_test.go
@@ -106,7 +106,7 @@ func Test_EventListHandler(t *testing.T) {
 		},
 	})
 
-	assertComponentEqual(t, expected, got)
+	component.AssertEqual(t, expected, got)
 }
 
 func Test_ReplicasetEvents(t *testing.T) {

--- a/internal/modules/overview/printer/helpers_test.go
+++ b/internal/modules/overview/printer/helpers_test.go
@@ -6,19 +6,14 @@ SPDX-License-Identifier: Apache-2.0
 package printer
 
 import (
-	"encoding/json"
-	"testing"
-
 	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	configFake "github.com/vmware/octant/internal/config/fake"
 	linkFake "github.com/vmware/octant/internal/link/fake"
-	objectStoreFake "github.com/vmware/octant/pkg/store/fake"
 	pluginFake "github.com/vmware/octant/pkg/plugin/fake"
+	objectStoreFake "github.com/vmware/octant/pkg/store/fake"
 	"github.com/vmware/octant/pkg/view/component"
 )
 
@@ -75,14 +70,4 @@ func (o *testPrinterOptions) PathForGVK(namespace, apiVersion, kind, name, text,
 func (o *testPrinterOptions) PathForOwner(parent runtime.Object, ownerReference *metav1.OwnerReference, ref string) {
 	l := component.NewLink("", ownerReference.Name, ref)
 	o.link.EXPECT().ForOwner(parent, ownerReference).Return(l, nil)
-}
-
-func assertComponentEqual(t *testing.T, expected, got component.Component) {
-	a, err := json.Marshal(expected)
-	require.NoError(t, err)
-
-	b, err := json.Marshal(got)
-	require.NoError(t, err)
-
-	assert.JSONEq(t, string(a), string(b))
 }

--- a/internal/modules/overview/printer/ingress_test.go
+++ b/internal/modules/overview/printer/ingress_test.go
@@ -187,7 +187,7 @@ func Test_printIngressConfig(t *testing.T) {
 			}
 			require.NoError(t, err)
 
-			assertComponentEqual(t, tc.expected, got)
+			component.AssertEqual(t, tc.expected, got)
 		})
 	}
 }
@@ -272,7 +272,7 @@ func Test_printIngressHosts(t *testing.T) {
 			}
 			require.NoError(t, err)
 
-			assertComponentEqual(t, tc.expected, got)
+			component.AssertEqual(t, tc.expected, got)
 		})
 	}
 }

--- a/internal/modules/overview/printer/object_test.go
+++ b/internal/modules/overview/printer/object_test.go
@@ -256,7 +256,7 @@ func Test_Object_ToComponent(t *testing.T) {
 			expected := component.NewFlexLayout("Summary")
 			expected.AddSections(tc.sections...)
 
-			assertComponentEqual(t, expected, got)
+			component.AssertEqual(t, expected, got)
 		})
 	}
 

--- a/internal/modules/overview/printer/pod_test.go
+++ b/internal/modules/overview/printer/pod_test.go
@@ -104,7 +104,7 @@ func Test_PodListHandler(t *testing.T) {
 		"Node":     component.NewText("node"),
 	})
 
-	assertComponentEqual(t, expected, got)
+	component.AssertEqual(t, expected, got)
 }
 
 var (
@@ -204,7 +204,7 @@ func Test_PodConfiguration(t *testing.T) {
 			}
 			require.NoError(t, err)
 
-			assertComponentEqual(t, tc.expected, summary)
+			component.AssertEqual(t, tc.expected, summary)
 		})
 	}
 }

--- a/internal/modules/overview/printer/replicaset_test.go
+++ b/internal/modules/overview/printer/replicaset_test.go
@@ -185,7 +185,7 @@ func TestReplicaSetConfiguration(t *testing.T) {
 			}
 			require.NoError(t, err)
 
-			assertComponentEqual(t, tc.expected, summary)
+			component.AssertEqual(t, tc.expected, summary)
 		})
 	}
 }

--- a/internal/modules/overview/printer/rolebinding_test.go
+++ b/internal/modules/overview/printer/rolebinding_test.go
@@ -54,7 +54,7 @@ func Test_RoleBindingListHandler(t *testing.T) {
 		"Role name": component.NewLink("", "pod-reader", "/role"),
 	})
 
-	assertComponentEqual(t, expected, observed)
+	component.AssertEqual(t, expected, observed)
 }
 
 func Test_printRoleBindingSubjects(t *testing.T) {
@@ -109,7 +109,7 @@ func Test_printRoleBindingSubjects(t *testing.T) {
 				component.NewTableCols("Kind", "Name", "Namespace"),
 				[]component.TableRow{tc.expected})
 
-			assertComponentEqual(t, expected, observed)
+			component.AssertEqual(t, expected, observed)
 		})
 	}
 }
@@ -137,5 +137,5 @@ func Test_printRoleBindingConfig(t *testing.T) {
 
 	expected := component.NewSummary("Configuration", sections...)
 
-	assertComponentEqual(t, expected, observed)
+	component.AssertEqual(t, expected, observed)
 }

--- a/internal/modules/overview/printer/serviceaccount_test.go
+++ b/internal/modules/overview/printer/serviceaccount_test.go
@@ -19,9 +19,9 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/vmware/octant/internal/testutil"
+	"github.com/vmware/octant/pkg/plugin"
 	"github.com/vmware/octant/pkg/store"
 	storefake "github.com/vmware/octant/pkg/store/fake"
-	"github.com/vmware/octant/pkg/plugin"
 	"github.com/vmware/octant/pkg/view/component"
 	"github.com/vmware/octant/pkg/view/flexlayout"
 )
@@ -113,7 +113,7 @@ func Test_serviceAccountHandler(t *testing.T) {
 
 	expected := fl.ToComponent("Summary")
 
-	assertComponentEqual(t, expected, got)
+	component.AssertEqual(t, expected, got)
 }
 
 func Test_printServiceAccountConfig(t *testing.T) {
@@ -171,7 +171,7 @@ func Test_printServiceAccountConfig(t *testing.T) {
 
 	expected := component.NewSummary("Configuration", sections...)
 
-	assertComponentEqual(t, expected, got)
+	component.AssertEqual(t, expected, got)
 }
 
 func Test_serviceAccountPolicyRules(t *testing.T) {

--- a/internal/modules/overview/printer/statefulset_test.go
+++ b/internal/modules/overview/printer/statefulset_test.go
@@ -93,7 +93,7 @@ func Test_StatefulSetListHandler(t *testing.T) {
 		"Selector": component.NewSelectors([]component.Selector{component.NewLabelSelector("app", "myapp")}),
 	})
 
-	assertComponentEqual(t, expected, got)
+	component.AssertEqual(t, expected, got)
 }
 
 func Test_StatefulSetStatus(t *testing.T) {

--- a/pkg/view/component/testing.go
+++ b/pkg/view/component/testing.go
@@ -1,0 +1,20 @@
+package component
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// AssertEqual asserts two components are equal.
+func AssertEqual(t *testing.T, expected, got Component) {
+	a, err := json.Marshal(expected)
+	require.NoError(t, err)
+
+	b, err := json.Marshal(got)
+	require.NoError(t, err)
+
+	assert.JSONEq(t, string(a), string(b))
+}


### PR DESCRIPTION
Creates `component.AssertEqual` that tests can use to compare
components and replaces all the duplicates.