### PR TITLE
ensure web-build sets working directory

### DIFF
--- a/build.go
+++ b/build.go
@@ -153,17 +153,22 @@ func webDeps() {
 }
 
 func webTest() {
-	cmd := newCmd("npm", nil, "run", "build")
+	cmd := newCmd("npm", nil, "run", "test:headless")
 	cmd.Stdout = os.Stdout
 	cmd.Dir = "./web"
 	if err := cmd.Run(); err != nil {
 		log.Fatalf("web-test: %s", err)
 	}
-	runCmd("go", nil, "generate", "./web")
 }
 
 func webBuild() {
-	runCmd("npm", nil, "run", "test:headless")
+	cmd := newCmd("npm", nil, "run", "build")
+	cmd.Stdout = os.Stdout
+	cmd.Dir = "./web"
+	if err := cmd.Run(); err != nil {
+		log.Fatalf("web-build: %s", err)
+	}
+	runCmd("go", nil, "generate", "./web")
 }
 
 func serve() {


### PR DESCRIPTION
Fixes broken `ci-quick` and `web-build` targets in our build.go file. Also fix copy/paste imposing error with webTest / webBuild.

Reported in Slack: https://kubernetes.slack.com/archives/CM37M9FCG/p1573227846099400

Signed-off-by: Wayne Witzel III <wayne@riotousliving.com>