### PR TITLE
Add option to not open browser

### DIFF
--- a/internal/commands/dash.go
+++ b/internal/commands/dash.go
@@ -32,6 +32,7 @@ func newOctantCmd(version string) *cobra.Command {
 	var initialContext string
 	var klogVerbosity int
 	var clientQPS float32
+	var openBrowser bool
 	var clientBurst int
 
 	octantCmd := &cobra.Command{
@@ -72,6 +73,7 @@ func newOctantCmd(version string) *cobra.Command {
 					Context:          initialContext,
 					ClientQPS:        clientQPS,
 					ClientBurst:      clientBurst,
+					OpenBrowser:      openBrowser,
 					UserAgent:        fmt.Sprintf("octant/%s", version),
 				}
 
@@ -113,6 +115,7 @@ func newOctantCmd(version string) *cobra.Command {
 	octantCmd.Flags().IntVarP(&klogVerbosity, "klog-verbosity", "", 0, "klog verbosity level")
 	octantCmd.Flags().Float32VarP(&clientQPS, "client-qps", "", 200, "maximum QPS for client")
 	octantCmd.Flags().IntVarP(&clientBurst, "client-burst", "", 400, "maximum burst for client throttle")
+	octantCmd.Flags().BoolVar(&openBrowser, "open-browser", true, "define if a web browser should be opend")
 
 	kubeConfig = os.Getenv("KUBECONFIG")
 	if kubeConfig == "" {

--- a/internal/dash/dash.go
+++ b/internal/dash/dash.go
@@ -53,6 +53,7 @@ type Options struct {
 	ClientQPS        float32
 	ClientBurst      int
 	UserAgent        string
+	OpenBrowser      bool
 }
 
 // Run runs the dashboard.
@@ -177,7 +178,7 @@ func Run(ctx context.Context, logger log.Logger, shutdownCh chan bool, options O
 	apiService := api.New(ctx, api.PathPrefix, actionManger, dashConfig)
 	frontendProxy.FrontendUpdateController = apiService
 
-	d, err := newDash(listener, options.Namespace, options.FrontendURL, apiService, logger)
+	d, err := newDash(listener, options.Namespace, options.FrontendURL, apiService, logger, options.OpenBrowser)
 	if err != nil {
 		return errors.Wrap(err, "failed to create dash instance")
 	}
@@ -314,13 +315,13 @@ type dash struct {
 	logger          log.Logger
 }
 
-func newDash(listener net.Listener, namespace, uiURL string, apiHandler api.Service, logger log.Logger) (*dash, error) {
+func newDash(listener net.Listener, namespace, uiURL string, apiHandler api.Service, logger log.Logger, openBrowser bool) (*dash, error) {
 	return &dash{
 		listener:        listener,
 		namespace:       namespace,
 		uiURL:           uiURL,
 		defaultHandler:  web.Handler,
-		willOpenBrowser: true,
+		willOpenBrowser: openBrowser,
 		apiHandler:      apiHandler,
 		logger:          logger,
 	}, nil


### PR DESCRIPTION
This options allows to specify wether the a browser should be opened or not in stead of hardcoding it to true. This is useful for environments where no web browser is installed (and prevent an ugly error message).