### PR TITLE
Fix netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,4 @@
 [build]
-  base = "site/"
+  base = "site"
   command = "jekyll build"
-  publish = "site/_site"
+  publish = "_site"


### PR DESCRIPTION
This provides a fix for Netlify's revamped configuration. Without removing "site" from `publish` the site wouldn't build. I've contacted their support to update their docs, this is due to a recent change on their end.

Signed-off-by: jonasrosland <jrosland@vmware.com>