### PR TITLE
Ensure correct container port is matched with state id

### DIFF
--- a/changelogs/unreleased/408-GuessWhoSamFoo
+++ b/changelogs/unreleased/408-GuessWhoSamFoo
@@ -1,0 +1,1 @@
+Fixed bug where container ports used for active port fowards used an incorrect state id


### PR DESCRIPTION
This change addresses the case where container ports for port forwards can get mixed up with the state id.

Before:
![pf-before](https://user-images.githubusercontent.com/10288252/68411560-81c59b00-013f-11ea-9795-d8f14bec624e.gif)

After:
![pf-after](https://user-images.githubusercontent.com/10288252/68411565-84c08b80-013f-11ea-8dc0-c0241fe0e5a3.gif)


Signed-off-by: GuessWhoSamFoo <foos@vmware.com>