### PR TITLE
Use vendor flag for mock generate check

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -13,6 +13,9 @@ steps:
       - git fetch --tags
   - name: mocks
     image: golang:1.13
+    environment:
+      GOFLAGS: -mod=vendor
+      GO111MODULE: on
     commands:
       - ci/check-generated-mocks.sh
   - name: frontend


### PR DESCRIPTION
This will use go tools from vendor rather than downloading them in CI

Signed-off-by: GuessWhoSamFoo <foos@vmware.com>