### PR TITLE
bug fix: don't let latent pod metrics break the workload viewer

### DIFF
--- a/changelogs/unreleased/572-bryanl
+++ b/changelogs/unreleased/572-bryanl
@@ -1,0 +1,1 @@
+bug fix: don't fail if pod metrics are not available for a pod (they are not available instantly)

--- a/internal/octant/fake/mock_pod_metrics_crud.go
+++ b/internal/octant/fake/mock_pod_metrics_crud.go
@@ -34,12 +34,13 @@ func (m *MockPodMetricsCRUD) EXPECT() *MockPodMetricsCRUDMockRecorder {
 }
 
 // Get mocks base method
-func (m *MockPodMetricsCRUD) Get(arg0, arg1 string) (*unstructured.Unstructured, error) {
+func (m *MockPodMetricsCRUD) Get(arg0, arg1 string) (*unstructured.Unstructured, bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", arg0, arg1)
 	ret0, _ := ret[0].(*unstructured.Unstructured)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // Get indicates an expected call of Get

--- a/internal/octant/fake/mock_pod_metrics_loader.go
+++ b/internal/octant/fake/mock_pod_metrics_loader.go
@@ -34,12 +34,13 @@ func (m *MockPodMetricsLoader) EXPECT() *MockPodMetricsLoaderMockRecorder {
 }
 
 // Load mocks base method
-func (m *MockPodMetricsLoader) Load(arg0, arg1 string) (*unstructured.Unstructured, error) {
+func (m *MockPodMetricsLoader) Load(arg0, arg1 string) (*unstructured.Unstructured, bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Load", arg0, arg1)
 	ret0, _ := ret[0].(*unstructured.Unstructured)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // Load indicates an expected call of Load

--- a/internal/octant/workload.go
+++ b/internal/octant/workload.go
@@ -429,9 +429,13 @@ func (wl *ClusterWorkloadLoader) podMetrics(pod *unstructured.Unstructured) (*co
 	namespace := pod.GetNamespace()
 	name := pod.GetName()
 
-	object, err := wl.PodMetricsLoader.Load(namespace, name)
+	object, found, err := wl.PodMetricsLoader.Load(namespace, name)
 	if err != nil {
 		return nil, fmt.Errorf("get pod metrics: %w", err)
+	}
+
+	if !found {
+		return nil, &NoPodMetricsErr{}
 	}
 
 	containersRaw, found, err := unstructured.NestedSlice(object.Object, "containers")

--- a/internal/octant/workload_test.go
+++ b/internal/octant/workload_test.go
@@ -42,7 +42,7 @@ func podMetricsLoader(controller *gomock.Controller, pm *unstructured.Unstructur
 	if pm != nil {
 		pml.EXPECT().
 			Load("namespace", gomock.Any()).
-			Return(pm, nil).
+			Return(pm, true, nil).
 			AnyTimes()
 	}
 


### PR DESCRIPTION
This change returns gracefully if pod metrics are not available for a pod. (i.e., it is new and they don't exist yet)

Fixes: #572
Signed-off-by: bryanl <bryanliles@gmail.com>