### PR TITLE
Consolidate pipelines to share workspace and bump goreleaser version

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -40,61 +40,32 @@ steps:
     depends_on:
     - frontend
     - backend
-
----
-kind: pipeline
-name: nightly
-
-trigger:
-  cron: [ nightly ]
-
-workspace:
-  base: /go
-  path: src/github.com/vmware-tanzu/octant
-
-steps:
-  - name: fetch
-    image: docker:git
-    commands:
-      - git fetch --tags
-  - name: releaser
-    environment:
-      GOOGLE_APPLICATION_JSON:
-        from_secret: google_application_json
-    image: goreleaser/goreleaser:v0.119-cgo
-    commands:
-      - echo "$GOOGLE_APPLICATION_JSON" | base64 -d > /tmp/gs.json
-      - GOOGLE_APPLICATION_CREDENTIALS=/tmp/gs.json goreleaser -f .goreleaser-nightly.yml --rm-dist --skip-validate
-
-depends_on:
-  - octant
-
----
-kind: pipeline
-name: release
-
-trigger:
-  event:
-  - tag
-
-workspace:
-  base: /go
-  path: src/github.com/vmware-tanzu/octant
-
-steps:
   - name: releaser
     environment:
       GITHUB_TOKEN:
         from_secret: github_token
-    image: goreleaser/goreleaser:v0.113-cgo
+    when:
+      event:
+        - tag
+    image: goreleaser/goreleaser:v0.120-cgo
     commands:
       - ci/drone-deploy.sh
-
-depends_on:
-  - octant
-
+    depends_on:
+    - build
+  - name: releaser-nightly
+    environment:
+      GOOGLE_APPLICATION_JSON:
+        from_secret: google_application_json
+    when:
+      cron: [ nightly ]
+    image: goreleaser/goreleaser:v0.120-cgo
+    commands:
+      - echo "$GOOGLE_APPLICATION_JSON" | base64 -d > /tmp/gs.json
+      - GOOGLE_APPLICATION_CREDENTIALS=/tmp/gs.json goreleaser -f .goreleaser-nightly.yml --rm-dist --skip-validate
+    depends_on:
+     - build 
 ---
 kind: signature
-hmac: fc3c8c31897d98fc7b9eed31a5bf5bda0f3f8c9096b6b7636b669a931c474c05
+hmac: 9540a6d6fc51dceafdff21f9b5ebae279cc0679b55b4c7e3d58f775c20dd84f7
 
 ...


### PR DESCRIPTION
Config looks cleaner as separate pipelines but this avoids the need to create a temp shared volume

Signed-off-by: GuessWhoSamFoo <foos@vmware.com>