### PR TITLE
Use clarity labels instead of custom labels

### DIFF
--- a/changelogs/unreleased/644-GuessWhoSamFoo
+++ b/changelogs/unreleased/644-GuessWhoSamFoo
@@ -1,0 +1,1 @@
+Changed labels and selectors to use clarity labels

--- a/web/src/app/modules/shared/components/presentation/label-selector/label-selector.component.html
+++ b/web/src/app/modules/shared/components/presentation/label-selector/label-selector.component.html
@@ -1,1 +1,1 @@
-<div class="selector--label">{{ key }}:{{ value }}</div>
+<span class="label label-orange">{{ key }}:{{ value }}</span>

--- a/web/src/app/modules/shared/components/presentation/label-selector/label-selector.component.scss
+++ b/web/src/app/modules/shared/components/presentation/label-selector/label-selector.component.scss
@@ -1,9 +1,4 @@
 /* Copyright (c) 2019 the Octant contributors. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-
-@import '../../../../../../styles';
-
-.selector--label {
-  @include pill(var(--selector-color));
-}
+ 

--- a/web/src/app/modules/shared/components/presentation/labels/labels.component.html
+++ b/web/src/app/modules/shared/components/presentation/labels/labels.component.html
@@ -2,17 +2,17 @@
   <div class="label-with-title clr-col-md-12">
     <h3>{{ title }}</h3>
     <div class="view-labels">
-      <div *ngFor="let key of labelKeys; trackBy: trackByIdentity" class="view-label" (click)="click(key, labels[key])">
+      <span *ngFor="let key of labelKeys; trackBy: trackByIdentity" class="label label-light-blue clickable" (click)="click(key, labels[key])">
         {{ key }}:{{ labels[key] }}
-      </div>
+      </span>
     </div>
   </div>
 </ng-template>
 <ng-template #noTitle>
   <div class="view-labels">
-    <div *ngFor="let key of labelKeys; trackBy: trackByIdentity" class="view-label" (click)="click(key, labels[key])">
+    <span *ngFor="let key of labelKeys; trackBy: trackByIdentity" class="label label-light-blue clickable" (click)="click(key, labels[key])">
       {{ key }}:{{ labels[key] }}
-    </div>
+    </span>
   </div>
 </ng-template>
 

--- a/web/src/app/modules/shared/components/presentation/labels/labels.component.scss
+++ b/web/src/app/modules/shared/components/presentation/labels/labels.component.scss
@@ -8,11 +8,10 @@
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
-  cursor: pointer;
+  align-items: center;
 
-  .view-label {
-    position: relative;
-    @include pill(var(--label-color));
+  & > span {
+    cursor: pointer;
   }
 }
 

--- a/web/src/app/modules/sugarloaf/components/smart/input-filter/input-filter.component.html
+++ b/web/src/app/modules/sugarloaf/components/smart/input-filter/input-filter.component.html
@@ -17,10 +17,8 @@
       </div>
       <ng-container *ngIf="filters?.length > 0">
         <div class="input-filter-tags-list">
-          <div class="input-filter-tag" *ngFor="let filter of filters; trackBy: identifyFilter">
-            <div class="input-filter-tag-text">
-              {{ filter.key }}:{{ filter.value }}
-            </div>
+          <div class="label label-light-blue" *ngFor="let filter of filters; trackBy: identifyFilter">
+            {{ filter.key }}:{{ filter.value }}
             <clr-icon class="input-filter-tag-remove" shape="times" (click)="remove(filter)"></clr-icon>
           </div>
         </div>

--- a/web/src/app/modules/sugarloaf/components/smart/input-filter/input-filter.component.scss
+++ b/web/src/app/modules/sugarloaf/components/smart/input-filter/input-filter.component.scss
@@ -64,25 +64,10 @@
       flex-direction: row;
       flex-wrap: wrap;
 
-      .input-filter-tag {
-        @include pill(var(--label-color));
-        text-align: center;
-        margin: 0 4px 4px 0;
-        padding: 0 8px;
-        max-width: 100%;
-        display: flex;
-
-        &-text {
-          flex: 1;
-          overflow-y: auto;
-          margin-right: 4px;
-        }
-
-        &-remove {
-          cursor: pointer;
-          height: 23px;
-          width: 12px;
-        }
+      .input-filter-tag-remove {
+        cursor: pointer;
+        height: 23px;
+        width: 12px;
       }
     }
 

--- a/web/src/app/modules/sugarloaf/components/smart/input-filter/input-filter.component.spec.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/input-filter/input-filter.component.spec.ts
@@ -84,7 +84,7 @@ describe('InputFilterComponent', () => {
     component.showTagList = true;
     fixture.detectChanges();
     const tagDebugElements: DebugElement[] = fixture.debugElement.queryAll(
-      By.css('.input-filter-tag')
+      By.css('.label-light-blue')
     );
     expect(tagDebugElements.length).toBe(3);
     expect(tagDebugElements[0].nativeElement.textContent).toMatch(


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates labels to use clarity which allows removing some CSS, get on-hover color changes, and better support for dark mode. 

This also fixes a bug where the entire label div was clickable rather than the labels themselves.

![image](https://user-images.githubusercontent.com/10288252/74057833-982aff00-4999-11ea-8e5b-ea4711904712.png)

**Which issue(s) this PR fixes**
- Fixes #633 

Signed-off-by: GuessWhoSamFoo <foos@vmware.com>