### PR TITLE
Fix flaky namespace dropdown test

### DIFF
--- a/web/cypress/integration/namespace.spec.js
+++ b/web/cypress/integration/namespace.spec.js
@@ -1,6 +1,8 @@
 describe('Namespace', () => {
   beforeEach(() => {
-    cy.visit('/');
+    cy.visit('/', {
+      onBeforeLoad: spyOnAddEventListener
+    }).then(waitForAppStart);
   });
 
   it('namespaces navigation', () => {
@@ -15,8 +17,36 @@ describe('Namespace', () => {
   it('namespace dropdown', () => {
     cy.get('input[role="combobox"]').click();
 
-    cy.get('[class="ng-option-label ng-star-inserted"]').contains('octant-cypress').parent().click();
+    cy.get('span[class="ng-option-label ng-star-inserted"]')
+      .contains('octant-cypress')
+      .parent()
+      .click()
 
     cy.location('hash').should('include', '/' + 'octant-cypress');
   });
 });
+
+let appHasStarted
+function spyOnAddEventListener (win) {
+  const addListener = win.EventTarget.prototype.addEventListener
+  win.EventTarget.prototype.addEventListener = function (name) {
+    console.log('Event listener added:', name)
+    if (name === 'test') {
+      // that means the web application has started
+      appHasStarted = true
+      win.EventTarget.prototype.addEventListener = addListener
+    }
+    return addListener.apply(this, arguments)
+  }
+}
+function waitForAppStart() {
+  return new Cypress.Promise((resolve, reject) => {
+    const isReady = () => {
+      if (appHasStarted) {
+        return resolve();
+      }
+      setTimeout(isReady, 0);
+    }
+    isReady();
+  });
+};


### PR DESCRIPTION
Cause seems to be clicking the dropdown item before event emitter is ready which results in octant not switching namespaces. ~This change adds retry-ability and additional checks for visibility for certain dom elements for clicking.~

Signed-off-by: GuessWhoSamFoo <foos@vmware.com>