### PR TITLE
Add tags back to nightly

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -53,6 +53,10 @@ workspace:
   path: src/github.com/vmware-tanzu/octant
 
 steps:
+  - name: fetch
+    image: docker:git
+    commands:
+      - git fetch --tags
   - name: releaser
     environment:
       GOOGLE_APPLICATION_JSON:


### PR DESCRIPTION
Drone needs to fetch tags after cloning for goreleaser to release on nightly

Signed-off-by: GuessWhoSamFoo <foos@vmware.com>