### PR TITLE
Add arm and arm64 to release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,6 +14,8 @@ builds:
       - linux
     goarch:
       - amd64
+      - arm
+      - arm64
     ldflags: -X "main.buildTime={{.Date}}" -X "main.gitCommit={{.Commit}}" -X "main.version={{.Version}}"
 nfpms:
   -
@@ -31,6 +33,8 @@ nfpms:
       linux: Linux
       windows: Windows
       amd64: 64bit
+      arm: ARM
+      arm64: ARM64
 archives:
   -
     wrap_in_directory: true

--- a/changelogs/unreleased/388-GuessWhoSamFoo
+++ b/changelogs/unreleased/388-GuessWhoSamFoo
@@ -1,0 +1,1 @@
+Added experimental arm and arm64 support


### PR DESCRIPTION
This was brought up early Oct in https://kubernetes.slack.com/archives/CM37M9FCG/p1569980813092200

We can see if this is stable for a release and decide if it is something to support moving forward.

Signed-off-by: GuessWhoSamFoo <foos@vmware.com>