### PR TITLE
Add iframe component

### DIFF
--- a/pkg/view/component/base.go
+++ b/pkg/view/component/base.go
@@ -15,6 +15,7 @@ const (
 	typeExpressionSelector = "expressionSelector"
 	typeFlexLayout         = "flexlayout"
 	typeGraphviz           = "graphviz"
+	typeIFrame             = "iframe"
 	typeLabels             = "labels"
 	typeLabelSelector      = "labelSelector"
 	typeLink               = "link"

--- a/pkg/view/component/iframe.go
+++ b/pkg/view/component/iframe.go
@@ -1,0 +1,56 @@
+/*
+Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package component
+
+import "encoding/json"
+
+// IFrame is a component for displaying content in an iframe
+type IFrame struct {
+	base
+	Config IFrameConfig `json:"config"`
+}
+
+// IFrameConfig is the title and url of the iframe
+type IFrameConfig struct {
+	Url   string `json:"url"`
+	Title string `json:"title"`
+}
+
+// NewIFrame creates an iframe component
+func NewIFrame(url string, title string) *IFrame {
+	return &IFrame{
+		base: newBase(typeText, nil),
+		Config: IFrameConfig{
+			Url:   url,
+			Title: title,
+		},
+	}
+}
+
+type IFrameMarshal IFrame
+
+// MarshalJSON implements json.Marshaler
+func (t *IFrame) MarshalJSON() ([]byte, error) {
+	m := IFrameMarshal(*t)
+	m.Metadata.Type = typeIFrame
+	return json.Marshal(&m)
+}
+
+// String returns the url content of the component.
+func (t *IFrame) String() string {
+	return t.Config.Url
+}
+
+// LessThan returns true if this component's url is lexically less than the argument supplied.
+func (t *IFrame) LessThan(i interface{}) bool {
+	v, ok := i.(*IFrame)
+	if !ok {
+		return false
+	}
+
+	return t.Config.Url < v.Config.Url
+
+}

--- a/pkg/view/component/unmarshal.go
+++ b/pkg/view/component/unmarshal.go
@@ -46,6 +46,11 @@ func unmarshal(to TypedObject) (Component, error) {
 		err = errors.Wrapf(json.Unmarshal(to.Config, &t.Config),
 			"unmarshal graphviz config")
 		o = t
+	case typeIFrame:
+		t := &IFrame{base: base{Metadata: to.Metadata}}
+		err = errors.Wrapf(json.Unmarshal(to.Config, &t.Config),
+			"unmarshal iframe config")
+		o = t
 	case typeLabels:
 		t := &Labels{base: base{Metadata: to.Metadata}}
 		err = errors.Wrapf(json.Unmarshal(to.Config, &t.Config),

--- a/web/src/app/models/content.ts
+++ b/web/src/app/models/content.ts
@@ -334,3 +334,10 @@ export interface ErrorView extends View {
     data: string;
   };
 }
+
+export interface IFrameView extends View {
+  config: {
+    url: string;
+    title: string;
+  };
+}

--- a/web/src/app/modules/overview/components/content-switcher/content-switcher.component.html
+++ b/web/src/app/modules/overview/components/content-switcher/content-switcher.component.html
@@ -33,6 +33,9 @@
     <ng-container *ngSwitchCase="'error'">
       <app-view-error [view]="view"></app-view-error>
     </ng-container>
+    <ng-container *ngSwitchCase="'iframe'">
+      <app-iframe [view]="view"></app-iframe>
+    </ng-container>
     <ng-container *ngSwitchCase="'link'">
       <app-view-link [view]="view"></app-view-link>
     </ng-container>

--- a/web/src/app/modules/overview/components/iframe/iframe.component.html
+++ b/web/src/app/modules/overview/components/iframe/iframe.component.html
@@ -1,0 +1,6 @@
+<iframe
+  title="{{ title }}"
+  width="100%"
+  height="100%"
+  [src]="url | safe">
+</iframe>

--- a/web/src/app/modules/overview/components/iframe/iframe.component.scss
+++ b/web/src/app/modules/overview/components/iframe/iframe.component.scss
@@ -1,0 +1,4 @@
+iframe {
+    border: none;
+    vertical-align: bottom;
+}

--- a/web/src/app/modules/overview/components/iframe/iframe.component.spec.ts
+++ b/web/src/app/modules/overview/components/iframe/iframe.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SafePipe } from '../../pipes/safe.pipe';
+import { IFrameComponent } from './iframe.component';
+
+describe('IFrameComponent', () => {
+  let component: IFrameComponent;
+  let fixture: ComponentFixture<IFrameComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [IFrameComponent, SafePipe],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(IFrameComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/web/src/app/modules/overview/components/iframe/iframe.component.ts
+++ b/web/src/app/modules/overview/components/iframe/iframe.component.ts
@@ -1,0 +1,24 @@
+import { Component, OnChanges, Input, SimpleChanges } from '@angular/core';
+import { IFrameView } from 'src/app/models/content';
+
+@Component({
+  selector: 'app-iframe',
+  templateUrl: './iframe.component.html',
+  styleUrls: ['./iframe.component.scss'],
+})
+export class IFrameComponent implements OnChanges {
+  @Input() view: IFrameView;
+
+  url: string;
+  title: string;
+
+  constructor() {}
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes.view.currentValue) {
+      const view = changes.view.currentValue as IFrameView;
+      this.url = view.config.url;
+      this.title = view.config.title;
+    }
+  }
+}

--- a/web/src/app/modules/overview/overview.module.ts
+++ b/web/src/app/modules/overview/overview.module.ts
@@ -50,11 +50,13 @@ import { TimestampComponent } from './components/timestamp/timestamp.component';
 import { YamlComponent } from './components/yaml/yaml.component';
 import { OverviewComponent } from './overview.component';
 import { DefaultPipe } from './pipes/default.pipe';
+import { SafePipe } from './pipes/safe.pipe';
 import { ButtonGroupComponent } from './components/button-group/button-group.component';
 import { AlertComponent } from './components/alert/alert.component';
 import { ContentFilterComponent } from './components/content-filter/content-filter.component';
 import { NgTerminalModule } from 'ng-terminal';
 import { TerminalComponent } from 'src/app/components/terminal/terminal.component';
+import { IFrameComponent } from './components/iframe/iframe.component';
 
 export function hljsLanguages() {
   return [{ name: 'yaml', func: yaml }, { name: 'json', func: json }];
@@ -70,6 +72,7 @@ export function hljsLanguages() {
     FiltersComponent,
     FlexlayoutComponent,
     GraphvizComponent,
+    IFrameComponent,
     LabelSelectorComponent,
     LabelsComponent,
     LoadingComponent,
@@ -97,6 +100,7 @@ export function hljsLanguages() {
     HeptagonLabelComponent,
     ContextSelectorComponent,
     DefaultPipe,
+    SafePipe,
     FormComponent,
     CardListComponent,
     CardComponent,
@@ -119,6 +123,6 @@ export function hljsLanguages() {
     MarkdownModule.forChild(),
     NgTerminalModule,
   ],
-  exports: [ContextSelectorComponent, DefaultPipe],
+  exports: [ContextSelectorComponent, DefaultPipe, SafePipe],
 })
 export class OverviewModule {}

--- a/web/src/app/modules/overview/pipes/safe.pipe.spec.ts
+++ b/web/src/app/modules/overview/pipes/safe.pipe.spec.ts
@@ -1,0 +1,19 @@
+import { BrowserModule, DomSanitizer } from '@angular/platform-browser';
+import { inject, TestBed } from '@angular/core/testing';
+import { SafePipe } from './safe.pipe';
+
+describe('SafePipe', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [BrowserModule],
+    });
+  });
+
+  it('create an instance', inject(
+    [DomSanitizer],
+    (domSanitizer: DomSanitizer) => {
+      const pipe = new SafePipe(domSanitizer);
+      expect(pipe).toBeTruthy();
+    }
+  ));
+});

--- a/web/src/app/modules/overview/pipes/safe.pipe.ts
+++ b/web/src/app/modules/overview/pipes/safe.pipe.ts
@@ -1,0 +1,13 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
+
+@Pipe({
+  name: 'safe',
+})
+export class SafePipe implements PipeTransform {
+  constructor(private sanitizer: DomSanitizer) {}
+
+  transform(url: any, args?: any): SafeResourceUrl {
+    return this.sanitizer.bypassSecurityTrustResourceUrl(url);
+  }
+}


### PR DESCRIPTION
Add iframe component, which enables displaying other sites in an
iframe within the octant UI.  This is a simple mechanism to visually
integrate another external application into octant.