### PR TITLE
Ensure embedded assets include icons

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -27,7 +27,7 @@ steps:
     commands:
       - go run build.go go-install
       - go run build.go test
-      - go generate ./web
+      - go generate ./web ./pkg/icon
       - go run build.go vet
     depends_on:
     - frontend


### PR DESCRIPTION
This will make sure the nightly builds properly. We can also consider committing the generated `rice-box.go` (at least the icon one) once the svg files are more permanent.

Signed-off-by: GuessWhoSamFoo <foos@vmware.com>