### PR TITLE
Do not remove fakes when running "build.go clean"

### DIFF
--- a/build.go
+++ b/build.go
@@ -125,7 +125,6 @@ func goInstall() {
 }
 
 func clean() {
-	removeFakes()
 	if err := os.Remove("pkg/icon/rice-box.go"); err != nil {
 		log.Fatalf("clean: %s", err)
 	}


### PR DESCRIPTION
This is a follow-up top #428 
Now that fakes are checked-in, running "clean" should not remove them.

Signed-off-by: Antonin Bas <abas@vmware.com>