### PR TITLE
Remove content from path and use namespace from service

### DIFF
--- a/changelogs/unreleased/326-GuessWhoSamFoo
+++ b/changelogs/unreleased/326-GuessWhoSamFoo
@@ -1,0 +1,1 @@
+Fix pod heptagon link

--- a/web/cypress/integration/app_spec.js
+++ b/web/cypress/integration/app_spec.js
@@ -71,6 +71,7 @@ describe('Octant Integration Tests', () => {
     })
 
     it('check plugin tab', () => {
+        cy.get('[href="#/overview/namespace/' + namespace + '/workloads/pods"]').click()
         cy.contains(/^nginx-deployment-[a-z0-9]+-[a-z0-9]+/).click()
         cy
             .get('[class=nav]')
@@ -81,6 +82,18 @@ describe('Octant Integration Tests', () => {
     
         cy.contains(/Extra Pod Details/).click()
         cy.contains('content')
+    })
+
+    it('check resource viewer', () => {
+        cy.contains(/Resource Viewer/).click()
+        // Check canvas is drawn
+        cy.get('[data-id="layer0-selectbox"]').invoke('width').should('be.greaterThan', 0)
+        cy.get('[data-id="layer2-node"]').click(400, 320, {force: true})
+
+        cy.get('app-heptagon-grid svg g:first').children().should('have.length', 3)
+        cy.get('app-heptagon-grid svg g:first').children().last().click()
+
+        cy.contains(/Container nginx/)
     })
 
     it('cleanup context and namespace', () => {

--- a/web/src/app/modules/overview/components/heptagon/heptagon.component.ts
+++ b/web/src/app/modules/overview/components/heptagon/heptagon.component.ts
@@ -12,6 +12,7 @@ import {
   Output,
 } from '@angular/core';
 
+import { NamespaceService } from 'src/app/services/namespace/namespace.service';
 import { PodStatus } from '../../models/pod-status';
 import { Point } from '../../models/point';
 import { Vector } from '../../models/vector';
@@ -40,9 +41,19 @@ export class HeptagonComponent implements OnInit, AfterViewInit {
   @Output()
   hovered = new EventEmitter<boolean>();
 
-  constructor(private elementRef: ElementRef, private router: Router) {}
+  currentNamespace = '';
 
-  ngOnInit() {}
+  constructor(
+    private elementRef: ElementRef,
+    private router: Router,
+    private namespaceService: NamespaceService
+  ) {}
+
+  ngOnInit() {
+    this.namespaceService.activeNamespace.subscribe((namespace: string) => {
+      this.currentNamespace = namespace;
+    });
+  }
 
   ngAfterViewInit(): void {
     const el = this.elementRef.nativeElement;
@@ -104,10 +115,9 @@ export class HeptagonComponent implements OnInit, AfterViewInit {
 
   navigate() {
     this.router.navigate([
-      '/content',
       'overview',
       'namespace',
-      'default',
+      this.currentNamespace,
       'workloads',
       'pods',
       this.status.name,


### PR DESCRIPTION
e2e testing for canvas elements is difficult because cypress is meant for functional testing rather than visual. The test currently decides viewport dimensions to click but has no knowledge of what is being drawn on canvas.

Signed-off-by: GuessWhoSamFoo <foos@vmware.com>