### PR TITLE
Avoid memory leak with trackBy

### DIFF
--- a/web/src/app/modules/overview/components/datagrid/datagrid.component.html
+++ b/web/src/app/modules/overview/components/datagrid/datagrid.component.html
@@ -19,7 +19,7 @@
                     ></app-content-filter>
                 </clr-dg-filter>
             </clr-dg-column>
-            <clr-dg-row *clrDgItems="let row of rows">
+            <clr-dg-row *clrDgItems="let row of rows; trackBy: identifyRow">
                 <clr-dg-cell *ngFor="let column of columns; trackBy: identifyColumn">
                     <app-content-switcher [view]="row[column]"></app-content-switcher>
                 </clr-dg-cell>


### PR DESCRIPTION
XR: https://github.com/vmware/clarity/issues/1876

Clarity gotcha: datagrids must use trackBy otherwise they will leak memory.

![image](https://user-images.githubusercontent.com/10288252/66782468-95f0e200-ee8a-11e9-8cdb-5b5aae4466e9.png)

Signed-off-by: GuessWhoSamFoo <foos@vmware.com>