### PR TITLE
pods with missing owners should not cause workload viewer to break

### DIFF
--- a/internal/modules/workloads/home_describer.go
+++ b/internal/modules/workloads/home_describer.go
@@ -52,7 +52,7 @@ func (h *HomeDescriber) Describe(ctx context.Context, namespace string, options 
 
 	cards, fullMetrics, err := collector.Collect(ctx, namespace)
 	if err != nil {
-		return component.EmptyContentResponse, fmt.Errorf("collect workload cards")
+		return component.EmptyContentResponse, fmt.Errorf("collect workload cards: %w", err)
 	}
 
 	cardWidth := component.WidthHalf

--- a/internal/octant/workload.go
+++ b/internal/octant/workload.go
@@ -171,8 +171,7 @@ func objectOwner(ctx context.Context, objectStore store.Store, object *unstructu
 	}
 
 	if !found {
-		// TODO: does this need a better error? (GH#510)
-		return nil, fmt.Errorf("unable to find %s: %w", ownerRefKey, err)
+		return object, nil
 	}
 
 	return objectOwner(ctx, objectStore, owner)


### PR DESCRIPTION
If a pod has a missing ancestor, i.e, it could not be found in the object store, skip finding the ancestor instead of returning an error.

#510