### PR TITLE
Added flag to disable cluster overview

### DIFF
--- a/changelogs/unreleased/380-GuessWhoSamFoo
+++ b/changelogs/unreleased/380-GuessWhoSamFoo
@@ -1,0 +1,1 @@
+Added flag to disable cluster overview

--- a/internal/commands/dash.go
+++ b/internal/commands/dash.go
@@ -33,6 +33,7 @@ func newOctantCmd(version string) *cobra.Command {
 	var klogVerbosity int
 	var clientQPS float32
 	var clientBurst int
+	var disableClusterOverview bool
 
 	octantCmd := &cobra.Command{
 		Use:   "octant",
@@ -65,14 +66,15 @@ func newOctantCmd(version string) *cobra.Command {
 
 			go func() {
 				options := dash.Options{
-					EnableOpenCensus: enableOpenCensus,
-					KubeConfig:       kubeConfig,
-					Namespace:        namespace,
-					FrontendURL:      uiURL,
-					Context:          initialContext,
-					ClientQPS:        clientQPS,
-					ClientBurst:      clientBurst,
-					UserAgent:        fmt.Sprintf("octant/%s", version),
+					DisableClusterOverview: disableClusterOverview,
+					EnableOpenCensus:       enableOpenCensus,
+					KubeConfig:             kubeConfig,
+					Namespace:              namespace,
+					FrontendURL:            uiURL,
+					Context:                initialContext,
+					ClientQPS:              clientQPS,
+					ClientBurst:            clientBurst,
+					UserAgent:              fmt.Sprintf("octant/%s", version),
 				}
 
 				if klogVerbosity > 0 {
@@ -113,6 +115,7 @@ func newOctantCmd(version string) *cobra.Command {
 	octantCmd.Flags().IntVarP(&klogVerbosity, "klog-verbosity", "", 0, "klog verbosity level")
 	octantCmd.Flags().Float32VarP(&clientQPS, "client-qps", "", 200, "maximum QPS for client")
 	octantCmd.Flags().IntVarP(&clientBurst, "client-burst", "", 400, "maximum burst for client throttle")
+	octantCmd.Flags().BoolVarP(&disableClusterOverview, "disable-cluster-overview", "", false, "disable cluster overview")
 
 	kubeConfig = os.Getenv("KUBECONFIG")
 	if kubeConfig == "" {


### PR DESCRIPTION
Adds `--disable-cluster-overview` flag. Also can be something tracked by a config file in the future

![image](https://user-images.githubusercontent.com/10288252/67713215-a1f89b80-f982-11e9-8b20-88b57f2f8b9d.png)


Signed-off-by: GuessWhoSamFoo <foos@vmware.com>