### PR TITLE
Fix configmap summary and sort env vars

### DIFF
--- a/changelogs/unreleased/545-GuessWhoSamFoo
+++ b/changelogs/unreleased/545-GuessWhoSamFoo
@@ -1,0 +1,1 @@
+Display container env vars by lexical sort and show summary with missing configmap references

--- a/internal/printer/container.go
+++ b/internal/printer/container.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path"
+	"sort"
 	"strings"
 
 	"github.com/vmware-tanzu/octant/internal/portforward"
@@ -333,6 +334,9 @@ func describeContainerEnv(ctx context.Context, parent runtime.Object, c *corev1.
 // Expected columns: Name, Value, Source
 func describeEnvRows(ctx context.Context, namespace string, vars []corev1.EnvVar, options Options) ([]component.TableRow, error) {
 	rows := make([]component.TableRow, 0)
+
+	sort.Slice(vars, func(i, j int) bool { return vars[i].Name < vars[j].Name })
+
 	for _, e := range vars {
 		row := component.TableRow{}
 		rows = append(rows, row)
@@ -383,19 +387,18 @@ func describeEnvRows(ctx context.Context, namespace string, vars []corev1.EnvVar
 				return nil, err
 			}
 
-			if !found {
-				return nil, errors.Errorf("configmap %q from %q not found",
-					ref.Name, namespace)
+			if found {
+				configMap := &corev1.ConfigMap{}
+				if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, configMap); err != nil {
+					return nil, err
+				}
+
+				row["Value"] = component.NewText(configMap.Data[ref.Key])
+				row["Source"] = source
+			} else {
+				row["Value"] = component.NewText("<none>")
+				row["Source"] = component.NewText(fmt.Sprintf("%s:%s", ref.Name, ref.Key))
 			}
-
-			configMap := &corev1.ConfigMap{}
-			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, configMap); err != nil {
-				return nil, err
-			}
-
-			row["Value"] = component.NewText(configMap.Data[ref.Key])
-
-			row["Source"] = source
 		}
 	}
 

--- a/internal/printer/container_test.go
+++ b/internal/printer/container_test.go
@@ -138,9 +138,9 @@ func Test_ContainerConfiguration(t *testing.T) {
 		component.NewTableCols("Name", "Value", "Source"))
 	envTable.Add(
 		component.TableRow{
-			"Name":   component.NewText("tier"),
-			"Value":  component.NewText("prod"),
-			"Source": component.NewText(""),
+			"Name":   component.NewText("configmapref"),
+			"Value":  component.NewText(""),
+			"Source": component.NewLink("", "myconfig:somekey", "/configMap"),
 		},
 		component.TableRow{
 			"Name":   component.NewText("fieldref"),
@@ -153,14 +153,14 @@ func Test_ContainerConfiguration(t *testing.T) {
 			"Source": component.NewText("requests.cpu"),
 		},
 		component.TableRow{
-			"Name":   component.NewText("configmapref"),
-			"Value":  component.NewText(""),
-			"Source": component.NewLink("", "myconfig:somekey", "/configMap"),
-		},
-		component.TableRow{
 			"Name":   component.NewText("secretref"),
 			"Value":  component.NewText(""),
 			"Source": component.NewLink("", "mysecret:somesecretkey", "/secret"),
+		},
+		component.TableRow{
+			"Name":   component.NewText("tier"),
+			"Value":  component.NewText("prod"),
+			"Source": component.NewText(""),
 		},
 		// EnvFromSource
 		component.TableRow{


### PR DESCRIPTION
xref: #504, #234 

For cases where a `configMapKeyRef` is defined in the spec but missing in cluster, octant will show none and use a text component instead of link.

Signed-off-by: GuessWhoSamFoo <foos@vmware.com>