### PR TITLE
Check for content before selecting namespace in e2e

### DIFF
--- a/web/cypress/integration/namespace.spec.js
+++ b/web/cypress/integration/namespace.spec.js
@@ -1,8 +1,6 @@
 describe('Namespace', () => {
   beforeEach(() => {
-    cy.visit('/', {
-      onBeforeLoad: spyOnAddEventListener
-    }).then(waitForAppStart);
+    cy.visit('/');
   });
 
   it('namespaces navigation', () => {
@@ -15,6 +13,8 @@ describe('Namespace', () => {
   });
 
   it('namespace dropdown', () => {
+    cy.get('h2').contains(/Overview/).should('be.visible');
+
     cy.get('input[role="combobox"]').click();
 
     cy.get('span[class="ng-option-label ng-star-inserted"]')
@@ -25,28 +25,3 @@ describe('Namespace', () => {
     cy.location('hash').should('include', '/' + 'octant-cypress');
   });
 });
-
-let appHasStarted
-function spyOnAddEventListener (win) {
-  const addListener = win.EventTarget.prototype.addEventListener
-  win.EventTarget.prototype.addEventListener = function (name) {
-    console.log('Event listener added:', name)
-    if (name === 'test') {
-      // that means the web application has started
-      appHasStarted = true
-      win.EventTarget.prototype.addEventListener = addListener
-    }
-    return addListener.apply(this, arguments)
-  }
-}
-function waitForAppStart() {
-  return new Cypress.Promise((resolve, reject) => {
-    const isReady = () => {
-      if (appHasStarted) {
-        return resolve();
-      }
-      setTimeout(isReady, 0);
-    }
-    isReady();
-  });
-};


### PR DESCRIPTION

![Screenshot_20200124_115327](https://user-images.githubusercontent.com/10288252/73099475-73fef680-3ea0-11ea-80bf-227659bccb1a.png)

In practice, this test failure is difficult for a user to replicate. This is a workaround that is more transparent than explicitly waiting for a given event listener, but more dynamic than waiting an arbitrary amount of time.

Signed-off-by: GuessWhoSamFoo <foos@vmware.com>