### PR TITLE
Remove extra actions from poller and websocket client

### DIFF
--- a/changelogs/unreleased/631-bryanl
+++ b/changelogs/unreleased/631-bryanl
@@ -1,0 +1,2 @@
+Remove extra actions from poller and websocket client
+

--- a/internal/api/content_manager_test.go
+++ b/internal/api/content_manager_test.go
@@ -46,9 +46,7 @@ func TestContentManager_GenerateContent(t *testing.T) {
 	moduleManager := moduleFake.NewMockManagerInterface(controller)
 	state := octantFake.NewMockState(controller)
 
-	state.EXPECT().GetContentPath().Return("/path")
-	state.EXPECT().GetNamespace().Return("default")
-	state.EXPECT().GetQueryParams().Return(params)
+	state.EXPECT().GetContentPath().Return("/path").AnyTimes()
 	state.EXPECT().OnContentPathUpdate(gomock.Any()).DoAndReturn(func(fn octant.ContentPathUpdateFunc) octant.UpdateCancelFunc {
 		fn("foo")
 		return func() {}
@@ -65,8 +63,8 @@ func TestContentManager_GenerateContent(t *testing.T) {
 
 	poller := api.NewSingleRunPoller()
 
-	contentGenerator := func(ctx context.Context, state octant.State) (component.ContentResponse, bool, error) {
-		return contentResponse, false, nil
+	contentGenerator := func(ctx context.Context, state octant.State) (api.Content, bool, error) {
+		return api.Content{Response: contentResponse}, false, nil
 	}
 	manager := api.NewContentManager(moduleManager, logger,
 		api.WithContentGenerator(contentGenerator),

--- a/internal/api/websocket_client.go
+++ b/internal/api/websocket_client.go
@@ -57,6 +57,7 @@ var _ OctantClient = (*WebsocketClient)(nil)
 // NewWebsocketClient creates an instance of WebsocketClient.
 func NewWebsocketClient(ctx context.Context, conn *websocket.Conn, manager *WebsocketClientManager, dashConfig config.Dash, actionDispatcher ActionDispatcher, id uuid.UUID) *WebsocketClient {
 	logger := dashConfig.Logger().With("component", "websocket-client", "client-id", id.String())
+	ctx = log.WithLoggerContext(ctx, logger)
 
 	ctx, cancel := context.WithCancel(ctx)
 
@@ -84,6 +85,8 @@ func NewWebsocketClient(ctx context.Context, conn *websocket.Conn, manager *Webs
 		client.RegisterHandler(handler)
 	}
 
+	logger.Debugf("created websocket client")
+
 	return client
 }
 
@@ -95,6 +98,7 @@ func (c *WebsocketClient) ID() string {
 func (c *WebsocketClient) readPump() {
 	defer func() {
 		c.isOpen = false
+		c.logger.Debugf("closing read pump")
 	}()
 
 	go func() {
@@ -180,6 +184,7 @@ func (c *WebsocketClient) writePump() {
 	ticker := time.NewTicker(pingPeriod)
 	defer func() {
 		ticker.Stop()
+		c.logger.Debugf("closing write pump")
 	}()
 
 	done := false

--- a/web/src/app/modules/sugarloaf/components/smart/container/container.component.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/container/container.component.ts
@@ -55,11 +55,5 @@ export class ContainerComponent implements OnInit, OnDestroy {
     this.websocketService.open();
   }
 
-  closeSocket() {
-    this.websocketService.close();
-  }
-
-  ngOnDestroy(): void {
-    this.closeSocket();
-  }
+  ngOnDestroy(): void {}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

There are a number of duplicated items in the poller and websocket:
* closing websockets
* the poller loop itself

This change attempts to remove some of these duplications.

This change also removes thrashing the websocket client.
The client was being closed too often.

**Which issue(s) this PR fixes**
 #631 

**Special notes for your reviewer**:
