### PR TITLE
Dark theme and theme switch implementation

### DIFF
--- a/changelogs/unreleased/36-nfarruggiagl
+++ b/changelogs/unreleased/36-nfarruggiagl
@@ -1,0 +1,1 @@
+Dark theme and theme switch implementation

--- a/web/angular.json
+++ b/web/angular.json
@@ -24,7 +24,17 @@
             "tsConfig": "src/tsconfig.app.json",
             "assets": [
               "src/favicon.ico",
-              "src/assets"
+              "src/assets",
+              {
+                "glob": "clr-ui-dark.min.css",
+                "input": "node_modules/@clr/ui",
+                "output": "assets/css"
+              },
+              {
+                "glob": "clr-ui.min.css",
+                "input": "node_modules/@clr/ui",
+                "output": "assets/css"
+              }
             ],
             "styles": [
               "node_modules/@clr/icons/clr-icons.min.css",

--- a/web/angular.json
+++ b/web/angular.json
@@ -38,7 +38,6 @@
             ],
             "styles": [
               "node_modules/@clr/icons/clr-icons.min.css",
-              "node_modules/@clr/ui/clr-ui.min.css",
               "src/styles.scss"
             ],
             "scripts": [

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -2399,6 +2399,22 @@
         "@types/node": "*"
       }
     },
+    "@vmw/ngx-components": {
+      "version": "7.5.11",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@vmw/ngx-components/-/@vmw/ngx-components-7.5.11.tgz",
+      "integrity": "sha1-0z2zcTqS0PGCVv5nJgY5JpUmDoc=",
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
+    "@vmw/ngx-utils": {
+      "version": "7.1.6",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@vmw/ngx-utils/-/@vmw/ngx-utils-7.1.6.tgz",
+      "integrity": "sha1-PSNE/k9tPLpqfe/mE3+urEc36jI=",
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
     "@webassemblyjs/ast": {
       "version": "1.8.5",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/ast/-/ast-1.8.5.tgz",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -2399,22 +2399,6 @@
         "@types/node": "*"
       }
     },
-    "@vmw/ngx-components": {
-      "version": "7.5.11",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@vmw/ngx-components/-/@vmw/ngx-components-7.5.11.tgz",
-      "integrity": "sha1-0z2zcTqS0PGCVv5nJgY5JpUmDoc=",
-      "requires": {
-        "tslib": "^1.9.0"
-      }
-    },
-    "@vmw/ngx-utils": {
-      "version": "7.1.6",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@vmw/ngx-utils/-/@vmw/ngx-utils-7.1.6.tgz",
-      "integrity": "sha1-PSNE/k9tPLpqfe/mE3+urEc36jI=",
-      "requires": {
-        "tslib": "^1.9.0"
-      }
-    },
     "@webassemblyjs/ast": {
       "version": "1.8.5",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/ast/-/ast-1.8.5.tgz",

--- a/web/package.json
+++ b/web/package.json
@@ -32,6 +32,8 @@
     "@clr/ui": "^2.2.0",
     "@ng-select/ng-select": "^2.20.0",
     "@types/cytoscape": "^3.8.2",
+    "@vmw/ngx-components": "^7.5.9",
+    "@vmw/ngx-utils": "^7.1.0",
     "@webcomponents/custom-elements": "^1.0.0",
     "core-js": "^2.5.4",
     "cytoscape": "^3.10.0",

--- a/web/package.json
+++ b/web/package.json
@@ -32,8 +32,6 @@
     "@clr/ui": "^2.2.0",
     "@ng-select/ng-select": "^2.20.0",
     "@types/cytoscape": "^3.8.2",
-    "@vmw/ngx-components": "^7.5.9",
-    "@vmw/ngx-utils": "7.1.6",
     "@webcomponents/custom-elements": "^1.0.0",
     "core-js": "^2.5.4",
     "cytoscape": "^3.10.0",

--- a/web/package.json
+++ b/web/package.json
@@ -33,7 +33,7 @@
     "@ng-select/ng-select": "^2.20.0",
     "@types/cytoscape": "^3.8.2",
     "@vmw/ngx-components": "^7.5.9",
-    "@vmw/ngx-utils": "^7.1.0",
+    "@vmw/ngx-utils": "7.1.6",
     "@webcomponents/custom-elements": "^1.0.0",
     "core-js": "^2.5.4",
     "cytoscape": "^3.10.0",

--- a/web/src/app/app.component.html
+++ b/web/src/app/app.component.html
@@ -18,6 +18,7 @@
             </div>
         </div>
         <div class="header-actions">
+            <app-theme-switch-button></app-theme-switch-button>
             <app-context-selector></app-context-selector>
         </div>
     </header>
@@ -29,9 +30,4 @@
             <router-outlet></router-outlet>
         </div>
     </div>
-    <div class="header-actions">
-      <vmw-theme-switch-button></vmw-theme-switch-button>
-      <app-context-selector></app-context-selector>
-    </div>
-  </header>
 </div>

--- a/web/src/app/app.component.html
+++ b/web/src/app/app.component.html
@@ -29,4 +29,9 @@
             <router-outlet></router-outlet>
         </div>
     </div>
+    <div class="header-actions">
+      <vmw-theme-switch-button></vmw-theme-switch-button>
+      <app-context-selector></app-context-selector>
+    </div>
+  </header>
 </div>

--- a/web/src/app/app.component.scss
+++ b/web/src/app/app.component.scss
@@ -5,6 +5,15 @@
 $navigation-width: 13rem;
 
 .main-container {
+    // Navigation's color variables for Light Theme.
+    :host-context(body) {
+      --navigation-border-color: rgb(215, 215, 215);
+    }
+    
+    // Navigation's color variables for Dark Theme.
+    :host-context(body.dark) {
+      --navigation-border-color: #0e161b;
+    }
   .header {
     .branding {
       min-width: $navigation-width;
@@ -35,7 +44,7 @@ $navigation-width: 13rem;
 
   .content-container {
     .navigation {
-      border-right: 1px solid rgb(215, 215, 215);
+      border-right: 1px solid var(--navigation-border-color);
       overflow-y: auto;
       min-width: 2rem;
       width: $navigation-width;

--- a/web/src/app/app.component.spec.ts
+++ b/web/src/app/app.component.spec.ts
@@ -47,7 +47,7 @@ describe('AppComponent', () => {
         NavigationComponent,
         ContextSelectorComponent,
         DefaultPipe,
-        ThemeSwitchButtonComponent
+        ThemeSwitchButtonComponent,
       ],
     }).compileComponents();
   }));

--- a/web/src/app/app.component.spec.ts
+++ b/web/src/app/app.component.spec.ts
@@ -22,6 +22,7 @@ import {
 } from './modules/overview/services/websocket/websocket.service';
 import { WebsocketServiceMock } from './modules/overview/services/websocket/mock';
 import { ClarityIcons } from '@clr/icons';
+import { ThemeSwitchButtonComponent } from './modules/overview/components/theme-switch/theme-switch-button.component';
 
 describe('AppComponent', () => {
   beforeEach(async(() => {
@@ -46,6 +47,7 @@ describe('AppComponent', () => {
         NavigationComponent,
         ContextSelectorComponent,
         DefaultPipe,
+        ThemeSwitchButtonComponent
       ],
     }).compileComponents();
   }));

--- a/web/src/app/app.module.ts
+++ b/web/src/app/app.module.ts
@@ -3,7 +3,7 @@
 //
 import { Location } from '@angular/common';
 import { HttpClientModule } from '@angular/common/http';
-import { Injectable, NgModule, NgZone } from '@angular/core';
+import { Injectable, NgModule, NgZone, APP_INITIALIZER } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
@@ -20,6 +20,26 @@ import { NotifierComponent } from './components/notifier/notifier.component';
 import { PageNotFoundComponent } from './components/page-not-found/page-not-found.component';
 import { OverviewModule } from './modules/overview/overview.module';
 import { MarkdownModule, MarkedOptions } from 'ngx-markdown';
+import { VmwThemeToolsModule, VmwClarityThemeService, VmwClarityThemeConfig } from '@vmw/ngx-utils';
+
+export const preloader = (themeService: VmwClarityThemeService) => {
+  const config: VmwClarityThemeConfig = {
+    clarityDarkPath: '/assets/css/clr-ui-dark.min.css',
+    clarityLightPath: '/assets/css/clr-ui.min.css',
+    cookieName: 'clarity-theme',
+    darkBodyClasses: ['dark'],
+    cookieDomain: 'vmware.com'
+  };
+
+  return () => {
+    return new Promise((resolve, reject) => {
+      themeService.initialize(config)
+        .then(() => {
+          resolve()
+        })
+    })
+  }
+}
 
 @Injectable()
 export class UnstripTrailingSlashLocation extends Location {
@@ -47,6 +67,7 @@ export class UnstripTrailingSlashLocation extends Location {
     AppRoutingModule,
     OverviewModule,
     NgSelectModule,
+    VmwThemeToolsModule,
     MarkdownModule.forRoot({
       markedOptions: {
         provide: MarkedOptions,
@@ -63,6 +84,13 @@ export class UnstripTrailingSlashLocation extends Location {
     }),
   ],
   providers: [
+    VmwClarityThemeService,
+    {
+      provide: APP_INITIALIZER,
+      useFactory: preloader,
+      deps: [VmwClarityThemeService],
+      multi: true
+    },
     {
       provide: Location,
       useClass: UnstripTrailingSlashLocation,

--- a/web/src/app/app.module.ts
+++ b/web/src/app/app.module.ts
@@ -3,7 +3,7 @@
 //
 import { Location } from '@angular/common';
 import { HttpClientModule } from '@angular/common/http';
-import { Injectable, NgModule, NgZone, APP_INITIALIZER } from '@angular/core';
+import { Injectable, NgModule, NgZone } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';

--- a/web/src/app/app.module.ts
+++ b/web/src/app/app.module.ts
@@ -20,26 +20,7 @@ import { NotifierComponent } from './components/notifier/notifier.component';
 import { PageNotFoundComponent } from './components/page-not-found/page-not-found.component';
 import { OverviewModule } from './modules/overview/overview.module';
 import { MarkdownModule, MarkedOptions } from 'ngx-markdown';
-import { VmwThemeToolsModule, VmwClarityThemeService, VmwClarityThemeConfig } from '@vmw/ngx-utils';
-
-export const preloader = (themeService: VmwClarityThemeService) => {
-  const config: VmwClarityThemeConfig = {
-    clarityDarkPath: '/assets/css/clr-ui-dark.min.css',
-    clarityLightPath: '/assets/css/clr-ui.min.css',
-    cookieName: 'clarity-theme',
-    darkBodyClasses: ['dark'],
-    cookieDomain: 'vmware.com'
-  };
-
-  return () => {
-    return new Promise((resolve, reject) => {
-      themeService.initialize(config)
-        .then(() => {
-          resolve()
-        })
-    })
-  }
-}
+import { ThemeSwitchButtonComponent } from './modules/overview/components/theme-switch/theme-switch-button.component';
 
 @Injectable()
 export class UnstripTrailingSlashLocation extends Location {
@@ -56,6 +37,7 @@ export class UnstripTrailingSlashLocation extends Location {
     InputFilterComponent,
     NotifierComponent,
     NavigationComponent,
+    ThemeSwitchButtonComponent,
   ],
   imports: [
     BrowserModule,
@@ -67,7 +49,6 @@ export class UnstripTrailingSlashLocation extends Location {
     AppRoutingModule,
     OverviewModule,
     NgSelectModule,
-    VmwThemeToolsModule,
     MarkdownModule.forRoot({
       markedOptions: {
         provide: MarkedOptions,
@@ -84,13 +65,6 @@ export class UnstripTrailingSlashLocation extends Location {
     }),
   ],
   providers: [
-    VmwClarityThemeService,
-    {
-      provide: APP_INITIALIZER,
-      useFactory: preloader,
-      deps: [VmwClarityThemeService],
-      multi: true
-    },
     {
       provide: Location,
       useClass: UnstripTrailingSlashLocation,

--- a/web/src/app/components/input-filter/input-filter.component.scss
+++ b/web/src/app/components/input-filter/input-filter.component.scss
@@ -5,6 +5,22 @@
 @import 'src/styles.scss';
 
 .input-filter {
+  // Dropdown's color variables for Light Theme.
+  :host-context(body) {
+    --tags-bg-color: white;
+    --tags-border-color: #ccc;
+    --tags-font-color: black;
+    --filterTag-link-color: #0079b8;
+  }
+  
+  // Dropdown's color variables for Dark Theme.
+  :host-context(body.dark) {
+    --tags-bg-color: #23353d;
+    --tags-border-color: black;
+    --tags-font-color: #adbbc4;
+    --filterTag-link-color: #49afd9;
+  }
+
   &-control {
     position: relative;
 
@@ -31,15 +47,15 @@
   }
 
   &-tags {
-    background: #fff;
-    border: 1px solid #ccc;
+    background: var(--tags-bg-color);
+    border: 1px solid var(--tags-border-color);
     border-bottom-left-radius: 0.125rem;
     border-bottom-right-radius: 0.125rem;
-    box-shadow: 0 1px 0.125rem rgba(115, 115, 115, 0.25);
+    box-shadow: 0 1px 0.125rem rgba(0, 0, 0, 0.5);
     padding: 8px 8px 4px 8px;
 
     .input-filter-empty {
-      color: #485969;
+      color: var(--tags-font-color);
       font-size: 12px;
     }
 
@@ -49,7 +65,7 @@
       flex-wrap: wrap;
 
       .input-filter-tag {
-        @include pill($label-color);
+        @include pill(var(--label-color));
         text-align: center;
         margin: 0 4px 4px 0;
         padding: 0 8px;
@@ -74,7 +90,7 @@
       text-align: center;
       padding-right: 4px;
       font-size: 12px;
-      color: #0079b8;
+      color: var(--filterTag-link-color);
       cursor: pointer;
 
       &:hover {

--- a/web/src/app/components/namespace/namespace.component.scss
+++ b/web/src/app/components/namespace/namespace.component.scss
@@ -3,22 +3,40 @@
  */
 
 .app-namespace-selector {
+  // Dropdown's color variables for Light Theme.
+  :host-context(body) {
+    --dropdownLink-color:  #0079b8;
+    --dropdownPanel-border-color: #ccc;
+    --dropdownOptionSelected-bg-color: #dae4ea;
+    --dropdownOption-bg-color: white;
+    --dropdownOption-font-color: black;
+  }
+  
+  // Dropdown's color variables for Dark Theme.
+  :host-context(body.dark) {
+    --dropdownLink-color: #49afd9;
+    --dropdownPanel-border-color: black;
+    --dropdownOptionSelected-bg-color: #324f60;
+    --dropdownOption-bg-color: #23353d;
+    --dropdownOption-font-color: #adbbc4;
+  }
+
   width: 250px;
 
   .namespace-dropdown {
     ::ng-deep {
       .ng-select-container {
-        border-color: #0079b8;
+        border-color: var(--dropdownLink-color);
         background: transparent;
       }
 
       .ng-value,
       .ng-input > input {
-        color: #0079b8;
+        color: var(--dropdownLink-color);
       }
 
       .ng-arrow {
-        border-color: #0079b8 transparent transparent;
+        border-color: var(--dropdownLink-color) transparent transparent;
       }
 
       .ng-input {
@@ -28,8 +46,31 @@
 
     &.ng-select-opened ::ng-deep {
       .ng-select-container .ng-arrow {
-        border-color: transparent transparent #0079b8;
+        border-color: transparent transparent var(--dropdownLink-color);
       }
     }
+
+    ::ng-deep .ng-dropdown-panel {
+      box-shadow: 0 1px 0.125rem rgba(0,0,0,.5);
+      border-color: var(--dropdownPanel-border-color);
+      background-color: var(--dropdownOption-bg-color);
+
+      .ng-dropdown-panel-items .ng-option {
+        background-color: var(--dropdownOption-bg-color);
+        color: var(--dropdownOption-font-color);
+
+        &:hover, &.ng-option-selected {
+          background-color: var(--dropdownOptionSelected-bg-color);
+        }
+      }
+
+      &.ng-select-bottom {
+        border-top-color: var(--dropdownLink-color);
+      }
+
+      &.ng-select-top {
+        border-bottom-color: var(--dropdownLink-color);
+      }
+    } 
   }
 }

--- a/web/src/app/modules/overview/components/expression-selector/expression-selector.component.scss
+++ b/web/src/app/modules/overview/components/expression-selector/expression-selector.component.scss
@@ -5,5 +5,5 @@
 @import 'src/styles.scss';
 
 .selector--expression {
-  @include pill($selector-color);
+  @include pill(var(--selector-color));
 }

--- a/web/src/app/modules/overview/components/filters/filters.component.scss
+++ b/web/src/app/modules/overview/components/filters/filters.component.scss
@@ -11,7 +11,7 @@
 
   .filter {
     position: relative;
-    @include pill($label-color);
+    @include pill(var(--label-color));
   }
 
   .filter-remove {

--- a/web/src/app/modules/overview/components/label-selector/label-selector.component.scss
+++ b/web/src/app/modules/overview/components/label-selector/label-selector.component.scss
@@ -5,5 +5,5 @@
 @import 'src/styles.scss';
 
 .selector--label {
-  @include pill($selector-color);
+  @include pill(var(--selector-color));
 }

--- a/web/src/app/modules/overview/components/labels/labels.component.scss
+++ b/web/src/app/modules/overview/components/labels/labels.component.scss
@@ -12,7 +12,7 @@
 
   .view-label {
     position: relative;
-    @include pill($label-color);
+    @include pill(var(--label-color));
   }
 }
 

--- a/web/src/app/modules/overview/components/resource-viewer/resource-viewer.component.scss
+++ b/web/src/app/modules/overview/components/resource-viewer/resource-viewer.component.scss
@@ -2,6 +2,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+body {
+  --statusContainer-bg-color:  #eee;
+}
+body.dark {
+  --statusContainer-bg-color: #0f181c;
+}
 .resourceViewer {
   .view-container {
     height: 100vh;
@@ -15,7 +21,7 @@
     height: 100vh;
     width: 100%;
     padding: 1rem;
-    background-color: #eeeeee;
+    background-color: var(--statusContainer-bg-color)
   }
 
   .node {

--- a/web/src/app/modules/overview/components/theme-switch/theme-switch-button.component.html
+++ b/web/src/app/modules/overview/components/theme-switch/theme-switch-button.component.html
@@ -1,0 +1,6 @@
+<div class="switch-button-container">
+  <button id="switchButton" class="btn btn-link btn-inverse" (click)="switchTheme()">
+    <clr-icon [attr.shape]="isLightThemeEnabled() ? 'moon' : 'sun'"></clr-icon>
+    {{ isLightThemeEnabled() ? 'dark' : 'light' }}
+  </button>
+</div>

--- a/web/src/app/modules/overview/components/theme-switch/theme-switch-button.component.scss
+++ b/web/src/app/modules/overview/components/theme-switch/theme-switch-button.component.scss
@@ -1,0 +1,5 @@
+.switch-button-container {
+  height: 100%;
+  display: flex;
+  align-items: center;
+}

--- a/web/src/app/modules/overview/components/theme-switch/theme-switch-button.component.spec.ts
+++ b/web/src/app/modules/overview/components/theme-switch/theme-switch-button.component.spec.ts
@@ -1,0 +1,75 @@
+// Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ThemeSwitchButtonComponent } from './theme-switch-button.component';
+import { ThemeService } from './theme-switch.service';
+import { themeServiceStub } from 'src/app/testing/theme-service-stub';
+import { By } from '@angular/platform-browser';
+
+describe('ThemeSwitchButtonComponent', () => {
+  let component: ThemeSwitchButtonComponent;
+  let fixture: ComponentFixture<ThemeSwitchButtonComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ThemeSwitchButtonComponent],
+      providers: [{ provide: ThemeService, useValue: themeServiceStub }]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ThemeSwitchButtonComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should load light theme when component mounts if there is not a stored value', () => {
+    spyOn(component, 'loadTheme');
+    component.ngOnInit();
+
+    expect(component.theme).toBe('light');
+    expect(component.loadTheme).toHaveBeenCalled();
+  });
+
+  it('should load right theme when component mounts if there is a stored value', () => {
+    spyOn(component, 'loadTheme');
+    localStorage.setItem('theme', 'dark');
+    component.ngOnInit();
+
+    expect(component.theme).toBe('dark');
+    expect(component.loadTheme).toHaveBeenCalled();
+  });
+
+  it('should indicate if the light theme is active or not', () => {
+    component.theme = 'light';
+    expect(component.isLightThemeEnabled()).toBe(true);
+
+    component.theme = 'dark';
+    expect(component.isLightThemeEnabled()).toBe(false);
+  });
+
+  it('should switch theme', () => {
+    component.theme = 'light';
+    component.switchTheme();
+
+    expect(component.theme).toBe('dark');
+    expect(localStorage.getItem('theme')).toBe('dark');
+
+    component.switchTheme();
+
+    expect(component.theme).toBe('light');
+    expect(localStorage.getItem('theme')).toBe('light');
+  });
+
+  it('should render the right button', () => {
+    component.theme = 'light';
+    fixture.detectChanges();
+    const switchButton = fixture.debugElement.query(By.css('#switchButton')).nativeElement;
+    
+    expect(switchButton.innerHTML).toContain('dark');
+  });
+});

--- a/web/src/app/modules/overview/components/theme-switch/theme-switch-button.component.spec.ts
+++ b/web/src/app/modules/overview/components/theme-switch/theme-switch-button.component.spec.ts
@@ -14,7 +14,7 @@ describe('ThemeSwitchButtonComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ThemeSwitchButtonComponent],
-      providers: [{ provide: ThemeService, useValue: themeServiceStub }]
+      providers: [{ provide: ThemeService, useValue: themeServiceStub }],
     }).compileComponents();
   }));
 
@@ -68,8 +68,9 @@ describe('ThemeSwitchButtonComponent', () => {
   it('should render the right button', () => {
     component.theme = 'light';
     fixture.detectChanges();
-    const switchButton = fixture.debugElement.query(By.css('#switchButton')).nativeElement;
-    
+    const switchButton = fixture.debugElement.query(By.css('#switchButton'))
+      .nativeElement;
+
     expect(switchButton.innerHTML).toContain('dark');
   });
 });

--- a/web/src/app/modules/overview/components/theme-switch/theme-switch-button.component.ts
+++ b/web/src/app/modules/overview/components/theme-switch/theme-switch-button.component.ts
@@ -4,37 +4,45 @@
 import { Component, OnInit, Renderer2 } from '@angular/core';
 import { ThemeService } from './theme-switch.service';
 
-type Theme = 'light' | 'dark'
+type Theme = 'light' | 'dark';
 
 @Component({
   selector: 'app-theme-switch-button',
   templateUrl: './theme-switch-button.component.html',
   styleUrls: ['./theme-switch-button.component.scss'],
-  providers: [ThemeService]
+  providers: [ThemeService],
 })
 export class ThemeSwitchButtonComponent implements OnInit {
   theme: Theme;
 
   constructor(
     private themeService: ThemeService,
-    private renderer: Renderer2,
-  ) { }
+    private renderer: Renderer2
+  ) {}
 
   ngOnInit() {
-    this.theme = localStorage.getItem('theme') as Theme || 'light';
+    this.theme = (localStorage.getItem('theme') as Theme) || 'light';
     this.loadTheme();
   }
 
   isLightThemeEnabled(): boolean {
-    return this.theme === 'light'
+    return this.theme === 'light';
   }
 
   loadTheme() {
     this.themeService.loadCSS(
-      this.isLightThemeEnabled() ? 'assets/css/clr-ui.min.css' : 'assets/css/clr-ui-dark.min.css'
+      this.isLightThemeEnabled()
+        ? 'assets/css/clr-ui.min.css'
+        : 'assets/css/clr-ui-dark.min.css'
     );
-    this.renderer.removeClass(document.body, this.isLightThemeEnabled() ? 'dark' : 'light');
-    this.renderer.addClass(document.body, this.isLightThemeEnabled() ? 'light' : 'dark');
+    this.renderer.removeClass(
+      document.body,
+      this.isLightThemeEnabled() ? 'dark' : 'light'
+    );
+    this.renderer.addClass(
+      document.body,
+      this.isLightThemeEnabled() ? 'light' : 'dark'
+    );
   }
 
   switchTheme() {

--- a/web/src/app/modules/overview/components/theme-switch/theme-switch-button.component.ts
+++ b/web/src/app/modules/overview/components/theme-switch/theme-switch-button.component.ts
@@ -1,0 +1,51 @@
+// Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+import { Component, OnInit, Renderer2 } from '@angular/core';
+import { ThemeService } from './theme-switch.service';
+
+type Theme = 'light' | 'dark'
+
+@Component({
+  selector: 'app-theme-switch-button',
+  templateUrl: './theme-switch-button.component.html',
+  styleUrls: ['./theme-switch-button.component.scss'],
+  providers: [ThemeService]
+})
+export class ThemeSwitchButtonComponent implements OnInit {
+  theme: Theme;
+
+  constructor(
+    private themeService: ThemeService,
+    private renderer: Renderer2,
+  ) { }
+
+  ngOnInit() {
+    this.theme = localStorage.getItem('theme') as Theme || 'light';
+    this.loadTheme();
+  }
+
+  isLightThemeEnabled(): boolean {
+    return this.theme === 'light'
+  }
+
+  loadTheme() {
+    this.themeService.loadCSS(
+      this.isLightThemeEnabled() ? 'assets/css/clr-ui.min.css' : 'assets/css/clr-ui-dark.min.css'
+    );
+    this.renderer.removeClass(document.body, this.isLightThemeEnabled() ? 'dark' : 'light');
+    this.renderer.addClass(document.body, this.isLightThemeEnabled() ? 'light' : 'dark');
+  }
+
+  switchTheme() {
+    if (this.isLightThemeEnabled()) {
+      this.theme = 'dark';
+      localStorage.setItem('theme', 'dark');
+    } else {
+      this.theme = 'light';
+      localStorage.setItem('theme', 'light');
+    }
+
+    this.loadTheme();
+  }
+}

--- a/web/src/app/modules/overview/components/theme-switch/theme-switch.service.spec.ts
+++ b/web/src/app/modules/overview/components/theme-switch/theme-switch.service.spec.ts
@@ -20,17 +20,27 @@ describe('ThemeService', () => {
     expect(service).toBeTruthy();
   });
 
-  it('should load light theme file correctly', inject([DOCUMENT], (document: Document) => {
-    service.loadCSS('assets/css/clr-ui.min.css');
+  it('should load light theme file correctly', inject(
+    [DOCUMENT],
+    (document: Document) => {
+      service.loadCSS('assets/css/clr-ui.min.css');
 
-    let themeLink = document.getElementById('client-theme') as HTMLLinkElement;
-    expect(themeLink.href).toContain('assets/css/clr-ui.min.css');
-  }));
+      const themeLink = document.getElementById(
+        'client-theme'
+      ) as HTMLLinkElement;
+      expect(themeLink.href).toContain('assets/css/clr-ui.min.css');
+    }
+  ));
 
-  it('should load dark theme file correctly', inject([DOCUMENT], (document: Document) => {
-    service.loadCSS('assets/css/clr-ui-dark.min.css');
+  it('should load dark theme file correctly', inject(
+    [DOCUMENT],
+    (document: Document) => {
+      service.loadCSS('assets/css/clr-ui-dark.min.css');
 
-    let themeLink = document.getElementById('client-theme') as HTMLLinkElement;
-    expect(themeLink.href).toContain('assets/css/clr-ui-dark.min.css');
-  }));
+      const themeLink = document.getElementById(
+        'client-theme'
+      ) as HTMLLinkElement;
+      expect(themeLink.href).toContain('assets/css/clr-ui-dark.min.css');
+    }
+  ));
 });

--- a/web/src/app/modules/overview/components/theme-switch/theme-switch.service.spec.ts
+++ b/web/src/app/modules/overview/components/theme-switch/theme-switch.service.spec.ts
@@ -1,0 +1,36 @@
+// Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+import { TestBed, inject } from '@angular/core/testing';
+import { ThemeService } from './theme-switch.service';
+import { DOCUMENT } from '@angular/common';
+
+describe('ThemeService', () => {
+  let service: ThemeService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [ThemeService, Document],
+    });
+
+    service = TestBed.get(ThemeService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should load light theme file correctly', inject([DOCUMENT], (document: Document) => {
+    service.loadCSS('assets/css/clr-ui.min.css');
+
+    let themeLink = document.getElementById('client-theme') as HTMLLinkElement;
+    expect(themeLink.href).toContain('assets/css/clr-ui.min.css');
+  }));
+
+  it('should load dark theme file correctly', inject([DOCUMENT], (document: Document) => {
+    service.loadCSS('assets/css/clr-ui-dark.min.css');
+
+    let themeLink = document.getElementById('client-theme') as HTMLLinkElement;
+    expect(themeLink.href).toContain('assets/css/clr-ui-dark.min.css');
+  }));
+});

--- a/web/src/app/modules/overview/components/theme-switch/theme-switch.service.ts
+++ b/web/src/app/modules/overview/components/theme-switch/theme-switch.service.ts
@@ -1,0 +1,28 @@
+// Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+import { Injectable, Inject } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ThemeService {
+  constructor(@Inject(DOCUMENT) private document: Document) { }
+
+  loadCSS(route: string) {
+    const head = this.document.getElementsByTagName('head')[0];
+    let themeLink = this.document.getElementById('client-theme') as HTMLLinkElement;
+
+    if (themeLink) {
+      themeLink.href = route;
+    } else {
+      const style = this.document.createElement('link');
+      style.id = 'client-theme';
+      style.rel = 'stylesheet';
+      style.href = `${route}`;
+
+      head.appendChild(style);
+    }
+  }
+} 

--- a/web/src/app/modules/overview/components/theme-switch/theme-switch.service.ts
+++ b/web/src/app/modules/overview/components/theme-switch/theme-switch.service.ts
@@ -8,11 +8,13 @@ import { DOCUMENT } from '@angular/common';
   providedIn: 'root',
 })
 export class ThemeService {
-  constructor(@Inject(DOCUMENT) private document: Document) { }
+  constructor(@Inject(DOCUMENT) private document: Document) {}
 
   loadCSS(route: string) {
     const head = this.document.getElementsByTagName('head')[0];
-    let themeLink = this.document.getElementById('client-theme') as HTMLLinkElement;
+    const themeLink = this.document.getElementById(
+      'client-theme'
+    ) as HTMLLinkElement;
 
     if (themeLink) {
       themeLink.href = route;
@@ -25,4 +27,4 @@ export class ThemeService {
       head.appendChild(style);
     }
   }
-} 
+}

--- a/web/src/app/modules/overview/components/yaml/yaml.component.scss
+++ b/web/src/app/modules/overview/components/yaml/yaml.component.scss
@@ -5,4 +5,47 @@
 .yaml-window > pre {
   min-height: 20vh;
   max-height: calc(100vh - 230px);
+
+  & > code.hljs ::ng-deep {
+    // Yaml viewer color variables for Dark Theme.
+    :host-context(body.dark) {
+      --background-color:  #0f171c;
+      --attr-color: white;
+      --string-color: #f96a9f;
+      --bullet-color: #f96a9f;
+      --number-color: #25c0af;
+      --literal-color: #25c0af;
+    }
+
+    // Use library's default color scheme for Light Theme.
+    :host-context(body) {
+      --background-color: #f8f8f8;
+      --attr-color: #565656;
+      --string-color: #d14;
+      --bullet-color: #d14;
+      --number-color: #008080;
+      --literal-color: #008080;
+    }
+
+    color: var(--attr-color);
+    background-color: var(--background-color);
+
+    span {
+      &.hljs-attr {
+        color: var(--attr-color);
+      }
+      &.hljs-string {
+        color: var(--string-color);
+      }
+      &.hljs-number {
+        color: var(--number-color);
+      }
+      &.hljs-literal {
+        color: var(--literal-color);
+      }
+      &.hljs-bullet {
+        color: var(--bullet-color);
+      }
+    }
+  }
 }

--- a/web/src/app/testing/theme-service-stub.ts
+++ b/web/src/app/testing/theme-service-stub.ts
@@ -1,0 +1,8 @@
+// Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+import { ThemeService } from '../modules/overview/components/theme-switch/theme-switch.service';
+
+export const themeServiceStub: Partial<ThemeService> = {
+  loadCSS: () => void(0),
+};

--- a/web/src/app/testing/theme-service-stub.ts
+++ b/web/src/app/testing/theme-service-stub.ts
@@ -4,5 +4,5 @@
 import { ThemeService } from '../modules/overview/components/theme-switch/theme-switch.service';
 
 export const themeServiceStub: Partial<ThemeService> = {
-  loadCSS: () => void(0),
+  loadCSS: () => void 0,
 };

--- a/web/src/sass/_variables.scss
+++ b/web/src/sass/_variables.scss
@@ -2,5 +2,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-$label-color: #0065ab;
-$selector-color: #00968b;
+// Color variables for Light Theme.
+:host-context(body) {
+  --label-color: #0065ab;
+  --selector-color: #00968b;
+}
+
+// Color variables for Dark Theme.
+:host-context(body.dark) {
+  --label-color: #49afd9;
+  --selector-color: #00968b;
+}


### PR DESCRIPTION
* Added Clarity's CSS for Dark Theme.
* Theme switcher button added to the main header.
* Dark Theme styles added for custom non-Clarity components such as namespace dropdown, yaml view and resource viewer.

fixes #36 

![Screen Shot 2019-10-10 at 17 23 05](https://user-images.githubusercontent.com/53268844/66604185-072b4f00-eb84-11e9-8fe0-81d8c2f3b34f.png)
