### PR TITLE
Fixed CRD watcher race condition

### DIFF
--- a/changelogs/unreleased/588-GuessWhoSamFoo
+++ b/changelogs/unreleased/588-GuessWhoSamFoo
@@ -1,0 +1,1 @@
+Fixed CRD watcher race condition

--- a/web/cypress.json
+++ b/web/cypress.json
@@ -3,7 +3,7 @@
   "projectId": "9oqomg",
   "viewportHeight": 900,
   "viewportWidth": 1440,
-  "defaultCommandTimeout": 25000,
+  "defaultCommandTimeout": 50000,
   "env": {
     "CYPRESS_CONTEXT": "octant-temporary"
   }

--- a/web/cypress/integration/crd.spec.js
+++ b/web/cypress/integration/crd.spec.js
@@ -1,0 +1,37 @@
+describe('CRD', () => {
+    before(() => {
+        cy.visit('/');
+    })
+})
+
+it('loads CRD', () => {
+  cy.exec(`kubectl config view --minify --output 'jsonpath={..namespace}'`
+  ).then(result => {
+    cy.exec('kubectl apply -f ../examples/resources/crd-crontab.yaml --namespace ' +
+      result.stdout
+    )
+      .its('stdout')
+      .should('contains', 'crontabs.stable.example.com created');
+
+      cy.exec('kubectl apply -f ../examples/resources/crd-crontab-resource.yaml --namespace ' +
+      result.stdout
+    )
+      .its('stdout')
+      .should('contains', 'crontab.stable.example.com/my-new-cron-object created');
+
+    cy.visit(
+      '/#/overview/namespace/' + result.stdout + '/custom-resources/crontabs.stable.example.com'
+    );
+
+    cy.get('a[class="ng-star-inserted"]')
+      .contains('my-new-cron-object');
+
+    cy.exec(
+      'kubectl delete crd crontabs.stable.example.com --namespace ' + result.stdout
+    )
+      .its('stdout')
+      .should('contain', 'deleted');
+
+    cy.contains(/my-new-cron-object/).should('not.exist');
+  });
+});


### PR DESCRIPTION
Also increases timeout of cypress commands from 25 to 50 seconds with e2e test

Signed-off-by: GuessWhoSamFoo <foos@vmware.com>
Co-authored-by: bryanl <bryanliles@gmail.com>