### PR TITLE
Correct PVC Misspell and Component Code Comment Typos

### DIFF
--- a/internal/printer/persistentvolumeclaim.go
+++ b/internal/printer/persistentvolumeclaim.go
@@ -79,7 +79,7 @@ func PersistentVolumeClaimHandler(ctx context.Context, persistentVolumeClaim *co
 	}
 
 	if err := ph.MountedPodList(ctx, options); err != nil {
-		return nil, errors.Wrap(err, "print peristentvolumeclaim mounted pod list")
+		return nil, errors.Wrap(err, "print persistentvolumeclaim mounted pod list")
 	}
 	return o.ToComponent(ctx, options)
 }

--- a/pkg/view/component/component.go
+++ b/pkg/view/component/component.go
@@ -157,7 +157,7 @@ type Component interface {
 
 	// GetMetadata returns metadata for the component.
 	GetMetadata() Metadata
-	// SetAccessor sets the accessfor the component.
+	// SetAccessor sets the access for the component.
 	SetAccessor(string)
 	// IsEmpty returns true if the component is "empty".
 	IsEmpty() bool


### PR DESCRIPTION
Correcting minor misspelling of persistentvolumeclaim (`peristentvolumeclaim` -> `persistentvolumeclaim`). 

Correct minor spacing issue for code comment.