### PR TITLE
Added ConfigMap and Secret node edges to Pod in resource viewer

### DIFF
--- a/changelogs/unreleased/367-GuessWhoSamFoo
+++ b/changelogs/unreleased/367-GuessWhoSamFoo
@@ -1,0 +1,1 @@
+Added ConfigMap and Secret node edges to Pod in resource viewer

--- a/examples/resources/kuard-with-configmap-secret.yaml
+++ b/examples/resources/kuard-with-configmap-secret.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kuard-env
+  labels:
+    app: kuard
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kuard
+  template:
+    metadata:
+      labels:
+        app: kuard
+    spec:
+      containers:
+        - name: kuard
+          image: gcr.io/kuar-demo/kuard-amd64:1
+          ports:
+          - containerPort: 8080
+            name: http
+            protocol: TCP
+          env:
+            - name: LOG_LEVEL
+              valueFrom:
+                configMapKeyRef:
+                  name: example-config
+                  key: app.config
+                  optional: true
+      volumes:
+        - name: kuard-volume
+          secret:
+            secretName: example-secret

--- a/internal/objectvisitor/pod_test.go
+++ b/internal/objectvisitor/pod_test.go
@@ -20,6 +20,8 @@ func TestPod_Visit(t *testing.T) {
 	defer controller.Finish()
 
 	serviceAccount := testutil.CreateServiceAccount("service-account")
+	configMap := testutil.CreateConfigMap("configmap")
+	secret := testutil.CreateSecret("secret")
 
 	object := testutil.CreatePod("pod")
 	object.Spec.ServiceAccountName = serviceAccount.Name
@@ -33,6 +35,12 @@ func TestPod_Visit(t *testing.T) {
 	q.EXPECT().
 		ServiceAccountForPod(gomock.Any(), object).
 		Return(serviceAccount, nil)
+	q.EXPECT().
+		ConfigMapsForPod(gomock.Any(), object).
+		Return([]*corev1.ConfigMap{configMap}, nil)
+	q.EXPECT().
+		SecretsForPod(gomock.Any(), object).
+		Return([]*corev1.Secret{secret}, nil)
 
 	handler := fake.NewMockObjectHandler(controller)
 	handler.EXPECT().
@@ -40,6 +48,11 @@ func TestPod_Visit(t *testing.T) {
 		Return(nil)
 	handler.EXPECT().
 		AddEdge(gomock.Any(), u, testutil.ToUnstructured(t, serviceAccount)).
+		Return(nil)
+	handler.EXPECT().
+		AddEdge(gomock.Any(), u, testutil.ToUnstructured(t, configMap)).
+		Return(nil)
+	handler.EXPECT().AddEdge(gomock.Any(), u, testutil.ToUnstructured(t, secret)).
 		Return(nil)
 
 	var visited []unstructured.Unstructured

--- a/web/cypress/integration/deployment.spec.js
+++ b/web/cypress/integration/deployment.spec.js
@@ -72,7 +72,7 @@ describe('Deployment', () => {
       cy.get('[data-id="layer0-selectbox"]')
         .invoke('width')
         .should('be.greaterThan', 0);
-      cy.get('[data-id="layer2-node"]').click(400, 320, { force: true });
+      cy.get('[data-id="layer2-node"]').click(370, 360, { force: true });
 
       cy.get('app-heptagon-grid svg g:first')
         .children()


### PR DESCRIPTION
For reasons described in #363, representation of configmaps may not necessarily be accurate. This does not apply to secrets as mounted secrets are updated automatically.

Signed-off-by: GuessWhoSamFoo <foos@vmware.com>