### PR TITLE
add support for user agent with octant version

### DIFF
--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -272,10 +272,15 @@ func withConfigDefaults(inConfig *rest.Config, options RESTConfigOptions) *rest.
 	codec := runtime.NoopEncoder{Decoder: scheme.Codecs.UniversalDecoder()}
 	config.NegotiatedSerializer = serializer.NegotiatedSerializerWrapper(runtime.SerializerInfo{Serializer: codec})
 
+	if options.UserAgent != "" {
+		config.UserAgent = options.UserAgent
+	}
+
 	return config
 }
 
 type RESTConfigOptions struct {
-	QPS   float32
-	Burst int
+	QPS       float32
+	Burst     int
+	UserAgent string
 }

--- a/internal/commands/dash.go
+++ b/internal/commands/dash.go
@@ -23,7 +23,7 @@ import (
 	"github.com/vmware/octant/internal/log"
 )
 
-func newOctantCmd() *cobra.Command {
+func newOctantCmd(version string) *cobra.Command {
 	var namespace string
 	var uiURL string
 	var kubeConfig string
@@ -72,6 +72,7 @@ func newOctantCmd() *cobra.Command {
 					Context:          initialContext,
 					ClientQPS:        clientQPS,
 					ClientBurst:      clientBurst,
+					UserAgent:        fmt.Sprintf("octant/%s", version),
 				}
 
 				if klogVerbosity > 0 {

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -28,7 +28,7 @@ func Execute(version string, gitCommit string, buildTime string) {
 }
 
 func newRoot(version string, gitCommit string, buildTime string) *cobra.Command {
-	rootCmd := newOctantCmd()
+	rootCmd := newOctantCmd(version)
 	rootCmd.AddCommand(newVersionCmd(version, gitCommit, buildTime))
 
 	return rootCmd

--- a/internal/dash/dash.go
+++ b/internal/dash/dash.go
@@ -50,6 +50,7 @@ type Options struct {
 	Context          string
 	ClientQPS        float32
 	ClientBurst      int
+	UserAgent        string
 }
 
 // Run runs the dashboard.
@@ -62,8 +63,9 @@ func Run(ctx context.Context, logger log.Logger, shutdownCh chan bool, options O
 
 	logger.Debugf("Loading configuration: %v", options.KubeConfig)
 	restConfigOptions := cluster.RESTConfigOptions{
-		QPS:   options.ClientQPS,
-		Burst: options.ClientBurst,
+		QPS:       options.ClientQPS,
+		Burst:     options.ClientBurst,
+		UserAgent: options.UserAgent,
 	}
 	clusterClient, err := cluster.FromKubeConfig(ctx, options.KubeConfig, options.Context, restConfigOptions)
 	if err != nil {


### PR DESCRIPTION
I could not test it as I am getting following error when trying to bring up octant on my laptop:

Fixes #273 

<details><summary>Logs</summary>
<p>
```
➜  octant git:(add-useragent) ✗ ./build/octant 
2019-09-17T01:10:15.794+0530    INFO    module/manager.go:79    registering action      {"component": "module-manager", "actionPath": "deployment/configuration", "module-name": "overview"}
2019-09-17T01:10:15.794+0530    INFO    module/manager.go:79    registering action      {"component": "module-manager", "actionPath": "overview/containerEditor", "module-name": "overview"}
2019-09-17T01:10:15.794+0530    INFO    module/manager.go:79    registering action      {"component": "module-manager", "actionPath": "octant/deleteObject", "module-name": "configuration"}
2019-09-17T01:10:15.794+0530    INFO    api/api.go:131  api prefix: /api/v1     {"component": "api"}
2019-09-17T01:10:15.794+0530    INFO    dash/dash.go:329        Dashboard is available at http://127.0.0.1:7777

2019-09-17T01:10:16.611+0530    ERROR   api/api.go:163  api handler not found: /api/v1/namespace        {"component": "api"}
github.com/vmware/octant/internal/api.(*API).Handler.func1
        /Users/rajatjindal/go/src/github.com/vmware/octant/internal/api/api.go:163
net/http.HandlerFunc.ServeHTTP
        /usr/local/Cellar/go/1.13/libexec/src/net/http/server.go:2007
github.com/gorilla/mux.(*Router).ServeHTTP
        /Users/rajatjindal/go/src/github.com/vmware/octant/vendor/github.com/gorilla/mux/mux.go:162
github.com/gorilla/mux.(*Router).ServeHTTP
        /Users/rajatjindal/go/src/github.com/vmware/octant/vendor/github.com/gorilla/mux/mux.go:162
github.com/gorilla/handlers.(*cors).ServeHTTP
        /Users/rajatjindal/go/src/github.com/vmware/octant/vendor/github.com/gorilla/handlers/cors.go:52
net/http.serverHandler.ServeHTTP
        /usr/local/Cellar/go/1.13/libexec/src/net/http/server.go:2802
net/http.(*conn).serve
        /usr/local/Cellar/go/1.13/libexec/src/net/http/server.go:1890
2019-09-17T01:10:16.611+0530    INFO    api/api.go:101  unable to serve {"component": "api", "code": 404, "message": "not found"}
2019-09-17T01:10:16.801+0530    ERROR   api/api.go:163  api handler not found: /api/v1/content/overview/namespace/default/?poll=5 {"component": "api"}
github.com/vmware/octant/internal/api.(*API).Handler.func1
        /Users/rajatjindal/go/src/github.com/vmware/octant/internal/api/api.go:163
net/http.HandlerFunc.ServeHTTP
        /usr/local/Cellar/go/1.13/libexec/src/net/http/server.go:2007
github.com/gorilla/mux.(*Router).ServeHTTP
        /Users/rajatjindal/go/src/github.com/vmware/octant/vendor/github.com/gorilla/mux/mux.go:162
github.com/gorilla/mux.(*Router).ServeHTTP
        /Users/rajatjindal/go/src/github.com/vmware/octant/vendor/github.com/gorilla/mux/mux.go:162
github.com/gorilla/handlers.(*cors).ServeHTTP
        /Users/rajatjindal/go/src/github.com/vmware/octant/vendor/github.com/gorilla/handlers/cors.go:52
net/http.serverHandler.ServeHTTP
        /usr/local/Cellar/go/1.13/libexec/src/net/http/server.go:2802
net/http.(*conn).serve
        /usr/local/Cellar/go/1.13/libexec/src/net/http/server.go:1890
2019-09-17T01:10:16.801+0530    INFO    api/api.go:101  unable to serve {"component": "api", "code": 404, "message": "not found"}
```

</p>
</details>