### PR TITLE
printer/service: Print svc port instead of target port in listing

### DIFF
--- a/internal/printer/service.go
+++ b/internal/printer/service.go
@@ -25,7 +25,7 @@ func ServiceListHandler(_ context.Context, list *corev1.ServiceList, options Opt
 		return nil, errors.New("nil list")
 	}
 
-	cols := component.NewTableCols("Name", "Labels", "Type", "Cluster IP", "External IP", "Target Ports", "Age", "Selector")
+	cols := component.NewTableCols("Name", "Labels", "Type", "Cluster IP", "External IP", "Ports", "Age", "Selector")
 	tbl := component.NewTable("Services", "We couldn't find any services!", cols)
 
 	for _, s := range list.Items {
@@ -40,7 +40,7 @@ func ServiceListHandler(_ context.Context, list *corev1.ServiceList, options Opt
 		row["Type"] = component.NewText(string(s.Spec.Type))
 		row["Cluster IP"] = component.NewText(s.Spec.ClusterIP)
 		row["External IP"] = component.NewText(describeExternalIPs(s))
-		row["Target Ports"] = printServicePorts(s.Spec.Ports)
+		row["Ports"] = printServicePorts(s.Spec.Ports)
 
 		ts := s.CreationTimestamp.Time
 		row["Age"] = component.NewTimestamp(ts)
@@ -80,7 +80,7 @@ func ServiceHandler(ctx context.Context, service *corev1.Service, options Option
 func printServicePorts(ports []corev1.ServicePort) component.Component {
 	out := make([]string, len(ports))
 	for i, port := range ports {
-		out[i] = describeTargetPort(port)
+		out[i] = describePortShort(port)
 	}
 
 	return component.NewText(strings.Join(out, ", "))
@@ -354,11 +354,7 @@ func createServiceEndpointsView(ctx context.Context, service *corev1.Service, op
 	return table, nil
 }
 
-func describeTargetPort(port corev1.ServicePort) string {
-	if targetPort := port.TargetPort.String(); targetPort != "0" {
-		return fmt.Sprintf("%s/%s", targetPort, port.Protocol)
-	}
-
+func describePortShort(port corev1.ServicePort) string {
 	return fmt.Sprintf("%d/%s", port.Port, port.Protocol)
 }
 

--- a/internal/printer/service_test.go
+++ b/internal/printer/service_test.go
@@ -83,17 +83,17 @@ func Test_ServiceListHandler(t *testing.T) {
 	got, err := ServiceListHandler(ctx, object, printOptions)
 	require.NoError(t, err)
 
-	cols := component.NewTableCols("Name", "Labels", "Type", "Cluster IP", "External IP", "Target Ports", "Age", "Selector")
+	cols := component.NewTableCols("Name", "Labels", "Type", "Cluster IP", "External IP", "Ports", "Age", "Selector")
 	expected := component.NewTable("Services", "We couldn't find any services!", cols)
 	expected.Add(component.TableRow{
-		"Name":         component.NewLink("", "service", "/service"),
-		"Labels":       component.NewLabels(labels),
-		"Type":         component.NewText("ClusterIP"),
-		"Cluster IP":   component.NewText("1.2.3.4"),
-		"External IP":  component.NewText("8.8.8.8, 8.8.4.4"),
-		"Target Ports": component.NewText("8181/TCP, 8888/UDP"),
-		"Age":          component.NewTimestamp(now),
-		"Selector":     component.NewSelectors([]component.Selector{component.NewLabelSelector("app", "myapp")}),
+		"Name":        component.NewLink("", "service", "/service"),
+		"Labels":      component.NewLabels(labels),
+		"Type":        component.NewText("ClusterIP"),
+		"Cluster IP":  component.NewText("1.2.3.4"),
+		"External IP": component.NewText("8.8.8.8, 8.8.4.4"),
+		"Ports":       component.NewText("8000/TCP, 8888/UDP"),
+		"Age":         component.NewTimestamp(now),
+		"Selector":    component.NewSelectors([]component.Selector{component.NewLabelSelector("app", "myapp")}),
 	})
 
 	component.AssertEqual(t, expected, got)
@@ -344,13 +344,14 @@ func Test_createServiceEndpointsView(t *testing.T) {
 	component.AssertEqual(t, expected, got)
 }
 
-func Test_describeTargetPort(t *testing.T) {
+func Test_describePortShort(t *testing.T) {
 	port := corev1.ServicePort{
-		Port:     8080,
-		Protocol: corev1.ProtocolTCP,
+		Port:       8080,
+		TargetPort: intstr.FromInt(80),
+		Protocol:   corev1.ProtocolTCP,
 	}
 
-	got := describeTargetPort(port)
+	got := describePortShort(port)
 	expected := "8080/TCP"
 	assert.Equal(t, expected, got)
 }


### PR DESCRIPTION
Service listing shows the service ports instead of the target ports.

Fixes #420 