### PR TITLE
Correcting Typo in Plugin Uninstall Documentation

### DIFF
--- a/site/docs/master/plugins/get-started.md
+++ b/site/docs/master/plugins/get-started.md
@@ -53,7 +53,7 @@ A plugin with support for `PrinterItems` allow adding a `FlexLayoutItem` consist
 ## Uninstall
 
 Plugins can be removed by deleting the plugin binary from `~/.config/octant/plugins`. An example of deleting a plugin is shown below 
-where `octant-sample-plugin` is the plugin that will uninstalled:
+where `octant-sample-plugin` is the plugin that will be uninstalled:
 
 ```
 rm ~/.config/octant/plugins/octant-sample-plugin


### PR DESCRIPTION
This pull request corrects a minor typo in the plugin uninstall documentation. 