### PR TITLE
Remove boolean value from object store Get

### DIFF
--- a/changelogs/unreleased/643-GuessWhoSamFoo
+++ b/changelogs/unreleased/643-GuessWhoSamFoo
@@ -1,0 +1,1 @@
+Remove boolean value from object store Get

--- a/cmd/octant-sample-plugin/main.go
+++ b/cmd/octant-sample-plugin/main.go
@@ -101,13 +101,13 @@ func handlePrint(request *service.PrintRequest) (plugin.PrintResponse, error) {
 	if err != nil {
 		return plugin.PrintResponse{}, err
 	}
-	u, found, err := request.DashboardClient.Get(request.Context(), key)
+	u, err := request.DashboardClient.Get(request.Context(), key)
 	if err != nil {
 		return plugin.PrintResponse{}, err
 	}
 
 	// The plugin can check if the object it requested exists.
-	if !found {
+	if u == nil {
 		return plugin.PrintResponse{}, errors.New("object doesn't exist")
 	}
 

--- a/internal/api/content_manager.go
+++ b/internal/api/content_manager.go
@@ -104,6 +104,9 @@ func (cm *ContentManager) runUpdate(state octant.State, s OctantClient) PollerFu
 					return false
 				}
 			}
+			if ctx.Err() == context.Canceled {
+				return false
+			}
 			cm.logger.
 				WithErr(err).
 				With("content-path", contentPath).

--- a/internal/describer/crd.go
+++ b/internal/describer/crd.go
@@ -96,12 +96,12 @@ func (c *crd) Describe(ctx context.Context, namespace string, options Options) (
 		Name:       options.Fields["name"],
 	}
 
-	object, found, err := objectStore.Get(ctx, key)
+	object, err := objectStore.Get(ctx, key)
 	if err != nil {
 		return component.EmptyContentResponse, err
 	}
 
-	if !found {
+	if object == nil {
 		return component.EmptyContentResponse, err
 	}
 

--- a/internal/describer/crd_section.go
+++ b/internal/describer/crd_section.go
@@ -69,7 +69,7 @@ func (csd *CRDSection) Describe(ctx context.Context, namespace string, options O
 		case *crdList:
 			key := store.KeyFromGroupVersionKind(gvk.CustomResourceDefinition)
 			key.Name = d.name
-			crd, _, err := options.ObjectStore().Get(ctx, key)
+			crd, err := options.ObjectStore().Get(ctx, key)
 			if err != nil {
 				return component.EmptyContentResponse, err
 			}

--- a/internal/describer/customresource.go
+++ b/internal/describer/customresource.go
@@ -22,7 +22,7 @@ func CustomResourceDefinition(ctx context.Context, name string, o store.Store) (
 	key := store.KeyFromGroupVersionKind(gvk.CustomResourceDefinition)
 	key.Name = name
 
-	crd, _, err := o.Get(ctx, key)
+	crd, err := o.Get(ctx, key)
 	if err != nil {
 		return nil, fmt.Errorf("get %s: %w", key, err)
 	}

--- a/internal/describer/describer.go
+++ b/internal/describer/describer.go
@@ -53,7 +53,7 @@ func LoadObject(ctx context.Context, objectStore store.Store, errorStore oerrors
 		objectStoreKey.Name = name
 	}
 
-	object, found, err := objectStore.Get(ctx, objectStoreKey)
+	object, err := objectStore.Get(ctx, objectStoreKey)
 	if err != nil {
 		var ae *oerrors.AccessError
 		if errors.As(err, &ae) {
@@ -68,7 +68,7 @@ func LoadObject(ctx context.Context, objectStore store.Store, errorStore oerrors
 		}
 		return nil, err
 	}
-	if !found {
+	if object == nil {
 		return nil, errors.New("object was not found")
 	}
 

--- a/internal/objectstatus/ingress.go
+++ b/internal/objectstatus/ingress.go
@@ -135,14 +135,14 @@ func (is *ingressStatus) run(ctx context.Context) (ObjectStatus, error) {
 			Name:       tls.SecretName,
 		}
 
-		_, found, err := is.objectstore.Get(ctx, key)
+		u, err := is.objectstore.Get(ctx, key)
 		if err != nil {
 			status.SetError()
 			status.AddDetailf("Unable to load Secret %q: %s", tls.SecretName, err)
 			continue
 		}
 
-		if !found {
+		if u == nil {
 			status.SetError()
 			status.AddDetailf("Secret %q does not exist", tls.SecretName)
 		}

--- a/internal/objectstatus/ingress_test.go
+++ b/internal/objectstatus/ingress_test.go
@@ -44,7 +44,7 @@ func Test_runIngressStatus(t *testing.T) {
 			name: "no matching backends",
 			init: func(t *testing.T, o *storefake.MockStore) runtime.Object {
 				key := store.Key{Namespace: "default", APIVersion: "v1", Kind: "Service", Name: "no-such-service"}
-				o.EXPECT().Get(gomock.Any(), gomock.Eq(key)).Return(nil, false, nil)
+				o.EXPECT().Get(gomock.Any(), gomock.Eq(key)).Return(nil, nil)
 
 				objectFile := "ingress_no_matching_backend.yaml"
 				return testutil.LoadObjectFromFile(t, objectFile)
@@ -88,7 +88,7 @@ func Test_runIngressStatus(t *testing.T) {
 				mockServiceInCache(t, o, "default", "my-service", "service_my-service.yaml")
 
 				key := store.Key{Namespace: "default", APIVersion: "v1", Kind: "Secret", Name: "no-such-secret"}
-				o.EXPECT().Get(gomock.Any(), gomock.Eq(key)).Return(nil, false, nil)
+				o.EXPECT().Get(gomock.Any(), gomock.Eq(key)).Return(nil, nil)
 
 				objectFile := "ingress_ingress-bad-tls-host.yaml"
 				return testutil.LoadObjectFromFile(t, objectFile)
@@ -146,7 +146,7 @@ func mockSecretInCache(t *testing.T, o *storefake.MockStore, namespace, name, fi
 		Name:       name,
 	}
 
-	o.EXPECT().Get(gomock.Any(), gomock.Eq(key)).Return(testutil.ToUnstructured(t, secret), true, nil)
+	o.EXPECT().Get(gomock.Any(), gomock.Eq(key)).Return(testutil.ToUnstructured(t, secret), nil)
 
 	return secret
 }
@@ -160,7 +160,7 @@ func mockServiceInCache(t *testing.T, o *storefake.MockStore, namespace, name, f
 		Name:       name,
 	}
 
-	o.EXPECT().Get(gomock.Any(), gomock.Eq(key)).Return(testutil.ToUnstructured(t, secret), true, nil)
+	o.EXPECT().Get(gomock.Any(), gomock.Eq(key)).Return(testutil.ToUnstructured(t, secret), nil)
 
 	return secret
 }

--- a/internal/objectstatus/service_test.go
+++ b/internal/objectstatus/service_test.go
@@ -41,7 +41,7 @@ func Test_service(t *testing.T) {
 				endpoints := testutil.LoadObjectFromFile(t, "endpoints_ok.yaml")
 
 				o.EXPECT().Get(gomock.Any(), gomock.Eq(key)).
-					Return(testutil.ToUnstructured(t, endpoints), true, nil)
+					Return(testutil.ToUnstructured(t, endpoints), nil)
 
 				objectFile := "service_ok.yaml"
 				return testutil.LoadObjectFromFile(t, objectFile)
@@ -65,7 +65,7 @@ func Test_service(t *testing.T) {
 				endpoints := testutil.LoadObjectFromFile(t, "endpoints_no_subsets.yaml")
 
 				o.EXPECT().Get(gomock.Any(), gomock.Eq(key)).
-					Return(testutil.ToUnstructured(t, endpoints), true, nil)
+					Return(testutil.ToUnstructured(t, endpoints), nil)
 
 				objectFile := "service_ok.yaml"
 				return testutil.LoadObjectFromFile(t, objectFile)

--- a/internal/octant/workload.go
+++ b/internal/octant/workload.go
@@ -179,12 +179,12 @@ func objectOwner(ctx context.Context, objectStore store.Store, object *unstructu
 		Name:       ownerReference.Name,
 	}
 
-	owner, found, err := objectStore.Get(ctx, ownerRefKey)
+	owner, err := objectStore.Get(ctx, ownerRefKey)
 	if err != nil {
 		return nil, fmt.Errorf("find object %s: %w", ownerRefKey, err)
 	}
 
-	if !found {
+	if owner == nil {
 		return object, nil
 	}
 

--- a/internal/octant/workload_test.go
+++ b/internal/octant/workload_test.go
@@ -95,7 +95,7 @@ func TestClusterWorkloadLoader(t *testing.T) {
 			Kind:       "ReplicaSet",
 			Name:       "rs-1",
 		}).
-		Return(replicaSet, true, nil).
+		Return(replicaSet, nil).
 		AnyTimes()
 
 	noOwnerObjectStore := storeFake.NewMockStore(controller)
@@ -114,7 +114,7 @@ func TestClusterWorkloadLoader(t *testing.T) {
 			Kind:       "ReplicaSet",
 			Name:       "missing",
 		}).
-		Return(nil, false, nil).
+		Return(nil, nil).
 		AnyTimes()
 
 	cases := []struct {

--- a/internal/printer/container.go
+++ b/internal/printer/container.go
@@ -378,12 +378,12 @@ func describeEnvRows(ctx context.Context, namespace string, vars []corev1.EnvVar
 				Kind:       "ConfigMap",
 			}
 
-			u, found, err := objectStore.Get(ctx, key)
+			u, err := objectStore.Get(ctx, key)
 			if err != nil {
 				return nil, err
 			}
 
-			if found {
+			if u != nil {
 				configMap := &corev1.ConfigMap{}
 				if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, configMap); err != nil {
 					return nil, err

--- a/internal/printer/container_test.go
+++ b/internal/printer/container_test.go
@@ -390,7 +390,7 @@ func Test_ContainerConfiguration(t *testing.T) {
 					Name:       configMap.Name,
 					Namespace:  configMap.Namespace,
 				}
-				tpo.objectStore.EXPECT().Get(ctx, gomock.Eq(key)).Return(testutil.ToUnstructured(t, configMap), true, nil).AnyTimes()
+				tpo.objectStore.EXPECT().Get(ctx, gomock.Eq(key)).Return(testutil.ToUnstructured(t, configMap), nil).AnyTimes()
 			}
 
 			cc := NewContainerConfiguration(ctx, parentPod, tc.container, pf, tc.isInit, printOptions)

--- a/internal/printer/horizontalpodautoscaler.go
+++ b/internal/printer/horizontalpodautoscaler.go
@@ -443,8 +443,8 @@ func forScaleTarget(ctx context.Context, object runtime.Object, scaleTarget *aut
 	}
 
 	objectStore := options.DashConfig.ObjectStore()
-	_, found, err := objectStore.Get(ctx, key)
-	if err != nil || !found {
+	u, err := objectStore.Get(ctx, key)
+	if err != nil || u == nil {
 		return component.NewLink("", "none", ""), nil
 	}
 

--- a/internal/printer/horizontalpodautoscaler_test.go
+++ b/internal/printer/horizontalpodautoscaler_test.go
@@ -156,7 +156,7 @@ func Test_HorizontalPodAutoscalerConfiguration(t *testing.T) {
 					Name:       deployment.Name,
 					Namespace:  deployment.Namespace,
 				}
-				tpo.objectStore.EXPECT().Get(ctx, gomock.Eq(key)).Return(testutil.ToUnstructured(t, deployment), true, nil)
+				tpo.objectStore.EXPECT().Get(ctx, gomock.Eq(key)).Return(testutil.ToUnstructured(t, deployment), nil)
 			}
 
 			summary, err := hc.Create(ctx, printOptions)

--- a/internal/printer/namespace.go
+++ b/internal/printer/namespace.go
@@ -328,7 +328,6 @@ func printNamespaceResourceLimits(limits *corev1.LimitRangeList) (*component.Tab
 
 	for i := range limits.Items {
 		limit := limits.Items[i]
-		fmt.Print(fmt.Sprintf("%+v", limit))
 		for _, item := range limit.Spec.Limits {
 			sortKey, row, created := createResourceLimitCPURow(item)
 			if created {

--- a/internal/printer/service.go
+++ b/internal/printer/service.go
@@ -311,11 +311,11 @@ func createServiceEndpointsView(ctx context.Context, service *corev1.Service, op
 	cols := component.NewTableCols("Target", "IP", "Node Name")
 	table := component.NewTable("Endpoints", "There are no endpoints!", cols)
 
-	object, found, err := o.Get(ctx, key)
+	object, err := o.Get(ctx, key)
 	if err != nil {
 		return nil, errors.Wrapf(err, "get endpoints for service %s", service.Name)
 	}
-	if !found {
+	if object == nil {
 		return table, nil
 	}
 

--- a/internal/printer/service_test.go
+++ b/internal/printer/service_test.go
@@ -321,7 +321,7 @@ func Test_createServiceEndpointsView(t *testing.T) {
 	key := store.Key{Namespace: "default", APIVersion: "v1", Kind: "Endpoints", Name: "service"}
 	tpo.objectStore.EXPECT().
 		Get(gomock.Any(), gomock.Eq(key)).
-		Return(toUnstructured(t, endpoints), true, nil)
+		Return(toUnstructured(t, endpoints), nil)
 
 	podLink := component.NewLink("", "pod", "/pod")
 	tpo.link.EXPECT().

--- a/internal/printer/serviceaccount.go
+++ b/internal/printer/serviceaccount.go
@@ -280,12 +280,12 @@ func (s *ServiceAccountPolicyRules) Create() (*component.Table, error) {
 		}
 		switch kind := roleRef.Kind; kind {
 		case "ClusterRole":
-			object, found, err := s.objectStore.Get(s.context, key)
+			object, err := s.objectStore.Get(s.context, key)
 			if err != nil {
 				return nil, err
 			}
 
-			if !found {
+			if object == nil {
 				return nil, errors.Errorf("unable to find %s", key)
 			}
 
@@ -299,12 +299,12 @@ func (s *ServiceAccountPolicyRules) Create() (*component.Table, error) {
 		case "Role":
 			key.Namespace = s.namespace
 
-			object, found, err := s.objectStore.Get(s.context, key)
+			object, err := s.objectStore.Get(s.context, key)
 			if err != nil {
 				return nil, err
 			}
 
-			if !found {
+			if object == nil {
 				return nil, errors.Errorf("unable to find %s", key)
 			}
 

--- a/internal/printer/serviceaccount_test.go
+++ b/internal/printer/serviceaccount_test.go
@@ -213,11 +213,11 @@ func Test_ServiceAccountPolicyRules(t *testing.T) {
 
 	tpo.objectStore.EXPECT().
 		Get(gomock.Any(), role1Key).
-		Return(testutil.ToUnstructured(t, role1), true, nil)
+		Return(testutil.ToUnstructured(t, role1), nil)
 
 	tpo.objectStore.EXPECT().
 		Get(gomock.Any(), role2Key).
-		Return(testutil.ToUnstructured(t, role2), true, nil)
+		Return(testutil.ToUnstructured(t, role2), nil)
 
 	saph := NewServiceAccountPolicyRules(ctx, serviceAccount, printOptions)
 	got, err := saph.Create()

--- a/internal/queryer/queryer.go
+++ b/internal/queryer/queryer.go
@@ -465,12 +465,12 @@ func (osq *ObjectStoreQueryer) OwnerReference(ctx context.Context, object *unstr
 			return true, object, nil
 		}
 
-		owner, found, err := osq.objectStore.Get(ctx, key)
+		owner, err := osq.objectStore.Get(ctx, key)
 		if err != nil {
 			return false, nil, errors.Wrap(err, "get owner from store")
 		}
 
-		if !found {
+		if owner == nil {
 			return false, nil, errors.Errorf("owner %s not found", key)
 		}
 
@@ -494,12 +494,12 @@ func (osq *ObjectStoreQueryer) ScaleTarget(ctx context.Context, hpa *autoscaling
 		Name:       hpa.Spec.ScaleTargetRef.Name,
 	}
 
-	u, found, err := osq.objectStore.Get(ctx, key)
+	u, err := osq.objectStore.Get(ctx, key)
 	if err != nil {
 		return nil, errors.WithMessagef(err, "retrieve scale target %q from namespace %q", key.Name, key.Namespace)
 	}
 
-	if found {
+	if u != nil {
 		switch key.Kind {
 		case "Deployment":
 			deployment := &appsv1.Deployment{}
@@ -619,12 +619,12 @@ func (osq *ObjectStoreQueryer) ServicesForIngress(ctx context.Context, ingress *
 			Kind:       "Service",
 			Name:       backend.ServiceName,
 		}
-		u, found, err := osq.objectStore.Get(ctx, key)
+		u, err := osq.objectStore.Get(ctx, key)
 		if err != nil {
 			return nil, errors.Wrapf(err, "retrieving service backend: %v", backend)
 		}
 
-		if !found {
+		if u == nil {
 			continue
 		}
 
@@ -690,13 +690,13 @@ func (osq *ObjectStoreQueryer) ServiceAccountForPod(ctx context.Context, pod *co
 		Name:       pod.Spec.ServiceAccountName,
 	}
 
-	u, found, err := osq.objectStore.Get(ctx, key)
+	u, err := osq.objectStore.Get(ctx, key)
 	if err != nil {
 		return nil, errors.WithMessagef(err, "retrieve service account %q from namespace %q",
 			key.Name, key.Namespace)
 	}
 
-	if !found {
+	if u == nil {
 		return nil, errors.Errorf("service account %q from namespace %q does not exist",
 			key.Name, key.Namespace)
 	}

--- a/internal/queryer/queryer_test.go
+++ b/internal/queryer/queryer_test.go
@@ -406,7 +406,7 @@ func TestCacheQueryer_OwnerReference(t *testing.T) {
 				}
 				o.EXPECT().
 					Get(gomock.Any(), gomock.Eq(key)).
-					Return(deployment, true, nil)
+					Return(deployment, nil)
 			},
 			expected: func(t *testing.T) runtime.Object {
 				return testutil.ToUnstructured(t, deployment)
@@ -423,7 +423,7 @@ func TestCacheQueryer_OwnerReference(t *testing.T) {
 				}
 				o.EXPECT().
 					Get(gomock.Any(), gomock.Eq(key)).
-					Return(nil, false, errors.New("failed"))
+					Return(nil, errors.New("failed"))
 			},
 			isErr: true,
 		},
@@ -579,7 +579,7 @@ func TestCacheQueryer_ServicesForIngress_service_not_found(t *testing.T) {
 	o := storeFake.NewMockStore(controller)
 	o.EXPECT().
 		Get(gomock.Any(), gomock.Any()).
-		Return(nil, false, nil)
+		Return(nil, nil)
 
 	discovery := queryerFake.NewMockDiscoveryInterface(controller)
 
@@ -668,7 +668,7 @@ func TestCacheQueryer_ServicesForIngress(t *testing.T) {
 				}
 				o.EXPECT().
 					Get(gomock.Any(), gomock.Eq(key)).
-					Return(testutil.ToUnstructured(t, service1), true, nil)
+					Return(testutil.ToUnstructured(t, service1), nil)
 			},
 			expected: []string{"service1"},
 		},
@@ -684,7 +684,7 @@ func TestCacheQueryer_ServicesForIngress(t *testing.T) {
 				}
 				o.EXPECT().
 					Get(gomock.Any(), gomock.Eq(key1)).
-					Return(testutil.ToUnstructured(t, service1), true, nil)
+					Return(testutil.ToUnstructured(t, service1), nil)
 				key2 := store.Key{
 					Namespace:  "default",
 					APIVersion: "v1",
@@ -693,7 +693,7 @@ func TestCacheQueryer_ServicesForIngress(t *testing.T) {
 				}
 				o.EXPECT().
 					Get(gomock.Any(), gomock.Eq(key2)).
-					Return(testutil.ToUnstructured(t, service2), true, nil)
+					Return(testutil.ToUnstructured(t, service2), nil)
 			},
 			expected: []string{"service1", "service2"},
 		},
@@ -714,7 +714,7 @@ func TestCacheQueryer_ServicesForIngress(t *testing.T) {
 				}
 				c.EXPECT().
 					Get(gomock.Any(), gomock.Eq(key)).
-					Return(nil, false, errors.New("failed"))
+					Return(nil, errors.New("failed"))
 			},
 			isErr: true,
 		},
@@ -880,7 +880,7 @@ func TestObjectStoreQueryer_ServiceAccountForPod(t *testing.T) {
 	require.NoError(t, err)
 	o.EXPECT().
 		Get(gomock.Any(), key).
-		Return(testutil.ToUnstructured(t, serviceAccount), true, nil)
+		Return(testutil.ToUnstructured(t, serviceAccount), nil)
 
 	discovery := queryerFake.NewMockDiscoveryInterface(controller)
 
@@ -1065,7 +1065,7 @@ func TestObjectStoreQueryer_ScaleTarget(t *testing.T) {
 	require.NoError(t, err)
 	o.EXPECT().
 		Get(gomock.Any(), key).
-		Return(testutil.ToUnstructured(t, deployment), true, nil)
+		Return(testutil.ToUnstructured(t, deployment), nil)
 
 	discovery := queryerFake.NewMockDiscoveryInterface(controller)
 

--- a/internal/terminal/manager.go
+++ b/internal/terminal/manager.go
@@ -96,11 +96,11 @@ func (tm *manager) Create(ctx context.Context, logger log.Logger, key store.Key,
 	t := NewTerminalInstance(ctx, logger, key, container, command, tm.chanInstance)
 	tm.instances.Store(t.ID(), t)
 
-	pod, ok, err := tm.objectStore.Get(ctx, key)
+	pod, err := tm.objectStore.Get(ctx, key)
 	if err != nil {
 		return nil, err
 	}
-	if !ok {
+	if pod == nil {
 		return nil, errors.New("pod not found")
 	}
 

--- a/pkg/plugin/api/api_test.go
+++ b/pkg/plugin/api/api_test.go
@@ -86,15 +86,14 @@ func TestAPI(t *testing.T) {
 			name: "get",
 			initFunc: func(t *testing.T, mocks *apiMocks) {
 				mocks.objectStore.EXPECT().
-					Get(gomock.Any(), gomock.Eq(getKey)).Return(object, true, nil)
+					Get(gomock.Any(), gomock.Eq(getKey)).Return(object, nil)
 			},
 			doFunc: func(t *testing.T, client *api.Client) {
 				clientCtx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 				defer cancel()
 
-				got, found, err := client.Get(clientCtx, getKey)
+				got, err := client.Get(clientCtx, getKey)
 				require.NoError(t, err)
-				require.True(t, found)
 
 				expected := object
 

--- a/pkg/plugin/api/client.go
+++ b/pkg/plugin/api/client.go
@@ -100,25 +100,25 @@ func (c *Client) List(ctx context.Context, key store.Key) (*unstructured.Unstruc
 }
 
 // Get retrieves an object from the dashboard's objectStore.
-func (c *Client) Get(ctx context.Context, key store.Key) (*unstructured.Unstructured, bool, error) {
+func (c *Client) Get(ctx context.Context, key store.Key) (*unstructured.Unstructured, error) {
 	client := c.DashboardConnection.Client()
 
 	keyRequest, err := convertFromKey(key)
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
 
 	resp, err := client.Get(ctx, keyRequest)
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
 
-	object, found, err := convertToObject(resp.Object)
+	object, err := convertToObject(resp.Object)
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
 
-	return object, found, nil
+	return object, nil
 }
 
 // Update updates an object in the store.

--- a/pkg/plugin/api/conversion.go
+++ b/pkg/plugin/api/conversion.go
@@ -76,11 +76,11 @@ func convertToObjects(in [][]byte) (*unstructured.UnstructuredList, error) {
 	list := &unstructured.UnstructuredList{}
 
 	for _, data := range in {
-		object, found, err := convertToObject(data)
+		object, err := convertToObject(data)
 		if err != nil {
 			return nil, err
 		}
-		if !found {
+		if object == nil {
 			continue
 		}
 		list.Items = append(list.Items, *object)
@@ -89,18 +89,22 @@ func convertToObjects(in [][]byte) (*unstructured.UnstructuredList, error) {
 	return list, nil
 }
 
-func convertToObject(in []byte) (*unstructured.Unstructured, bool, error) {
+func convertToObject(in []byte) (*unstructured.Unstructured, error) {
 	if in == nil {
-		return nil, false, nil
+		return nil, nil
 	}
 
 	object := unstructured.Unstructured{}
 	err := json.Unmarshal(in, &object)
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
 
-	return &object, true, nil
+	if object.Object == nil {
+		return nil, nil
+	}
+
+	return &object, nil
 }
 
 func convertToPortForwardRequest(in *proto.PortForwardRequest) (*PortForwardRequest, error) {

--- a/pkg/plugin/api/fake/mock_dash_service.go
+++ b/pkg/plugin/api/fake/mock_dash_service.go
@@ -63,13 +63,12 @@ func (mr *MockServiceMockRecorder) ForceFrontendUpdate(arg0 interface{}) *gomock
 }
 
 // Get mocks base method
-func (m *MockService) Get(arg0 context.Context, arg1 store.Key) (*unstructured.Unstructured, bool, error) {
+func (m *MockService) Get(arg0 context.Context, arg1 store.Key) (*unstructured.Unstructured, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", arg0, arg1)
 	ret0, _ := ret[0].(*unstructured.Unstructured)
-	ret1, _ := ret[1].(bool)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // Get indicates an expected call of Get

--- a/pkg/plugin/service/dashboard.go
+++ b/pkg/plugin/service/dashboard.go
@@ -15,7 +15,7 @@ import (
 type Dashboard interface {
 	Close() error
 	List(ctx context.Context, key store.Key) (*unstructured.UnstructuredList, error)
-	Get(ctx context.Context, key store.Key) (*unstructured.Unstructured, bool, error)
+	Get(ctx context.Context, key store.Key) (*unstructured.Unstructured, error)
 	Update(ctx context.Context, object *unstructured.Unstructured) error
 	PortForward(ctx context.Context, req api.PortForwardRequest) (api.PortForwardResponse, error)
 	CancelPortForward(ctx context.Context, id string)

--- a/pkg/plugin/service/fake/mock_dashboard.go
+++ b/pkg/plugin/service/fake/mock_dashboard.go
@@ -77,13 +77,12 @@ func (mr *MockDashboardMockRecorder) ForceFrontendUpdate(arg0 interface{}) *gomo
 }
 
 // Get mocks base method
-func (m *MockDashboard) Get(arg0 context.Context, arg1 store.Key) (*unstructured.Unstructured, bool, error) {
+func (m *MockDashboard) Get(arg0 context.Context, arg1 store.Key) (*unstructured.Unstructured, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", arg0, arg1)
 	ret0, _ := ret[0].(*unstructured.Unstructured)
-	ret1, _ := ret[1].(bool)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // Get indicates an expected call of Get

--- a/pkg/store/fake/mock_store.go
+++ b/pkg/store/fake/mock_store.go
@@ -53,13 +53,12 @@ func (mr *MockStoreMockRecorder) Delete(arg0, arg1 interface{}) *gomock.Call {
 }
 
 // Get mocks base method
-func (m *MockStore) Get(arg0 context.Context, arg1 store.Key) (*unstructured.Unstructured, bool, error) {
+func (m *MockStore) Get(arg0 context.Context, arg1 store.Key) (*unstructured.Unstructured, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", arg0, arg1)
 	ret0, _ := ret[0].(*unstructured.Unstructured)
-	ret1, _ := ret[1].(bool)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // Get indicates an expected call of Get

--- a/pkg/store/get_as.go
+++ b/pkg/store/get_as.go
@@ -19,12 +19,12 @@ import (
 // GetAs gets an object from the object store by key. If the object is not found,
 // return false and a nil error.
 func GetAs(ctx context.Context, o Store, key Key, as interface{}) (bool, error) {
-	u, found, err := o.Get(ctx, key)
+	u, err := o.Get(ctx, key)
 	if err != nil {
 		return false, errors.Wrap(err, "get object from object store")
 	}
 
-	if !found {
+	if u == nil {
 		return false, nil
 	}
 

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -29,7 +29,7 @@ type UpdateFn func(store Store)
 // Store stores Kubernetes objects.
 type Store interface {
 	List(ctx context.Context, key Key) (list *unstructured.UnstructuredList, loading bool, err error)
-	Get(ctx context.Context, key Key) (object *unstructured.Unstructured, found bool, err error)
+	Get(ctx context.Context, key Key) (object *unstructured.Unstructured, err error)
 	Delete(ctx context.Context, key Key) error
 	Watch(ctx context.Context, key Key, handler cache.ResourceEventHandler) error
 	Unwatch(ctx context.Context, groupVersionKinds ...schema.GroupVersionKind) error


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes the found boolean from Get because both an invalid key or non-existent object will return a nil object. The value is redundant and potentially misleading because Get uses the dynamic informer as a fallback.

This also fixes the case where a Get returns nil and prevents encoding of a nil object.

**Which issue(s) this PR fixes**
- Fixes #540

**Special notes for your reviewer**: This is a breaking API change :warning:

Signed-off-by: GuessWhoSamFoo <foos@vmware.com>