### PR TITLE
Display configmap value from using object reference

### DIFF
--- a/internal/printer/job_template.go
+++ b/internal/printer/job_template.go
@@ -6,6 +6,8 @@ SPDX-License-Identifier: Apache-2.0
 package printer
 
 import (
+	"context"
+
 	"github.com/pkg/errors"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -16,12 +18,14 @@ import (
 
 type JobTemplate struct {
 	parent          runtime.Object
+	context         context.Context
 	jobTemplateSpec batchv1beta1.JobTemplateSpec
 }
 
-func NewJobTemplate(parent runtime.Object, jobTemplateSpec batchv1beta1.JobTemplateSpec) *JobTemplate {
+func NewJobTemplate(ctx context.Context, parent runtime.Object, jobTemplateSpec batchv1beta1.JobTemplateSpec) *JobTemplate {
 	return &JobTemplate{
 		parent:          parent,
+		context:         ctx,
 		jobTemplateSpec: jobTemplateSpec,
 	}
 }
@@ -47,7 +51,7 @@ func (jt *JobTemplate) AddToFlexLayout(fl *flexlayout.FlexLayout, options Option
 	containerSection := fl.AddSection()
 
 	for _, container := range jt.jobTemplateSpec.Spec.Template.Spec.Containers {
-		containerConfig := NewContainerConfiguration(jt.parent, &container, portForwarder, false, options)
+		containerConfig := NewContainerConfiguration(jt.context, jt.parent, &container, portForwarder, false, options)
 		summary, err := containerConfig.Create()
 		if err != nil {
 			return err

--- a/internal/printer/object.go
+++ b/internal/printer/object.go
@@ -42,17 +42,17 @@ func defaultMetadataGen(object runtime.Object, fl *flexlayout.FlexLayout, option
 	return nil
 }
 
-func defaultPodTemplateGen(object runtime.Object, template corev1.PodTemplateSpec, fl *flexlayout.FlexLayout, options Options) error {
+func defaultPodTemplateGen(ctx context.Context, object runtime.Object, template corev1.PodTemplateSpec, fl *flexlayout.FlexLayout, options Options) error {
 	podTemplate := NewPodTemplate(object, template)
-	if err := podTemplate.AddToFlexLayout(fl, options); err != nil {
+	if err := podTemplate.AddToFlexLayout(ctx, fl, options); err != nil {
 		return errors.Wrap(err, "add pod template to layout")
 	}
 
 	return nil
 }
 
-func defaultJobTemplateGen(object runtime.Object, template batchv1beta1.JobTemplateSpec, fl *flexlayout.FlexLayout, options Options) error {
-	podTemplate := NewJobTemplate(object, template)
+func defaultJobTemplateGen(ctx context.Context, object runtime.Object, template batchv1beta1.JobTemplateSpec, fl *flexlayout.FlexLayout, options Options) error {
+	podTemplate := NewJobTemplate(ctx, object, template)
 	if err := podTemplate.AddToFlexLayout(fl, options); err != nil {
 		return errors.Wrap(err, "add job template to layout")
 	}
@@ -110,8 +110,8 @@ type Object struct {
 	flexLayout *flexlayout.FlexLayout
 
 	MetadataGen    func(runtime.Object, *flexlayout.FlexLayout, Options) error
-	PodTemplateGen func(runtime.Object, corev1.PodTemplateSpec, *flexlayout.FlexLayout, Options) error
-	JobTemplateGen func(runtime.Object, batchv1beta1.JobTemplateSpec, *flexlayout.FlexLayout, Options) error
+	PodTemplateGen func(context.Context, runtime.Object, corev1.PodTemplateSpec, *flexlayout.FlexLayout, Options) error
+	JobTemplateGen func(context.Context, runtime.Object, batchv1beta1.JobTemplateSpec, *flexlayout.FlexLayout, Options) error
 	EventsGen      func(ctx context.Context, object runtime.Object, fl *flexlayout.FlexLayout, options Options) error
 }
 
@@ -283,13 +283,13 @@ func (o *Object) ToComponent(ctx context.Context, options Options) (component.Co
 	}
 
 	if o.isPodTemplateEnabled {
-		if err := o.PodTemplateGen(o.object, o.podTemplateOptions.template, o.flexLayout, options); err != nil {
+		if err := o.PodTemplateGen(ctx, o.object, o.podTemplateOptions.template, o.flexLayout, options); err != nil {
 			return nil, errors.Wrap(err, "generate pod template")
 		}
 	}
 
 	if o.isJobTemplateEnabled {
-		if err := o.JobTemplateGen(o.object, o.jobTemplateOptions.template, o.flexLayout, options); err != nil {
+		if err := o.JobTemplateGen(ctx, o.object, o.jobTemplateOptions.template, o.flexLayout, options); err != nil {
 			return nil, errors.Wrap(err, "generate job template")
 		}
 	}

--- a/internal/printer/object_test.go
+++ b/internal/printer/object_test.go
@@ -60,7 +60,7 @@ func Test_Object_ToComponent(t *testing.T) {
 	}
 
 	fnPodTemplate := func(o *Object) {
-		o.PodTemplateGen = func(_ runtime.Object, _ corev1.PodTemplateSpec, fl *flexlayout.FlexLayout, options Options) error {
+		o.PodTemplateGen = func(_ context.Context, _ runtime.Object, _ corev1.PodTemplateSpec, fl *flexlayout.FlexLayout, options Options) error {
 			section := fl.AddSection()
 			require.NoError(t, section.Add(component.NewText("pod template"), 12))
 			return nil

--- a/internal/printer/pod_template_test.go
+++ b/internal/printer/pod_template_test.go
@@ -6,6 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 package printer
 
 import (
+	"context"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -38,14 +39,14 @@ func TestPodTemplateHeader(t *testing.T) {
 }
 
 func stubPodTemplateSection(name string) podTemplateFunc {
-	return func(fl *flexlayout.FlexLayout, options podTemplateLayoutOptions) error {
+	return func(ctx context.Context, fl *flexlayout.FlexLayout, options podTemplateLayoutOptions) error {
 		section := fl.AddSection()
 		return section.Add(component.NewText(name), component.WidthFull)
 	}
 }
 
 func stubPodTemplateSectionWithError() podTemplateFunc {
-	return func(fl *flexlayout.FlexLayout, options podTemplateLayoutOptions) error {
+	return func(ctx context.Context, fl *flexlayout.FlexLayout, options podTemplateLayoutOptions) error {
 		return errors.Errorf("failed")
 	}
 }
@@ -159,7 +160,8 @@ func TestPodTemplate_AddToFlexLayout(t *testing.T) {
 
 			options := Options{}
 
-			err := pt.AddToFlexLayout(tc.flexlayout, options)
+			ctx := context.Background()
+			err := pt.AddToFlexLayout(ctx, tc.flexlayout, options)
 			if tc.isErr {
 				require.Error(t, err)
 				return
@@ -186,7 +188,8 @@ func Test_podTemplateHeader(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, podTemplateHeader(fl, options))
+	ctx := context.Background()
+	require.NoError(t, podTemplateHeader(ctx, fl, options))
 
 	got := fl.ToComponent("Foo")
 


### PR DESCRIPTION
This pull request uses the objectstore to get a configmap value based on the name given in `LocalObjectReference`.

Currently all configmaps under `valueFrom` defaults to showing an empty string. It would be better if there were a way to query the pod for the value directly so that they can be compared for any mismatches with object status indicating as such.

Signed-off-by: GuessWhoSamFoo <foos@vmware.com>