### PR TITLE
Initial implementation of quick-switcher (keyboard-driven navigation)

### DIFF
--- a/web/cypress/integration/deployment.spec.js
+++ b/web/cypress/integration/deployment.spec.js
@@ -19,7 +19,7 @@ describe('Deployment', () => {
         '/#/overview/namespace/' + result.stdout + '/workloads/deployments'
       );
 
-      cy.get('span[class="ng-value-label"]').contains(result.stdout);
+      cy.get('span[class="ng-value-label ng-star-inserted"]').contains(result.stdout);
 
       cy.get('[class="ng-star-inserted"]')
         .contains('nginx-deployment')
@@ -60,7 +60,7 @@ describe('Deployment', () => {
         '/#/overview/namespace/' + result.stdout + '/workloads/deployments'
       );
 
-      cy.get('span[class="ng-value-label"]').contains(result.stdout);
+      cy.get('span[class="ng-value-label ng-star-inserted"]').contains(result.stdout);
 
       cy.get('[class="ng-star-inserted"]')
         .contains('nginx-deployment')

--- a/web/src/app/app.component.html
+++ b/web/src/app/app.component.html
@@ -30,4 +30,7 @@
             <router-outlet></router-outlet>
         </div>
     </div>
+    <div class="quick-switcher">
+        <app-quick-switcher></app-quick-switcher>
+    </div>
 </div>

--- a/web/src/app/app.component.spec.ts
+++ b/web/src/app/app.component.spec.ts
@@ -49,7 +49,7 @@ describe('AppComponent', () => {
         ContextSelectorComponent,
         DefaultPipe,
         ThemeSwitchButtonComponent,
-        QuickSwitcherComponent
+        QuickSwitcherComponent,
       ],
     }).compileComponents();
   }));

--- a/web/src/app/app.component.spec.ts
+++ b/web/src/app/app.component.spec.ts
@@ -23,6 +23,7 @@ import {
 import { WebsocketServiceMock } from './modules/overview/services/websocket/mock';
 import { ClarityIcons } from '@clr/icons';
 import { ThemeSwitchButtonComponent } from './modules/overview/components/theme-switch/theme-switch-button.component';
+import { QuickSwitcherComponent } from './components/quick-switcher/quick-switcher.component';
 
 describe('AppComponent', () => {
   beforeEach(async(() => {
@@ -48,6 +49,7 @@ describe('AppComponent', () => {
         ContextSelectorComponent,
         DefaultPipe,
         ThemeSwitchButtonComponent,
+        QuickSwitcherComponent
       ],
     }).compileComponents();
   }));

--- a/web/src/app/app.module.ts
+++ b/web/src/app/app.module.ts
@@ -16,6 +16,7 @@ import { AppComponent } from './app.component';
 import { InputFilterComponent } from './components/input-filter/input-filter.component';
 import { NamespaceComponent } from './components/namespace/namespace.component';
 import { NavigationComponent } from './components/navigation/navigation.component';
+import { QuickSwitcherComponent } from './components/quick-switcher/quick-switcher.component';
 import { NotifierComponent } from './components/notifier/notifier.component';
 import { PageNotFoundComponent } from './components/page-not-found/page-not-found.component';
 import { OverviewModule } from './modules/overview/overview.module';
@@ -37,6 +38,7 @@ export class UnstripTrailingSlashLocation extends Location {
     InputFilterComponent,
     NotifierComponent,
     NavigationComponent,
+    QuickSwitcherComponent,
     ThemeSwitchButtonComponent,
   ],
   imports: [

--- a/web/src/app/components/quick-switcher/quick-switcher.component.html
+++ b/web/src/app/components/quick-switcher/quick-switcher.component.html
@@ -1,0 +1,30 @@
+<clr-modal 
+  class="quick-switcher-modal" 
+  [(clrModalOpen)]="opened"
+  [clrModalStaticBackdrop]="false"
+  [clrModalSkipAnimation]="true"
+  (keyup.enter)="onEnter()" 
+  (keyup)='onKeyUp($event)' 
+  (keydown)='onKeyDown($event)'>
+  
+  <div class="modal-body">
+    <input class="filter-input" 
+      clrInput 
+      placeholder="Let's go somewhere" 
+      name="input" 
+      [(ngModel)]="input" 
+      (ngModelChange)="onInputChange($event)" 
+      />
+    <table class="table table-noborder destinations">
+      <tbody>
+        <tr 
+          *ngFor="let destination of filteredDestinations; trackBy: identifyDestinationItem; index as index"
+          (mouseover)="activeIndex = index" 
+          (click)="onEnter($event)"
+          [class.destination-active]="index == activeIndex" >
+          <td >{{ destination.title }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</clr-modal>

--- a/web/src/app/components/quick-switcher/quick-switcher.component.scss
+++ b/web/src/app/components/quick-switcher/quick-switcher.component.scss
@@ -1,0 +1,56 @@
+/* Copyright (c) 2019 the Octant contributors. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+.quick-switcher-modal {
+
+    // Color variables for Light Theme.
+    :host-context(body) {
+        --destinationActive-color: #000;
+        --destinationActive-bg-color: #d8e3e9;
+    }
+
+    // Color variables for Dark Theme.
+    :host-context(body.dark) {
+        --destinationActive-color: #fff;
+        --destinationActive-bg-color:  #324f62;
+    }
+
+    .filter-input {
+        padding: 1rem 0.5rem;
+    }
+
+    td {
+        padding-left: 11px !important;
+    }
+
+    .destinations td {
+        text-align: left;
+    }
+
+    ::ng-deep .clr-input, ::ng-deep .clr-control-container {
+        width: 100%;
+    }
+
+    ::ng-deep .modal-dialog {
+        position: fixed;
+        top: 4rem;
+    }
+
+    ::ng-deep .modal-header {
+        display: none;
+    }
+
+    ::ng-deep .modal-body, ::ng-deep .modal-content {
+        padding: 0;
+    }
+
+    .destination-active {
+        background-color: var(--destinationActive-bg-color);
+        color: var(--destinationActive-color);
+    }
+
+    .destination-active:hover {
+        cursor: pointer;
+    }
+}

--- a/web/src/app/components/quick-switcher/quick-switcher.component.spec.ts
+++ b/web/src/app/components/quick-switcher/quick-switcher.component.spec.ts
@@ -1,0 +1,28 @@
+// Copyright (c) 2019 the Octant contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DefaultPipe } from '../../modules/overview/pipes/default.pipe';
+import { QuickSwitcherComponent } from './quick-switcher.component';
+
+describe('QuickSwitcherComponent', () => {
+  let component: QuickSwitcherComponent;
+  let fixture: ComponentFixture<QuickSwitcherComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [QuickSwitcherComponent, DefaultPipe],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(QuickSwitcherComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/web/src/app/components/quick-switcher/quick-switcher.component.ts
+++ b/web/src/app/components/quick-switcher/quick-switcher.component.ts
@@ -87,7 +87,7 @@ export class QuickSwitcherComponent implements OnInit, OnDestroy {
 
       // TODO(abrand): Hack for focusing on input. Need to figure this out.
       const el = this.el;
-      setTimeout(function() {
+      setTimeout(() => {
         el.nativeElement.querySelector('.filter-input').focus();
       }, 250);
     }

--- a/web/src/app/components/quick-switcher/quick-switcher.component.ts
+++ b/web/src/app/components/quick-switcher/quick-switcher.component.ts
@@ -1,0 +1,181 @@
+// Copyright (c) 2019 the Octant contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+import {
+  Component,
+  OnInit,
+  OnDestroy,
+  HostListener,
+  ElementRef,
+} from '@angular/core';
+import { Router } from '@angular/router';
+import { Subject, BehaviorSubject } from 'rxjs';
+import { Navigation, NavigationChild } from '../../models/navigation';
+import { NavigationService } from '../../modules/overview/services/navigation/navigation.service';
+import { untilDestroyed } from 'ngx-take-until-destroy';
+import { distinctUntilChanged, debounceTime } from 'rxjs/operators';
+
+const emptyNavigation: Navigation = {
+  sections: [],
+  defaultPath: '',
+};
+
+interface Destination {
+  title: string;
+  path: string;
+  keywords: string[];
+}
+
+@Component({
+  selector: 'app-quick-switcher',
+  templateUrl: './quick-switcher.component.html',
+  styleUrls: ['./quick-switcher.component.scss'],
+})
+export class QuickSwitcherComponent implements OnInit, OnDestroy {
+  behavior = new BehaviorSubject<Navigation>(emptyNavigation);
+
+  navigation: Navigation = emptyNavigation;
+
+  opened = false;
+
+  destinations: Destination[];
+  filteredDestinations: Destination[];
+  currentDestination = '';
+
+  input = '';
+  inputChanged: Subject<string> = new Subject<string>();
+
+  activeIndex = 0;
+
+  constructor(
+    private navigationService: NavigationService,
+    private router: Router,
+    private el: ElementRef
+  ) {
+    // wait a bit before reacting to user input
+    this.inputChanged
+      .pipe(
+        debounceTime(150),
+        distinctUntilChanged()
+      )
+      .subscribe(f => this.updateFilteredDestinations(f));
+  }
+
+  ngOnInit() {
+    this.navigationService.current
+      .pipe(untilDestroyed(this))
+      .subscribe(navigation => {
+        this.navigation = navigation;
+        this.destinations = this.buildDestinations(navigation);
+      });
+  }
+
+  ngOnDestroy() {}
+
+  identifyNavigationItem(index: number, item: NavigationChild): string {
+    return item.title;
+  }
+
+  @HostListener('window:keyup', ['$event'])
+  keyEvent(event: KeyboardEvent) {
+    if (this.opened) {
+      return;
+    }
+    if (event.key === 'k') {
+      this.resetModal();
+      this.opened = true;
+
+      // TODO(abrand): Hack for focusing on input. Need to figure this out.
+      const el = this.el;
+      setTimeout(function() {
+        el.nativeElement.querySelector('.filter-input').focus();
+      }, 250);
+    }
+  }
+
+  // buildDestinations recursively builds an array of destinations based on the
+  // information obtained from the navigation service
+  private buildDestinations(navigation) {
+    return navigation.sections.flatMap(section =>
+      this.recBuildDestinations('', [], section)
+    );
+  }
+
+  private recBuildDestinations(titleAcc: string, keywordAcc, item) {
+    let title = item.title;
+    if (titleAcc !== '') {
+      title = titleAcc + ' -> ' + item.title;
+    }
+    if (!item.children) {
+      let k = keywordAcc.slice(0);
+      k.push(item.title);
+      k = k.flatMap(i => i.split(' '));
+      return [{ title, path: item.path, keywords: k, active: false }];
+    }
+    keywordAcc.push(item.title);
+    return item.children.flatMap(child =>
+      this.recBuildDestinations(title, keywordAcc, child)
+    );
+  }
+
+  private handleEvent = (message: MessageEvent) => {
+    const data = JSON.parse(message.data);
+    this.behavior.next(data);
+  };
+
+  identifyDestinationItem(_: number, item: Destination): string {
+    return item.title;
+  }
+
+  navigateTo(destination: string) {
+    console.log(destination);
+  }
+
+  onInputChange(input: string) {
+    this.inputChanged.next(input);
+  }
+
+  onEnter() {
+    const d = this.filteredDestinations[this.activeIndex].path;
+    this.router.navigateByUrl(d);
+    this.opened = false;
+    this.resetModal();
+  }
+
+  onKeyUp(event: KeyboardEvent) {
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      this.activeIndex = Math.min(
+        this.activeIndex + 1,
+        this.filteredDestinations.length - 1
+      );
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      this.activeIndex = Math.max(this.activeIndex - 1, 0);
+    }
+  }
+
+  onKeyDown(event: KeyboardEvent) {
+    if (event.key === 'ArrowUp' || event.key === 'ArrowDown') {
+      event.preventDefault();
+    }
+  }
+
+  updateFilteredDestinations(filter: string) {
+    this.activeIndex = 0;
+    if (filter === '') {
+      this.filteredDestinations = this.destinations;
+      return;
+    }
+    this.filteredDestinations = this.destinations.filter(d => {
+      const lk = d.keywords.map(k => k.toLowerCase());
+      return lk.findIndex(k => k.includes(filter)) !== -1;
+    });
+  }
+
+  private resetModal() {
+    this.input = '';
+    this.filteredDestinations = this.destinations;
+    this.activeIndex = 0;
+  }
+}


### PR DESCRIPTION
Initial implementation of a quick-switcher / keyboard-driven navigation.

I created a new component that is attached to the root of the application. The component leverages the Clarity modal functionality. 

To open the quick-switcher, hit the `k` key. Once open, you can use the input field to filter the list of potential destinations. You can use the arrow keys to go up and down in the list. Once you are set on a destination, hit `Enter` to navigate there. You may also use the mouse to select an item from the list.

Demo:
![2019-11-19 11 15 56](https://user-images.githubusercontent.com/545723/69164437-03151a00-0abe-11ea-9f2d-10255abffda9.gif)

Fixes #413 