### PR TITLE
crd printer should support multiple versions

### DIFF
--- a/internal/printer/customresourcedefinition.go
+++ b/internal/printer/customresourcedefinition.go
@@ -39,9 +39,10 @@ func CustomResourceDefinitionHandler(ctx context.Context, crd *unstructured.Unst
 		return nil, err
 	}
 
-	for _, version := range versions {
+	for i := range versions {
 		object.RegisterItems(ItemDescriptor{
 			Func: func() (c component.Component, err error) {
+				version := versions[i]
 				crGVK, err := gvk.CustomResource(crd, version)
 				if err != nil {
 					return nil, err


### PR DESCRIPTION
In the printers, items are generated and then printed later in a func. This func is defined in a for loop and being referred to by value and not by reference, so each version ended up being the last version.

This change uses in the range index to ensure the proper version is being shown.

Noted in: https://github.com/vmware-tanzu/octant/issues/483#issuecomment-569144151

Signed-off-by: bryanl <bryanliles@gmail.com>