### PR TITLE
quickswitcher: update key shortcut to ctrl +k

### DIFF
--- a/web/src/app/components/quick-switcher/quick-switcher.component.ts
+++ b/web/src/app/components/quick-switcher/quick-switcher.component.ts
@@ -81,7 +81,7 @@ export class QuickSwitcherComponent implements OnInit, OnDestroy {
     if (this.opened) {
       return;
     }
-    if (event.key === 'k') {
+    if (event.key === 'k' && event.ctrlKey) {
       this.resetModal();
       this.opened = true;
 


### PR DESCRIPTION
Fixes #474 

The initial implementation of the quick-switcher used `k` as the shortcut key. This was problematic because the quick-switcher would open, even if the user was trying to type a `k` char into an input box.

With this PR,  the quick-switcher shortcut is updated to `ctrl + k`.