### PR TITLE
List additional columns in Custom Resource view

### DIFF
--- a/internal/printer/testdata/cr-versioned-cols.yaml
+++ b/internal/printer/testdata/cr-versioned-cols.yaml
@@ -1,0 +1,7 @@
+apiVersion: "stable.example.com/v2"
+kind: Version
+metadata:
+  name: my-version
+spec:
+  cronSpec: "* * * * */9"
+  replicas: 1

--- a/internal/printer/testdata/crd-versioned-cols.yaml
+++ b/internal/printer/testdata/crd-versioned-cols.yaml
@@ -1,0 +1,65 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: versions.stable.example.com
+spec:
+  group: stable.example.com
+  scope: Namespaced
+  names:
+    plural: versions
+    singular: version
+    kind: Version
+    shortNames:
+    - ver
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              cronSpec:
+                type: string
+              image:
+                type: string
+              replicas:
+                type: integer
+    additionalPrinterColumns:
+    - name: Spec
+      type: string
+      description: The cron spec defining the interval a CronJob is run
+      jsonPath: .spec.cronSpec
+    - name: Replicas
+      type: integer
+      description: The number of jobs launched by the CronJob
+      jsonPath: .spec.replicas
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
+  - name: v2
+    served: true
+    storage: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              cronSpec:
+                type: string
+              replicas:
+                type: integer
+    additionalPrinterColumns:
+    - name: Spec
+      type: string
+      description: The cron spec defining the interval a CronJob is run
+      jsonPath: .spec.cronSpec
+    - name: Count
+      type: integer
+      description: The number of jobs launched by the CronJob
+      jsonPath: .spec.replicas


### PR DESCRIPTION
Custom Resource Definitions may additionalPrinterColumns that are
specific to a give api version.  The CustomResourceHandler and
CustomResourceListHandler were only handling top-level
additionalPrinterColumns that apply to all columns regardless of
version.  This change handles version-specific additionalPrinterColumns.
This change addresses https://github.com/vmware-tanzu/octant/issues/405