### PR TITLE
fix issue with kubeconfig not being fetched correctly from envvar

### DIFF
--- a/internal/commands/dash.go
+++ b/internal/commands/dash.go
@@ -26,7 +26,6 @@ import (
 )
 
 func newOctantCmd(version string) *cobra.Command {
-	var kubeConfig string
 	var verboseLevel int
 
 	octantCmd := &cobra.Command{
@@ -69,11 +68,15 @@ func newOctantCmd(version string) *cobra.Command {
 
 			logger.Debugf("disable-open-browser: %s", viper.Get("disable-open-browser"))
 
+			if viper.GetString("kubeconfig") == "" {
+				viper.Set("kubeconfig", clientcmd.NewDefaultClientConfigLoadingRules().GetDefaultFilename())
+			}
+
 			go func() {
 				options := dash.Options{
 					DisableClusterOverview: viper.GetBool("disable-cluster-overview"),
 					EnableOpenCensus:       viper.GetBool("enable-opencensus"),
-					KubeConfig:             kubeConfig,
+					KubeConfig:             viper.GetString("kubeconfig"),
 					Namespace:              viper.GetString("namespace"),
 					FrontendURL:            viper.GetString("ui-url"),
 					Context:                viper.GetString("context"),
@@ -134,12 +137,7 @@ func newOctantCmd(version string) *cobra.Command {
 	octantCmd.Flags().BoolP("disable-cluster-overview", "", false, "disable cluster overview")
 	octantCmd.Flags().BoolP("disable-open-browser", "", false, "disable automatic launching of the browser")
 
-	kubeConfig = viper.GetString("kubeconfig")
-	if kubeConfig == "" {
-		kubeConfig = clientcmd.NewDefaultClientConfigLoadingRules().GetDefaultFilename()
-	}
-
-	octantCmd.Flags().StringVar(&kubeConfig, "kubeconfig", kubeConfig, "absolute path to kubeConfig file")
+	octantCmd.Flags().String("kubeconfig", "", "absolute path to kubeConfig file")
 
 	return octantCmd
 }

--- a/internal/commands/dash_test.go
+++ b/internal/commands/dash_test.go
@@ -1,0 +1,35 @@
+/*
+Copyright (c) 2019 the Octant contributors. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package commands
+
+import (
+	"os"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_bindViper_KUBECONFIG(t *testing.T) {
+	cmd := &cobra.Command{}
+
+	expected := "/testdata/kubeconfig.yml"
+	os.Setenv("KUBECONFIG", expected)
+	defer os.Unsetenv("KUBECONFIG")
+
+	// Before bindViper
+	actual := viper.GetString("kubeconfig")
+	assert.Equal(t, "", actual)
+
+	err := bindViper(cmd)
+	require.NoError(t, err)
+
+	// After bindViper
+	actual = viper.GetString("kubeconfig")
+	assert.Equal(t, expected, actual)
+}


### PR DESCRIPTION
fixes #150 

This fixes a regression introduced in 0.9 with the refactoring of arguments and env vars to viper.

Signed-off-by: Wayne Witzel III <wayne@riotousliving.com>