### PR TITLE
Create plugin helper service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ internal/portforward/fake
 /pkg/store/fake
 /pkg/plugin/fake
 /pkg/plugin/api/fake
+/pkg/plugin/service/fake
 
 
 # electron bundling

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,10 +10,8 @@ linters-settings:
   goconst:
     min-len: 2
     min-occurrences: 2
-  lll:
-    line-length: 140
   goimports:
-    local-prefixes: github.com/golangci/golangci-lint
+    local-prefixes: github.com/vmware/octant
   gocritic:
     enabled-tags:
       - performance
@@ -29,3 +27,4 @@ linters:
     - maligned
     - prealloc
     - gochecknoglobals
+    - lll

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ octant-docker:
 
 generate:
 	@echo "-> $@"
-	@go generate -v ./pkg/store ./pkg/plugin/api/proto ./pkg/plugin/dashboard ./pkg/plugin/api ./pkg/plugin ./internal/...
+	@go generate -v ./pkg/... ./internal/...
 
 go-install:
 	@env GO111MODULE=on $(GOINSTALL) github.com/GeertJohan/go.rice

--- a/changelogs/unreleased/17-bryanl
+++ b/changelogs/unreleased/17-bryanl
@@ -1,0 +1,4 @@
+Create plugin helper service
+
+The plugin helper service provides a method for plugin authors to initialize
+and implement their plugins.

--- a/internal/commands/dash.go
+++ b/internal/commands/dash.go
@@ -7,7 +7,7 @@ package commands
 
 import (
 	"context"
-	"fmt"
+	golog "log"
 	"os"
 	"os/signal"
 
@@ -40,10 +40,15 @@ func newOctantCmd() *cobra.Command {
 
 			z, err := newZapLogger(verboseLevel)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "failed to initialize logger: %v\n", err)
+				golog.Printf("failed to initialize logger: %v", err)
 				os.Exit(1)
 			}
-			defer z.Sync()
+			defer func() {
+				if zErr := z.Sync(); zErr != nil {
+					golog.Printf("unable to sync logger: %v", zErr)
+				}
+			}()
+
 			logger := log.Wrap(z.Sugar())
 
 			sigCh := make(chan os.Signal, 1)

--- a/pkg/plugin/grpc.go
+++ b/pkg/plugin/grpc.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/status"
@@ -149,7 +150,8 @@ func (c *GRPCClient) Register(dashboardAPIAddress string) (Metadata, error) {
 
 		resp, err := c.client.Register(context.Background(), registerRequest)
 		if err != nil {
-			return errors.Wrap(err, "grpc client register")
+			spew.Dump(err)
+			return errors.WithMessage(err, "unable to call register function")
 		}
 
 		capabilities := convertToCapabilities(resp.Capabilities)

--- a/pkg/plugin/service/dashboard.go
+++ b/pkg/plugin/service/dashboard.go
@@ -1,0 +1,33 @@
+package service
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/vmware/octant/pkg/plugin/api"
+	"github.com/vmware/octant/pkg/store"
+)
+
+//go:generate mockgen -source=dashboard.go -destination=./fake/mock_dashboard.go -package=fake github.com/vmware/octant/pkg/plugin/service Dashboard
+
+// Dashboard is the client a plugin can use to interact with Octant.
+type Dashboard interface {
+	Close() error
+	List(ctx context.Context, key store.Key) ([]*unstructured.Unstructured, error)
+	Get(ctx context.Context, key store.Key) (*unstructured.Unstructured, error)
+	Update(ctx context.Context, object *unstructured.Unstructured) error
+	PortForward(ctx context.Context, req api.PortForwardRequest) (api.PortForwardResponse, error)
+	CancelPortForward(ctx context.Context, id string)
+	ForceFrontendUpdate(ctx context.Context) error
+}
+
+// NewDashboardClient creates a dashboard client.
+func NewDashboardClient(dashboardAPIAddress string) (Dashboard, error) {
+	client, err := api.NewClient(dashboardAPIAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	return client, nil
+}

--- a/pkg/plugin/service/handler.go
+++ b/pkg/plugin/service/handler.go
@@ -1,0 +1,92 @@
+package service
+
+import (
+	"sync"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/vmware/octant/pkg/action"
+	"github.com/vmware/octant/pkg/plugin"
+	"github.com/vmware/octant/pkg/view/component"
+)
+
+// Handler is the plugin service helper handler. Functions on this struct are called from Octant.
+type Handler struct {
+	HandlerFuncs
+
+	mu sync.Mutex
+
+	name         string
+	description  string
+	capabilities *plugin.Capabilities
+
+	dashboardFactory func(dashboardAPIAddress string) (Dashboard, error)
+	dashboardClient  Dashboard
+}
+
+var _ plugin.Service = (*Handler)(nil)
+
+// Validate validates Handler.
+func (p *Handler) Validate() error {
+	if p.dashboardFactory == nil {
+		return errors.New("plugin handler doesn't know how to create a dashboard client")
+	}
+
+	return nil
+}
+
+// Register registers a plugin with Octant.
+func (p *Handler) Register(dashboardAPIAddress string) (plugin.Metadata, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	client, err := p.dashboardFactory(dashboardAPIAddress)
+	if err != nil {
+		return plugin.Metadata{}, errors.Wrap(err, "create api client")
+	}
+
+	p.dashboardClient = client
+
+	return plugin.Metadata{
+		Name:         p.name,
+		Description:  p.description,
+		Capabilities: *p.capabilities,
+	}, nil
+}
+
+// Print prints components for an object.
+func (p *Handler) Print(object runtime.Object) (plugin.PrintResponse, error) {
+	if p.HandlerFuncs.Print == nil {
+		return plugin.PrintResponse{}, nil
+	}
+
+	return p.HandlerFuncs.Print(p.dashboardClient, object)
+}
+
+// PrintTab prints a tab for an object.
+func (p *Handler) PrintTab(object runtime.Object) (*component.Tab, error) {
+	if p.HandlerFuncs.PrintTab == nil {
+		return &component.Tab{}, nil
+	}
+
+	return p.HandlerFuncs.PrintTab(p.dashboardClient, object)
+}
+
+// ObjectStatus creates status for an object.
+func (p *Handler) ObjectStatus(object runtime.Object) (plugin.ObjectStatusResponse, error) {
+	if p.HandlerFuncs.ObjectStatus == nil {
+		return plugin.ObjectStatusResponse{}, nil
+	}
+
+	return p.HandlerFuncs.ObjectStatus(p.dashboardClient, object)
+}
+
+// HandleAction handles actions given a payload.
+func (p *Handler) HandleAction(payload action.Payload) error {
+	if p.HandlerFuncs.HandleAction == nil {
+		return nil
+	}
+
+	return p.HandlerFuncs.HandleAction(p.dashboardClient, payload)
+}

--- a/pkg/plugin/service/handler_test.go
+++ b/pkg/plugin/service/handler_test.go
@@ -1,0 +1,267 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/vmware/octant/internal/gvk"
+	"github.com/vmware/octant/internal/testutil"
+	"github.com/vmware/octant/pkg/action"
+	"github.com/vmware/octant/pkg/plugin"
+	"github.com/vmware/octant/pkg/plugin/service/fake"
+	"github.com/vmware/octant/pkg/view/component"
+)
+
+func TestHandler_Register(t *testing.T) {
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	dashboard := fake.NewMockDashboard(controller)
+	factory := func(string) (Dashboard, error) {
+		return dashboard, nil
+	}
+
+	capabilities := &plugin.Capabilities{
+		SupportsPrinterConfig: []schema.GroupVersionKind{gvk.PodGVK},
+	}
+
+	h := Handler{
+		name:             "name",
+		description:      "description",
+		capabilities:     capabilities,
+		dashboardFactory: factory,
+	}
+
+	got, err := h.Register("address")
+	require.NoError(t, err)
+
+	expected := plugin.Metadata{
+		Name:         "name",
+		Description:  "description",
+		Capabilities: *capabilities,
+	}
+
+	require.Equal(t, expected, got)
+}
+
+func TestHandler_Register_with_dashboard_factory_failure(t *testing.T) {
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	factory := func(string) (Dashboard, error) {
+		return nil, errors.New("failure")
+	}
+
+	capabilities := &plugin.Capabilities{
+		SupportsPrinterConfig: []schema.GroupVersionKind{gvk.PodGVK},
+	}
+
+	h := Handler{
+		name:             "name",
+		description:      "description",
+		capabilities:     capabilities,
+		dashboardFactory: factory,
+	}
+
+	_, err := h.Register("address")
+	require.Error(t, err)
+}
+
+func TestHandler_Print_default(t *testing.T) {
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	dashboardClient := fake.NewMockDashboard(controller)
+
+	h := Handler{
+		dashboardClient: dashboardClient,
+	}
+
+	pod := testutil.CreatePod("pod")
+
+	got, err := h.Print(pod)
+	require.NoError(t, err)
+
+	expected := plugin.PrintResponse{}
+
+	require.Equal(t, expected, got)
+}
+
+func TestHandler_Print_using_supplied_function(t *testing.T) {
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	pod := testutil.CreatePod("pod")
+
+	dashboardClient := fake.NewMockDashboard(controller)
+
+	ran := false
+	h := Handler{
+		HandlerFuncs: HandlerFuncs{
+			Print: func(gotClient Dashboard, gotObject runtime.Object) (response plugin.PrintResponse, e error) {
+				ran = true
+				assert.Equal(t, dashboardClient, gotClient)
+				assert.Equal(t, pod, gotObject)
+				return plugin.PrintResponse{}, nil
+			},
+		},
+		dashboardClient: dashboardClient,
+	}
+
+	got, err := h.Print(pod)
+	require.NoError(t, err)
+
+	expected := plugin.PrintResponse{}
+
+	assert.Equal(t, expected, got)
+	assert.True(t, ran)
+}
+
+func TestHandler_PrintTab_default(t *testing.T) {
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	dashboardClient := fake.NewMockDashboard(controller)
+
+	h := Handler{
+		dashboardClient: dashboardClient,
+	}
+
+	pod := testutil.CreatePod("pod")
+
+	got, err := h.PrintTab(pod)
+	require.NoError(t, err)
+
+	expected := &component.Tab{}
+
+	require.Equal(t, expected, got)
+}
+
+func TestHandler_PrintTab_using_supplied_function(t *testing.T) {
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	pod := testutil.CreatePod("pod")
+
+	dashboardClient := fake.NewMockDashboard(controller)
+
+	ran := false
+
+	h := Handler{
+		dashboardClient: dashboardClient,
+		HandlerFuncs: HandlerFuncs{
+			PrintTab: func(gotClient Dashboard, gotObject runtime.Object) (tab *component.Tab, e error) {
+				ran = true
+				assert.Equal(t, dashboardClient, gotClient)
+				assert.Equal(t, pod, gotObject)
+				return &component.Tab{}, nil
+			},
+		},
+	}
+
+	got, err := h.PrintTab(pod)
+	require.NoError(t, err)
+
+	expected := &component.Tab{}
+	assert.Equal(t, expected, got)
+	assert.True(t, ran)
+}
+
+func TestHandler_ObjectStatus_default(t *testing.T) {
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	dashboardClient := fake.NewMockDashboard(controller)
+
+	h := Handler{
+		dashboardClient: dashboardClient,
+	}
+
+	pod := testutil.CreatePod("pod")
+
+	got, err := h.ObjectStatus(pod)
+	require.NoError(t, err)
+
+	expected := plugin.ObjectStatusResponse{}
+
+	require.Equal(t, expected, got)
+}
+
+func TestHandler_ObjectStatus_using_supplied_function(t *testing.T) {
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	dashboardClient := fake.NewMockDashboard(controller)
+	pod := testutil.CreatePod("pod")
+
+	ran := false
+
+	h := Handler{
+		dashboardClient: dashboardClient,
+		HandlerFuncs: HandlerFuncs{
+			ObjectStatus: func(gotClient Dashboard, gotObject runtime.Object) (response plugin.ObjectStatusResponse, e error) {
+				ran = true
+				assert.Equal(t, dashboardClient, gotClient)
+				assert.Equal(t, pod, gotObject)
+				return plugin.ObjectStatusResponse{}, nil
+			},
+		},
+	}
+
+	got, err := h.ObjectStatus(pod)
+	require.NoError(t, err)
+
+	expected := plugin.ObjectStatusResponse{}
+	assert.Equal(t, expected, got)
+	assert.True(t, ran)
+}
+
+func TestHandler_HandleAction_default(t *testing.T) {
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	dashboardClient := fake.NewMockDashboard(controller)
+
+	h := Handler{
+		dashboardClient: dashboardClient,
+	}
+
+	payload := action.Payload{"foo": "bar"}
+
+	err := h.HandleAction(payload)
+	require.NoError(t, err)
+}
+
+func TestHandler_HandleAction_using_supplied_function(t *testing.T) {
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	dashboardClient := fake.NewMockDashboard(controller)
+
+	payload := action.Payload{"foo": "bar"}
+
+	ran := false
+
+	h := Handler{
+		dashboardClient: dashboardClient,
+		HandlerFuncs: HandlerFuncs{
+			HandleAction: func(gotClient Dashboard, gotPayload action.Payload) error {
+				ran = true
+				assert.Equal(t, dashboardClient, gotClient)
+				assert.Equal(t, payload, gotPayload)
+
+				return nil
+			},
+		},
+	}
+
+	err := h.HandleAction(payload)
+	assert.NoError(t, err)
+	assert.True(t, ran)
+}

--- a/pkg/plugin/service/service.go
+++ b/pkg/plugin/service/service.go
@@ -1,0 +1,94 @@
+/*
+Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package service
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/vmware/octant/pkg/action"
+	"github.com/vmware/octant/pkg/plugin"
+	"github.com/vmware/octant/pkg/view/component"
+)
+
+func defaultServerFactory(service plugin.Service) {
+	plugin.Serve(service)
+}
+
+// PluginOption is an option for configuring Plugin.
+type PluginOption func(p *Plugin)
+
+// Plugin is a plugin service helper.
+type Plugin struct {
+	pluginHandler *Handler
+	serverFactory func(service plugin.Service)
+}
+
+// Register registers a plugin with Octant.
+func Register(name, description string, capabilities *plugin.Capabilities, handlers HandlerFuncs, options ...PluginOption) (*Plugin, error) {
+	p := &Plugin{
+		pluginHandler: &Handler{
+			name:             name,
+			description:      description,
+			capabilities:     capabilities,
+			HandlerFuncs:     handlers,
+			dashboardFactory: NewDashboardClient,
+		},
+
+		serverFactory: defaultServerFactory,
+	}
+
+	for _, option := range options {
+		option(p)
+	}
+
+	if err := p.Validate(); err != nil {
+		return nil, err
+	}
+
+	return p, nil
+}
+
+// Validate validates this helper.
+func (p *Plugin) Validate() error {
+	var list []string
+
+	if p.pluginHandler.name == "" {
+		list = append(list, "requires name")
+	}
+	if p.pluginHandler.description == "" {
+		list = append(list, "requires description")
+	}
+
+	if p.pluginHandler.capabilities == nil {
+		list = append(list, "requires capabilities")
+	}
+
+	if err := p.pluginHandler.Validate(); err != nil {
+		list = append(list, err.Error())
+	}
+
+	if len(list) == 0 {
+		return nil
+	}
+
+	return errors.Errorf("validation errors: %s", strings.Join(list, ", "))
+}
+
+// Serve serves a plugin.
+func (p *Plugin) Serve() {
+	p.serverFactory(p.pluginHandler)
+}
+
+// HandlerFuncs are functions for configuring a plugin.
+type HandlerFuncs struct {
+	Print        func(dashboardClient Dashboard, object runtime.Object) (plugin.PrintResponse, error)
+	PrintTab     func(dashboardClient Dashboard, object runtime.Object) (*component.Tab, error)
+	ObjectStatus func(dashboardClient Dashboard, object runtime.Object) (plugin.ObjectStatusResponse, error)
+	HandleAction func(dashboardClient Dashboard, payload action.Payload) error
+}

--- a/pkg/plugin/service/service_test.go
+++ b/pkg/plugin/service/service_test.go
@@ -1,0 +1,107 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vmware/octant/pkg/plugin"
+)
+
+func TestNewPlugin(t *testing.T) {
+	name := "plugin-name"
+	description := "description"
+	capabilities := &plugin.Capabilities{}
+
+	type args struct {
+		name         string
+		description  string
+		capabilities *plugin.Capabilities
+	}
+
+	tests := []struct {
+		name  string
+		args  args
+		isErr bool
+	}{
+		{
+			name: "with correct parameters",
+			args: args{
+				name:         name,
+				description:  description,
+				capabilities: capabilities,
+			},
+		},
+		{
+			name: "blank name",
+			args: args{
+				name:         "",
+				description:  description,
+				capabilities: capabilities,
+			},
+			isErr: true,
+		},
+		{
+			name: "blank description",
+			args: args{
+				name:         description,
+				description:  "",
+				capabilities: capabilities,
+			},
+			isErr: true,
+		},
+		{
+			name: "nil capabilities",
+			args: args{
+				name:         name,
+				description:  description,
+				capabilities: nil,
+			},
+			isErr: true,
+		},
+	}
+
+	for i := range tests {
+		test := tests[i]
+		t.Run(test.name, func(t *testing.T) {
+			handlers := HandlerFuncs{}
+
+			args := test.args
+			_, err := Register(args.name, args.description, args.capabilities, handlers)
+			if test.isErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestNewPlugin_multiple_errors(t *testing.T) {
+	handlers := HandlerFuncs{}
+	_, err := Register("", "", nil, handlers)
+	require.Error(t, err)
+	require.Equal(t, "validation errors: requires name, requires description, requires capabilities", err.Error())
+}
+
+func TestPlugin_Serve(t *testing.T) {
+	capabilities := &plugin.Capabilities{}
+	handlers := HandlerFuncs{}
+
+	ran := false
+
+	serveOpt := func(p *Plugin) {
+		p.serverFactory = func(service plugin.Service) {
+			ran = true
+		}
+	}
+
+	p, err := Register("name", "description", capabilities, handlers, serveOpt)
+	require.NoError(t, err)
+
+	p.Serve()
+
+	assert.True(t, ran)
+}

--- a/web/src/app/modules/overview/components/card-list/card-list.component.ts
+++ b/web/src/app/modules/overview/components/card-list/card-list.component.ts
@@ -13,7 +13,7 @@ export class CardListComponent {
 
   constructor(private viewService: ViewService) {}
 
-  identifyCard(index: number, item: CardView): string {
+  identifyCard = (index: number, item: CardView): string => {
     return [index, this.viewService.viewTitleAsText(item)].join(',');
-  }
+  };
 }

--- a/web/src/app/modules/overview/components/content-switcher/content-switcher.component.html
+++ b/web/src/app/modules/overview/components/content-switcher/content-switcher.component.html
@@ -3,6 +3,9 @@
     <ng-container *ngSwitchCase="'annotations'">
       <app-view-annotations [view]="view"></app-view-annotations>
     </ng-container>
+    <ng-container *ngSwitchCase="'card'">
+      <app-view-card [view]="view"></app-view-card>
+    </ng-container>
     <ng-container *ngSwitchCase="'cardList'">
       <app-view-card-list [view]="view"></app-view-card-list>
     </ng-container>

--- a/web/src/app/modules/overview/services/view/view.service.ts
+++ b/web/src/app/modules/overview/services/view/view.service.ts
@@ -7,18 +7,18 @@ import { TextView, View } from '../../../../models/content';
 export class ViewService {
   constructor() {}
 
-  viewTitleAsText(view: View): string {
-    return this.titleAsText(view.metadata.title);
-  }
-
   titleAsText(titleViews: View[]): string {
     if (!titleViews) {
       return '';
     }
 
-    // assume it's a text title for now
+    // assume it's a text title
     return titleViews
       .map((titleView: TextView) => titleView.config.value)
       .join(' / ');
+  }
+
+  viewTitleAsText(view: View): string {
+    return this.titleAsText(view.metadata.title);
   }
 }


### PR DESCRIPTION
The plugin helper service provides a method for plugin authors to initialize
and implement their plugins.