### PR TITLE
Added codeblock component for long configmap values

### DIFF
--- a/changelogs/unreleased/583-GuessWhoSamFoo
+++ b/changelogs/unreleased/583-GuessWhoSamFoo
@@ -1,0 +1,1 @@
+Added new component for multi-line text to handle long ConfigMap values

--- a/internal/printer/configmap.go
+++ b/internal/printer/configmap.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/pkg/errors"
 
@@ -146,7 +147,11 @@ func describeConfigMapDataRows(cm *corev1.ConfigMap) ([]component.TableRow, erro
 
 		row["Key"] = component.NewText(k)
 
-		row["Value"] = component.NewText(data[k])
+		if strings.Contains(data[k], "\n") {
+			row["Value"] = component.NewCodeBlock(data[k])
+		} else {
+			row["Value"] = component.NewText(data[k])
+		}
 	}
 
 	return rows, nil

--- a/pkg/view/component/base.go
+++ b/pkg/view/component/base.go
@@ -10,6 +10,7 @@ const (
 	typeButtonGroup         = "buttonGroup"
 	typeCard                = "card"
 	typeCardList            = "cardList"
+	typeCodeBlock           = "codeBlock"
 	typeContainers          = "containers"
 	typeDonutChart          = "donutChart"
 	typeError               = "error"

--- a/pkg/view/component/code.go
+++ b/pkg/view/component/code.go
@@ -1,0 +1,38 @@
+/*
+Copyright (c) 2020 the Octant contributors. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package component
+
+import "encoding/json"
+
+// Code is a component for code
+type Code struct {
+	base
+	Config CodeConfig `json:"config"`
+}
+
+// CodeConfig is the contents of Code
+type CodeConfig struct {
+	Code string `json:"value"`
+}
+
+// NewCodeBlock creates a code component
+func NewCodeBlock(s string) *Code {
+	return &Code{
+		base: newBase(typeCodeBlock, nil),
+		Config: CodeConfig{
+			Code: s,
+		},
+	}
+}
+
+type codeMarshal Code
+
+// MarshalJSON implements json.Marshaler
+func (c *Code) MarshalJSON() ([]byte, error) {
+	m := codeMarshal(*c)
+	m.Metadata.Type = typeCodeBlock
+	return json.Marshal(&m)
+}

--- a/pkg/view/component/code_test.go
+++ b/pkg/view/component/code_test.go
@@ -1,0 +1,53 @@
+/*
+Copyright (c) 2020 the Octant contributors. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package component
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Code_Marshal(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    Component
+		expected string
+		isErr    bool
+	}{
+		{
+			name: "general",
+			input: &Code{
+				Config: CodeConfig{
+					Code: "hello world\nthis is a newline",
+				},
+			},
+			expected: `
+			{
+				"metadata": {
+								"type": "codeBlock"
+				},
+				"config": {
+					"value": "hello world\nthis is a newline"
+				}
+			}
+`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := json.Marshal(tc.input)
+			isErr := (err != nil)
+			if isErr != tc.isErr {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			assert.JSONEq(t, tc.expected, string(actual))
+		})
+	}
+}

--- a/web/src/app/models/content.ts
+++ b/web/src/app/models/content.ts
@@ -455,3 +455,9 @@ export interface ExtensionView extends View {
     tabs: ExtensionTab[];
   };
 }
+
+export interface CodeView extends View {
+  config: {
+    value: string;
+  };
+}

--- a/web/src/app/modules/overview/components/code/code.component.html
+++ b/web/src/app/modules/overview/components/code/code.component.html
@@ -1,0 +1,8 @@
+<div class="code-button-wrapper">
+    <button type="button" class="btn btn-icon btn-link" title="Copy to clipboard" (click)="copyToClipboard(value)">
+        <clr-icon shape="copy-to-clipboard" size="32"></clr-icon>
+    </button>
+</div>
+<pre>
+<code>{{value}}</code>
+</pre>

--- a/web/src/app/modules/overview/components/code/code.component.scss
+++ b/web/src/app/modules/overview/components/code/code.component.scss
@@ -1,0 +1,9 @@
+/* Copyright (c) 2020 the Octant contributors. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+ .code-button-wrapper {
+     position: absolute;
+     margin-top: 20px;
+     right: 30px;
+ }

--- a/web/src/app/modules/overview/components/code/code.component.spec.ts
+++ b/web/src/app/modules/overview/components/code/code.component.spec.ts
@@ -1,0 +1,38 @@
+/* Copyright (c) 2020 the Octant contributors. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { CodeComponent } from './code.component';
+
+describe('CodeComponent', () => {
+  let component: CodeComponent;
+  let fixture: ComponentFixture<CodeComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [CodeComponent],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CodeComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('copy button copies text', async(() => {
+    spyOn(component, 'copyToClipboard');
+
+    const button = fixture.debugElement.nativeElement.querySelector('button');
+    button.click();
+
+    fixture.whenStable().then(() => {
+      expect(component.copyToClipboard).toHaveBeenCalled();
+    });
+  }));
+});

--- a/web/src/app/modules/overview/components/code/code.component.ts
+++ b/web/src/app/modules/overview/components/code/code.component.ts
@@ -1,0 +1,44 @@
+/*
+Copyright (c) 2020 the Octant contributors. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { CodeView, View } from 'src/app/models/content';
+
+@Component({
+  selector: 'app-view-code',
+  templateUrl: './code.component.html',
+  styleUrls: ['./code.component.scss'],
+})
+export class CodeComponent implements OnChanges {
+  private v: CodeView;
+
+  @Input() set view(v: View) {
+    this.v = v as CodeView;
+  }
+
+  get view() {
+    return this.v;
+  }
+
+  value: string;
+
+  constructor() {}
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes.view.currentValue) {
+      const view = changes.view.currentValue as CodeView;
+      this.value = view.config.value;
+    }
+  }
+
+  copyToClipboard(text) {
+    document.addEventListener('copy', (e: ClipboardEvent) => {
+      e.clipboardData.setData('text/plain', text);
+      e.preventDefault();
+      document.removeEventListener('copy', null);
+    });
+    document.execCommand('copy');
+  }
+}

--- a/web/src/app/modules/overview/components/content-switcher/content-switcher.component.html
+++ b/web/src/app/modules/overview/components/content-switcher/content-switcher.component.html
@@ -15,6 +15,9 @@
     <ng-container *ngSwitchCase="'containers'">
       <app-view-containers [view]="view"></app-view-containers>
     </ng-container>
+    <ng-container *ngSwitchCase="'codeBlock'">
+      <app-view-code [view]="view"></app-view-code>
+    </ng-container>
     <ng-container *ngSwitchCase="'donutChart'">
         <app-view-donut-chart [view]="view"></app-view-donut-chart>
     </ng-container>

--- a/web/src/app/modules/overview/overview.module.ts
+++ b/web/src/app/modules/overview/overview.module.ts
@@ -18,6 +18,7 @@ import { CardComponent } from './components/card/card.component';
 import { ContainersComponent } from './components/containers/containers.component';
 import { ContentSwitcherComponent } from './components/content-switcher/content-switcher.component';
 import { ContextSelectorComponent } from './components/context-selector/context-selector.component';
+import { CodeComponent } from './components/code/code.component';
 import { CytoscapeComponent } from './components/cytoscape/cytoscape.component';
 import { DatagridComponent } from './components/datagrid/datagrid.component';
 import { ErrorComponent } from './components/error/error.component';
@@ -74,6 +75,7 @@ export function hljsLanguages() {
   declarations: [
     AnnotationsComponent,
     ContainersComponent,
+    CodeComponent,
     DatagridComponent,
     ExpressionSelectorComponent,
     ErrorComponent,


### PR DESCRIPTION
ref: #527 

This also adds a copy to clipboard button as sometimes multi-line configmap values are configuration files.

Signed-off-by: GuessWhoSamFoo <foos@vmware.com>