### PR TITLE
Handle access denied errors in a more user friendly way.

### DIFF
--- a/changelogs/unreleased/218-wwitzel3
+++ b/changelogs/unreleased/218-wwitzel3
@@ -1,0 +1,1 @@
+access denied errors no longer spam console

--- a/internal/config/dash.go
+++ b/internal/config/dash.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/vmware/octant/internal/cluster"
+	internalErr "github.com/vmware/octant/internal/errors"
 	"github.com/vmware/octant/internal/log"
 	"github.com/vmware/octant/internal/module"
 	"github.com/vmware/octant/internal/portforward"
@@ -77,6 +78,8 @@ type Dash interface {
 
 	ObjectStore() store.Store
 
+	ErrorStore() internalErr.ErrorStore
+
 	Logger() log.Logger
 
 	PluginManager() plugin.ManagerInterface
@@ -103,6 +106,7 @@ type Live struct {
 	logger             log.Logger
 	moduleManager      module.ManagerInterface
 	objectStore        store.Store
+	errorStore         internalErr.ErrorStore
 	pluginManager      plugin.ManagerInterface
 	portForwarder      portforward.PortForwarder
 	kubeConfigPath     string
@@ -120,6 +124,7 @@ func NewLiveConfig(
 	logger log.Logger,
 	moduleManager module.ManagerInterface,
 	objectStore store.Store,
+	errorStore internalErr.ErrorStore,
 	pluginManager plugin.ManagerInterface,
 	portForwarder portforward.PortForwarder,
 	currentContextName string,
@@ -132,6 +137,7 @@ func NewLiveConfig(
 		logger:             logger,
 		moduleManager:      moduleManager,
 		objectStore:        objectStore,
+		errorStore:         errorStore,
 		pluginManager:      pluginManager,
 		portForwarder:      portForwarder,
 		currentContextName: currentContextName,
@@ -162,6 +168,11 @@ func (l *Live) CRDWatcher() CRDWatcher {
 // Store returns an object store.
 func (l *Live) ObjectStore() store.Store {
 	return l.objectStore
+}
+
+// ErrorStore returns an error store.
+func (l *Live) ErrorStore() internalErr.ErrorStore {
+	return l.errorStore
 }
 
 // KubeConfigPath returns the kube config path.

--- a/internal/config/dash_test.go
+++ b/internal/config/dash_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/vmware/octant/internal/cluster"
 	clusterFake "github.com/vmware/octant/internal/cluster/fake"
+	internalErr "github.com/vmware/octant/internal/errors"
 	"github.com/vmware/octant/internal/log"
 	moduleFake "github.com/vmware/octant/internal/module/fake"
 	portForwardFake "github.com/vmware/octant/internal/portforward/fake"
@@ -80,6 +81,8 @@ func TestLiveConfig(t *testing.T) {
 		Return("/pod", nil)
 
 	objectStore := objectStoreFake.NewMockStore(controller)
+	errorStore, err := internalErr.NewErrorStore()
+	assert.NoError(t, err)
 	pluginManager := pluginFake.NewMockManagerInterface(controller)
 	portForwarder := portForwardFake.NewMockPortForwarder(controller)
 	kubeConfigPath := "/path"
@@ -90,7 +93,7 @@ func TestLiveConfig(t *testing.T) {
 	contextName := "context-name"
 	restConfigOptions := cluster.RESTConfigOptions{}
 
-	config := NewLiveConfig(clusterClient, crdWatcher, kubeConfigPath, logger, moduleManager, objectStore, pluginManager, portForwarder, contextName, restConfigOptions)
+	config := NewLiveConfig(clusterClient, crdWatcher, kubeConfigPath, logger, moduleManager, objectStore, errorStore, pluginManager, portForwarder, contextName, restConfigOptions)
 
 	assert.NoError(t, config.Validate())
 	assert.Equal(t, clusterClient, config.ClusterClient())

--- a/internal/dash/dash.go
+++ b/internal/dash/dash.go
@@ -27,6 +27,7 @@ import (
 	"github.com/vmware/octant/internal/cluster"
 	"github.com/vmware/octant/internal/config"
 	"github.com/vmware/octant/internal/describer"
+	internalErr "github.com/vmware/octant/internal/errors"
 	"github.com/vmware/octant/internal/log"
 	"github.com/vmware/octant/internal/module"
 	"github.com/vmware/octant/internal/modules/applications"
@@ -95,7 +96,12 @@ func Run(ctx context.Context, logger log.Logger, shutdownCh chan bool, options O
 		return errors.Wrap(err, "initializing store")
 	}
 
-	crdWatcher, err := describer.NewDefaultCRDWatcher(ctx, appObjectStore)
+	errorStore, err := internalErr.NewErrorStore()
+	if err != nil {
+		return errors.Wrap(err, "initializing error store")
+	}
+
+	crdWatcher, err := describer.NewDefaultCRDWatcher(ctx, appObjectStore, errorStore)
 	if err != nil {
 		return errors.Wrap(err, "initializing CRD watcher")
 	}
@@ -138,6 +144,7 @@ func Run(ctx context.Context, logger log.Logger, shutdownCh chan bool, options O
 		logger,
 		moduleManager,
 		appObjectStore,
+		errorStore,
 		pluginManager,
 		portForwarder,
 		options.Context,

--- a/internal/describer/crd_list_test.go
+++ b/internal/describer/crd_list_test.go
@@ -59,6 +59,7 @@ func Test_crdListDescriber(t *testing.T) {
 
 	dashConfig := configFake.NewMockDash(controller)
 	dashConfig.EXPECT().ObjectStore().Return(o).AnyTimes()
+	dashConfig.EXPECT().ErrorStore().Return(o).AnyTImes()
 
 	options := Options{
 		Dash: dashConfig,

--- a/internal/describer/crd_list_test.go
+++ b/internal/describer/crd_list_test.go
@@ -59,7 +59,6 @@ func Test_crdListDescriber(t *testing.T) {
 
 	dashConfig := configFake.NewMockDash(controller)
 	dashConfig.EXPECT().ObjectStore().Return(o).AnyTimes()
-	dashConfig.EXPECT().ErrorStore().Return(o).AnyTImes()
 
 	options := Options{
 		Dash: dashConfig,

--- a/internal/describer/crd_watcher.go
+++ b/internal/describer/crd_watcher.go
@@ -15,28 +15,31 @@ import (
 	kcache "k8s.io/client-go/tools/cache"
 
 	"github.com/vmware/octant/internal/config"
+	internalErr "github.com/vmware/octant/internal/errors"
 	"github.com/vmware/octant/internal/log"
-	"github.com/vmware/octant/internal/objectstore"
 	"github.com/vmware/octant/pkg/store"
 )
 
 // DefaultCRDWatcher is the default CRD watcher.
 type DefaultCRDWatcher struct {
 	objectStore store.Store
+	errorStore  internalErr.ErrorStore
 
-	mu sync.Mutex
+	accessError sync.Once
+	mu          sync.Mutex
 }
 
 var _ config.CRDWatcher = (*DefaultCRDWatcher)(nil)
 
 // NewDefaultCRDWatcher creates an instance of DefaultCRDWatcher.
-func NewDefaultCRDWatcher(ctx context.Context, objectStore store.Store) (*DefaultCRDWatcher, error) {
+func NewDefaultCRDWatcher(ctx context.Context, objectStore store.Store, errorStore internalErr.ErrorStore) (*DefaultCRDWatcher, error) {
 	if objectStore == nil {
 		return nil, errors.New("object store is nil")
 	}
 
 	cw := &DefaultCRDWatcher{
 		objectStore: objectStore,
+		errorStore:  errorStore,
 	}
 
 	objectStore.RegisterOnUpdate(func(newObjectStore store.Store) {
@@ -80,9 +83,14 @@ func (cw *DefaultCRDWatcher) Watch(ctx context.Context, watchConfig *config.CRDW
 
 	err := cw.objectStore.Watch(ctx, crdKey, handler)
 	if err != nil {
-		if err, ok := err.(*objectstore.AccessError); ok {
-			logger := log.From(ctx)
-			logger.Warnf("%s", err)
+		aErr, ok := err.(*internalErr.AccessError)
+		if ok {
+			found := cw.errorStore.Add(aErr)
+			// Log if we have not seen this access error before.
+			if !found {
+				logger := log.From(ctx)
+				logger.WithErr(aErr).Errorf("access denied")
+			}
 			return nil
 		}
 		return errors.WithMessage(err, "crd watcher has failed")

--- a/internal/describer/crd_watcher_test.go
+++ b/internal/describer/crd_watcher_test.go
@@ -17,13 +17,14 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/vmware/octant/internal/config"
+	internalErr "github.com/vmware/octant/internal/errors"
 	"github.com/vmware/octant/pkg/store"
 	objectStoreFake "github.com/vmware/octant/pkg/store/fake"
 )
 
 func TestNewDefaultCRDWatcher_requires_object_store(t *testing.T) {
 	ctx := context.Background()
-	_, err := NewDefaultCRDWatcher(ctx, nil)
+	_, err := NewDefaultCRDWatcher(ctx, nil, nil)
 	require.Error(t, err)
 }
 
@@ -43,8 +44,10 @@ func TestDefaultCRDWatcher_Watch(t *testing.T) {
 		})
 	objectStore.EXPECT().
 		RegisterOnUpdate(gomock.Any())
+	errorStore, err := internalErr.NewErrorStore()
+	require.NoError(t, err)
 
-	watcher, err := NewDefaultCRDWatcher(ctx, objectStore)
+	watcher, err := NewDefaultCRDWatcher(ctx, objectStore, errorStore)
 	require.NoError(t, err)
 
 	watchConfig := &config.CRDWatchConfig{
@@ -71,8 +74,10 @@ func TestDefaultCRDWatcher_Watch_failure(t *testing.T) {
 		})
 	objectStore.EXPECT().
 		RegisterOnUpdate(gomock.Any())
-
-	watcher, err := NewDefaultCRDWatcher(ctx, objectStore)
+	errorStore, err := internalErr.NewErrorStore()
+	require.NoError(t, err)
+	
+	watcher, err := NewDefaultCRDWatcher(ctx, objectStore, errorStore)
 	require.NoError(t, err)
 
 	watchConfig := &config.CRDWatchConfig{

--- a/internal/describer/list.go
+++ b/internal/describer/list.go
@@ -14,7 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 
-	"github.com/vmware/octant/internal/log"
 	"github.com/vmware/octant/pkg/store"
 	"github.com/vmware/octant/pkg/view/component"
 )

--- a/internal/describer/list.go
+++ b/internal/describer/list.go
@@ -10,7 +10,6 @@ import (
 	"reflect"
 
 	"github.com/pkg/errors"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 
@@ -74,9 +73,7 @@ func (d *List) Describe(ctx context.Context, namespace string, options Options) 
 
 	objectList, err := options.LoadObjects(ctx, namespace, options.Fields, []store.Key{key})
 	if err != nil {
-		logger := log.From(ctx)
-		logger.WithErr(err).Warnf("error loading objects")
-		objectList = &unstructured.UnstructuredList{}
+		return component.EmptyContentResponse, err
 	}
 
 	list := component.NewList(d.title, nil)

--- a/internal/errors/access_error.go
+++ b/internal/errors/access_error.go
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package errors
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/vmware/octant/pkg/store"
+)
+
+type AccessError struct {
+	id        string
+	key       store.Key
+	timestamp time.Time
+	verb      string
+	err       error
+}
+
+var _ InternalError = (*AccessError)(nil)
+
+func NewAccessError(key store.Key, verb string, err error) *AccessError {
+	return &AccessError{
+		verb:      verb,
+		err:       err,
+		timestamp: time.Now(),
+		id:        key.String(),
+		key:       key,
+	}
+}
+
+// ID returns the error unique ID.
+func (o *AccessError) ID() string {
+	return o.id
+}
+
+// Timestamp returns the error timestamp.
+func (o *AccessError) Timestamp() time.Time {
+	return o.timestamp
+}
+
+// Error returns an error string.
+func (o *AccessError) Error() string {
+	return fmt.Sprintf("%s: %s: %s", o.verb, o.key, o.err)
+}
+
+// Key returns the key for the error.
+func (o *AccessError) Key() store.Key {
+	return o.key
+}
+
+// Verb returns the verb for the error.
+func (o *AccessError) Verb() string {
+	return o.verb
+}

--- a/internal/errors/access_error_test.go
+++ b/internal/errors/access_error_test.go
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package errors
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vmware/octant/pkg/store"
+)
+
+func TestNewAccessError(t *testing.T) {
+	key := store.Key{
+		Namespace:  "default",
+		APIVersion: "v1",
+		Kind:       "Pod",
+	}
+	verb := "watch"
+	err := fmt.Errorf("access denied")
+
+	intErr := NewAccessError(key, verb, err)
+	assert.Equal(t, key, intErr.Key())
+	assert.Equal(t, verb, intErr.Verb())
+	assert.Equal(t, fmt.Sprintf("%s: %s: %s", verb, key, err), intErr.Error())
+	assert.EqualError(t, err, "access denied")
+	assert.NotEmpty(t, intErr.Timestamp())
+	assert.NotZero(t, intErr.ID())
+}

--- a/internal/errors/action_error.go
+++ b/internal/errors/action_error.go
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package errors
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/vmware/octant/pkg/action"
+)
+
+type ActionError struct {
+	id          string
+	timestamp   time.Time
+	payload     action.Payload
+	requestType string
+	err         error
+}
+
+var _ InternalError = (*ActionError)(nil)
+
+func NewActionError(requestType string, payload action.Payload, err error) *ActionError {
+	id, _ := uuid.NewUUID()
+
+	return &ActionError{
+		requestType: requestType,
+		payload:     payload,
+		err:         err,
+		timestamp:   time.Now(),
+		id:          id.String(),
+	}
+}
+
+// ID returns the error unique ID.
+func (o *ActionError) ID() string {
+	return o.id
+}
+
+// Timestamp returns the error timestamp.
+func (o *ActionError) Timestamp() time.Time {
+	return o.timestamp
+}
+
+// Error returns an error string.
+func (o *ActionError) Error() string {
+	return fmt.Sprintf("%s: %s", o.requestType, o.err)
+}
+
+// Client returns a client if one is available.
+func (o *ActionError) RequestType() string {
+	return o.requestType
+}
+
+// Request returns the payload that generated the error, if available.
+func (o *ActionError) Payload() action.Payload {
+	return o.payload
+}

--- a/internal/errors/action_error_test.go
+++ b/internal/errors/action_error_test.go
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package errors
 
 import (
@@ -8,12 +13,12 @@ import (
 	"github.com/vmware/octant/pkg/action"
 )
 
-func TestNewInternalError(t *testing.T) {
+func TestNewActionError(t *testing.T) {
 	requestType := "errorList"
 	payload := action.Payload{}
 	err := fmt.Errorf("setNamespace error")
 
-	intErr := NewInternalError(requestType, payload, err)
+	intErr := NewActionError(requestType, payload, err)
 	assert.Equal(t, payload, intErr.Payload())
 	assert.Equal(t, requestType, intErr.RequestType())
 	assert.Equal(t, fmt.Sprintf("%s: %s", requestType, err), intErr.Error())

--- a/internal/errors/generic_error.go
+++ b/internal/errors/generic_error.go
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+ package errors
+
+ import (
+	 "fmt"
+	 "time"
+ 
+	 "github.com/google/uuid"
+ )
+ 
+ type GenericError struct {
+	 id          string
+	 timestamp   time.Time
+	 err         error
+ }
+ 
+ var _ InternalError = (*GenericError)(nil)
+ 
+ func NewGenericError(err error) *GenericError {
+	 id, _ := uuid.NewUUID()
+ 
+	 return &GenericError{
+		 err:         err,
+		 timestamp:   time.Now(),
+		 id:          id.String(),
+	 }
+ }
+ 
+ // ID returns the error unique ID.
+ func (o *GenericError) ID() string {
+	 return o.id
+ }
+ 
+ // Timestamp returns the error timestamp.
+ func (o *GenericError) Timestamp() time.Time {
+	 return o.timestamp
+ }
+ 
+ // Error returns an error string.
+ func (o *GenericError) Error() string {
+	 return fmt.Sprintf("%s", o.err)
+ }

--- a/internal/errors/generic_error_test.go
+++ b/internal/errors/generic_error_test.go
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package errors
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewGenericError(t *testing.T) {
+	err := fmt.Errorf("access denied")
+
+	intErr := NewGenericError(err)
+	assert.Equal(t, "access denied", intErr.Error())
+	assert.EqualError(t, intErr.err, "access denied")
+	assert.NotEmpty(t, intErr.Timestamp())
+	assert.NotZero(t, intErr.ID())
+}

--- a/internal/errors/store.go
+++ b/internal/errors/store.go
@@ -1,22 +1,32 @@
+/*
+ * Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package errors
 
 import (
 	"sort"
 
-	"github.com/google/uuid"
 	lru "github.com/hashicorp/golang-lru"
-	"github.com/vmware/octant/pkg/action"
 )
 
 const maxErrors = 50
 
 type ErrorStore interface {
-	List() []*InternalError
-	Get(uuid.UUID) (*InternalError, bool)
-	Add(*InternalError)
-	NewError(string, action.Payload, error) *InternalError
+	List() []InternalError
+	Get(string) (InternalError, bool)
+	Add(InternalError) (found bool)
+	AddError(error) InternalError
 }
 
+type errorStore struct {
+	recentErrors *lru.Cache
+}
+
+var _ ErrorStore = (*errorStore)(nil)
+
+// NewErrorStore creates a new error store.
 func NewErrorStore() (ErrorStore, error) {
 	cache, err := lru.New(maxErrors)
 	if err != nil {
@@ -28,43 +38,44 @@ func NewErrorStore() (ErrorStore, error) {
 	}, nil
 }
 
-type errorStore struct {
-	recentErrors *lru.Cache
-}
-
-// NewError creates a new InternalError and adds it to the store.
-func (e *errorStore) NewError(requestType string, payload action.Payload, err error) *InternalError {
-	intErr := NewInternalError(requestType, payload, err)
-	e.Add(intErr)
-	return intErr
-}
-
 // Get returns an InternalError and if it was found in the store.
-func (e *errorStore) Get(id uuid.UUID) (err *InternalError, found bool) {
+func (e *errorStore) Get(id string) (err InternalError, found bool) {
 	v, ok := e.recentErrors.Peek(id)
 	if !ok {
 		return nil, ok
 	}
-	return v.(*InternalError), ok
+	return v.(InternalError), ok
 }
 
-// Add adds a new InternalError directly in to the store.
-func (e *errorStore) Add(intErr *InternalError) {
-	e.recentErrors.ContainsOrAdd(intErr.id, intErr)
+// AddError coverts a standard Go error to an InternalError and adds it to the error store.
+func (e *errorStore) AddError(err error) InternalError {
+	intErr := convertError(err)
+	e.Add(intErr)
+	return intErr
 }
 
-// List returns a list of all the IntrenalError objects in the store from newest to oldest.
-func (e *errorStore) List() []*InternalError {
-	var intErrList []*InternalError
+// Add adds an InternalError directly to the error store.
+func (e *errorStore) Add(intErr InternalError) (found bool) {
+	ok, _ := e.recentErrors.ContainsOrAdd(intErr.ID(), intErr)
+	return ok
+}
+
+// List returns a list of all the error objects in the store from newest to oldest.
+func (e *errorStore) List() []InternalError {
+	var intErrList []InternalError
 	for _, key := range e.recentErrors.Keys() {
 		v, ok := e.recentErrors.Peek(key)
 		if !ok {
 			continue
 		}
-		intErrList = append(intErrList, v.(*InternalError))
+		intErrList = append(intErrList, v.(InternalError))
 	}
 	sort.Slice(intErrList, func(i, j int) bool {
-		return intErrList[i].timestamp.After(intErrList[j].timestamp)
+		return intErrList[i].Timestamp().After(intErrList[j].Timestamp())
 	})
 	return intErrList
+}
+
+func convertError(err error) InternalError {
+	return NewGenericError(err)
 }

--- a/internal/errors/store_test.go
+++ b/internal/errors/store_test.go
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package errors
 
 import (
@@ -22,8 +27,10 @@ func TestNewError(t *testing.T) {
 	payload := action.Payload{}
 	err = fmt.Errorf("setNavigation error")
 
-	intErr := errStore.NewError(requestType, payload, err)
-	_, found := errStore.Get(intErr.id)
+	intErr := NewActionError(requestType, payload, err)
+	errStore.Add(intErr)
+
+	_, found := errStore.Get(intErr.ID())
 	assert.True(t, found)
 }
 
@@ -35,19 +42,19 @@ func TestErrorStore_Accessors(t *testing.T) {
 	payload := action.Payload{}
 	err = fmt.Errorf("setNamespace error")
 
-	i := NewInternalError(requestType, payload, err)
-	_, found := errStore.Get(i.id)
+	i := NewActionError(requestType, payload, err)
+	_, found := errStore.Get(i.ID())
 	assert.False(t, found)
 
 	errStore.Add(i)
 
-	e, found := errStore.Get(i.id)
+	e, found := errStore.Get(i.ID())
 	assert.True(t, found)
-	assert.Equal(t, i.id, e.id)
+	assert.Equal(t, i.ID(), e.ID())
 
 	l := errStore.List()
 	assert.Len(t, l, 1)
-	assert.Equal(t, i.id, l[0].id)
+	assert.Equal(t, i.ID(), l[0].ID())
 }
 
 func TestErrorStore_ListOrder(t *testing.T) {
@@ -58,11 +65,14 @@ func TestErrorStore_ListOrder(t *testing.T) {
 	payload := action.Payload{}
 	err = fmt.Errorf("setContext error")
 
-	older := errStore.NewError(requestType, payload, err)
-	newer := errStore.NewError(requestType, payload, err)
+	older := NewActionError(requestType, payload, err)
+	newer := NewGenericError(err)
+
+	errStore.Add(newer)
+	errStore.Add(older)
 
 	l := errStore.List()
 	assert.Len(t, l, 2)
-	assert.Equal(t, older.id, l[1].id)
-	assert.Equal(t, newer.id, l[0].id)
+	assert.Equal(t, older.ID(), l[1].ID())
+	assert.Equal(t, newer.ID(), l[0].ID())
 }

--- a/internal/errors/types.go
+++ b/internal/errors/types.go
@@ -1,44 +1,15 @@
+/*
+ * Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package errors
 
-import (
-	"fmt"
-	"time"
+import "time"
 
-	"github.com/google/uuid"
-	"github.com/vmware/octant/pkg/action"
-)
-
-type InternalError struct {
-	id          uuid.UUID
-	timestamp   time.Time
-	payload     action.Payload
-	requestType string
-	err         error
-}
-
-func NewInternalError(requestType string, payload action.Payload, err error) *InternalError {
-	id, _ := uuid.NewUUID()
-
-	return &InternalError{
-		requestType: requestType,
-		payload:     payload,
-		err:         err,
-		timestamp:   time.Now(),
-		id:          id,
-	}
-}
-
-// Error returns an error string.
-func (o *InternalError) Error() string {
-	return fmt.Sprintf("%s: %s", o.requestType, o.err)
-}
-
-// Client returns a client if one is available.
-func (o *InternalError) RequestType() string {
-	return o.requestType
-}
-
-// Request returns the payload that generated the error, if available.
-func (o *InternalError) Payload() action.Payload {
-	return o.payload
+// InternalError represents an internal Octant error.
+type InternalError interface {
+	ID() string
+	Error() string
+	Timestamp() time.Time
 }

--- a/internal/modules/overview/content_handlers_test.go
+++ b/internal/modules/overview/content_handlers_test.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/clock"
 
 	"github.com/vmware/octant/internal/describer"
+	internalErr "github.com/vmware/octant/internal/errors"
 	"github.com/vmware/octant/internal/testutil"
 	"github.com/vmware/octant/pkg/store"
 	storeFake "github.com/vmware/octant/pkg/store/fake"
@@ -110,10 +111,13 @@ func Test_loadObjects(t *testing.T) {
 			o := storeFake.NewMockStore(controller)
 			tc.init(t, o)
 
+			errorStore, err := internalErr.NewErrorStore()
+			require.NoError(t, err)
+
 			namespace := "default"
 
 			ctx := context.Background()
-			got, err := describer.LoadObjects(ctx, o, namespace, tc.fields, tc.keys)
+			got, err := describer.LoadObjects(ctx, o, errorStore, namespace, tc.fields, tc.keys)
 			if tc.isErr {
 				require.Error(t, err)
 				return

--- a/internal/objectstore/access.go
+++ b/internal/objectstore/access.go
@@ -15,6 +15,7 @@ import (
 	authorizationv1 "k8s.io/api/authorization/v1"
 
 	"github.com/vmware/octant/internal/cluster"
+	internalErr "github.com/vmware/octant/internal/errors"
 	"github.com/vmware/octant/pkg/store"
 )
 
@@ -141,7 +142,7 @@ func (r *resourceAccess) HasAccess(ctx context.Context, key store.Key, verb stri
 	}
 
 	if !access {
-		return &AccessError{Key: aKey}
+		return internalErr.NewAccessError(key, verb, err)
 	}
 
 	return nil

--- a/pkg/navigation/navigation.go
+++ b/pkg/navigation/navigation.go
@@ -132,7 +132,6 @@ func CustomResourceDefinitions(ctx context.Context, o store.Store) ([]*apiextv1b
 
 	rawList, hasSynced, err := o.List(ctx, key)
 	if err != nil {
-		logger.WithErr(err).Warnf("error listing CRDs")
 		hasSynced = false
 		rawList = &unstructured.UnstructuredList{}
 	}


### PR DESCRIPTION
Only log AccessErrors once in the console per type.

This uses the `ErrorStore` to add `AccessErrors`  which use a `store.Key` as their ID. The `Add` returns if the error for that ID is already present. We leverage that to only log the error on the first occurrence.

Adding these to the `ErrorStore` now also allows us to surface them to the UI once we have the status view work completed.

fixes #218 
related #76 #240 #79 