### PR TITLE
Move object metadata to its own tab

### DIFF
--- a/changelogs/unreleased/539-bryanl
+++ b/changelogs/unreleased/539-bryanl
@@ -1,0 +1,1 @@
+Move object metadata to its own tab

--- a/internal/describer/crd_list.go
+++ b/internal/describer/crd_list.go
@@ -70,6 +70,13 @@ func (cld *crdList) Describe(ctx context.Context, namespace string, options Opti
 	contentResponse := component.NewContentResponse(title)
 	contentResponse.Add(view)
 
+	metadata, err := printer.MetadataHandler(crd, options.Link)
+	if err != nil {
+		return component.EmptyContentResponse, err
+	}
+	metadata.SetAccessor("metadata")
+	contentResponse.Add(metadata)
+
 	yamlView, err := yamlviewer.ToComponent(crd)
 	if err != nil {
 		return component.EmptyContentResponse, err

--- a/internal/printer/object_test.go
+++ b/internal/printer/object_test.go
@@ -44,21 +44,6 @@ func Test_Object_ToComponent(t *testing.T) {
 		},
 	}
 
-	metadataSection := component.FlexLayoutSection{
-		{
-			Width: component.WidthHalf,
-			View:  component.NewText("metadata"),
-		},
-	}
-
-	fnMetadata := func(o *Object) {
-		o.MetadataGen = func(object runtime.Object, fl *flexlayout.FlexLayout, options Options) error {
-			section := fl.AddSection()
-			require.NoError(t, section.Add(component.NewText("metadata"), 12))
-			return nil
-		}
-	}
-
 	fnPodTemplate := func(o *Object) {
 		o.PodTemplateGen = func(_ context.Context, _ runtime.Object, _ corev1.PodTemplateSpec, fl *flexlayout.FlexLayout, options Options) error {
 			section := fl.AddSection()
@@ -97,7 +82,6 @@ func Test_Object_ToComponent(t *testing.T) {
 			},
 			sections: []component.FlexLayoutSection{
 				defaultConfigSection,
-				metadataSection,
 			},
 		},
 		{
@@ -124,7 +108,6 @@ func Test_Object_ToComponent(t *testing.T) {
 							}...),
 					},
 				},
-				metadataSection,
 			},
 		},
 		{
@@ -136,7 +119,6 @@ func Test_Object_ToComponent(t *testing.T) {
 			},
 			sections: []component.FlexLayoutSection{
 				defaultConfigSection,
-				metadataSection,
 				{
 					{
 						Width: component.WidthHalf,
@@ -154,7 +136,6 @@ func Test_Object_ToComponent(t *testing.T) {
 			},
 			sections: []component.FlexLayoutSection{
 				defaultConfigSection,
-				metadataSection,
 				{
 					{
 						Width: component.WidthHalf,
@@ -175,7 +156,6 @@ func Test_Object_ToComponent(t *testing.T) {
 			},
 			sections: []component.FlexLayoutSection{
 				defaultConfigSection,
-				metadataSection,
 			},
 		},
 		{
@@ -206,7 +186,6 @@ func Test_Object_ToComponent(t *testing.T) {
 			},
 			sections: []component.FlexLayoutSection{
 				defaultConfigSection,
-				metadataSection,
 				{
 					{
 						Width: component.WidthHalf,
@@ -240,7 +219,7 @@ func Test_Object_ToComponent(t *testing.T) {
 			tpo := newTestPrinterOptions(controller)
 			printOptions := tpo.ToOptions()
 
-			o := NewObject(tc.object, fnMetadata, fnPodTemplate, fnEvent)
+			o := NewObject(tc.object, fnPodTemplate, fnEvent)
 
 			o.RegisterConfig(defaultConfig)
 

--- a/web/cypress/integration/plugin.spec.js
+++ b/web/cypress/integration/plugin.spec.js
@@ -20,7 +20,7 @@ describe('Plugin', () => {
 
       cy.get('[class=nav]')
         .find('button')
-        .should('have.length', 5)
+        .should('have.length', 6)
         .last()
         .contains('Extra Pod Details')
         .click();


### PR DESCRIPTION
Also:

* replaced github.com/pkg/errors with fmt.Errorf

<img width="1629" alt="Screen Shot 2020-01-16 at 10 20 54 AM" src="https://user-images.githubusercontent.com/240/72538185-6a93df80-384b-11ea-81ac-584a7114eeea.png">

<img width="1629" alt="Screen Shot 2020-01-16 at 10 20 58 AM" src="https://user-images.githubusercontent.com/240/72538163-64056800-384b-11ea-8b2e-e8ea3f5bd8a6.png">




Signed-off-by: bryanl <bryanliles@gmail.com>