### PR TITLE
add Request interface to make plugin testing easier

### DIFF
--- a/build.go
+++ b/build.go
@@ -236,7 +236,11 @@ func installTestPlugin() {
 	dir := pluginDir()
 	log.Printf("Plugin path: %s", dir)
 	os.MkdirAll(dir, 0755)
-	pluginFile := fmt.Sprintf("%s/octant-sample-plugin", dir)
+	filename := "octant-sample-plugin"
+	if runtime.GOOS == "windows" {
+		filename = "octant-sample-plugin.exe"
+	}
+	pluginFile := filepath.Join(dir, filename)
 	runCmd("go", nil, "build", "-o", pluginFile, "github.com/vmware-tanzu/octant/cmd/octant-sample-plugin")
 }
 

--- a/changelogs/unreleased/645-wwitzel3
+++ b/changelogs/unreleased/645-wwitzel3
@@ -1,0 +1,3 @@
+Plugins, service.Request is now an interface. This is a breaking API change.
+  - HandlerFunc now takes this new interface which allows for fakes/mocks during unit testing.
+  - Path proprety is now accessed via Path()

--- a/cmd/octant-sample-plugin/main.go
+++ b/cmd/octant-sample-plugin/main.go
@@ -181,10 +181,10 @@ func initRoutes(router *service.Router) {
 		return cardList
 	}
 
-	router.HandleFunc("*", func(request *service.Request) (component.ContentResponse, error) {
+	router.HandleFunc("*", func(request service.Request) (component.ContentResponse, error) {
 		// For each page, generate two tabs with a some content.
-		component1 := gen("Tab 1", "tab1", request.Path)
-		component2 := gen("Tab 2", "tab2", request.Path)
+		component1 := gen("Tab 1", "tab1", request.Path())
+		component2 := gen("Tab 2", "tab2", request.Path())
 
 		contentResponse := component.NewContentResponse(component.TitleFromString("Example"))
 		contentResponse.Add(component1, component2)

--- a/pkg/plugin/service/handler.go
+++ b/pkg/plugin/service/handler.go
@@ -139,10 +139,10 @@ func (p *Handler) Content(ctx context.Context, contentPath string) (component.Co
 		return component.ContentResponse{}, nil
 	}
 
-	request := &Request{
+	request := &request{
 		baseRequest:     newBaseRequest(ctx, p.name),
 		dashboardClient: p.dashboardClient,
-		Path:            contentPath,
+		path:            contentPath,
 	}
 
 	return handlerFunc(request)

--- a/pkg/plugin/service/router.go
+++ b/pkg/plugin/service/router.go
@@ -1,30 +1,44 @@
 package service
 
 import (
+	"context"
+
 	"github.com/gobwas/glob"
 
 	"github.com/vmware-tanzu/octant/pkg/view/component"
 )
 
 // HandleFunc is a function that generates a content response.
-type HandleFunc func(request *Request) (component.ContentResponse, error)
+type HandleFunc func(request Request) (component.ContentResponse, error)
+
+type Request interface {
+	Context() context.Context
+	DashboardClient() Dashboard
+	Path() string
+}
+
+var _ Request = (*request)(nil)
 
 // Request represents a path request from Octant. It will always be a
 // GET style request with a path.
-type Request struct {
+type request struct {
 	baseRequest
 
 	dashboardClient Dashboard
 
-	// Path is path that Octant is requesting. It is scoped to the plugin.
-	// i.e. If Octant wants to render /content/plugin/foo, Path will be
-	// `/foo`.
-	Path string
+	path string
 }
 
 // DashboardClient returns a dashboard client for the request.
-func (r *Request) DashboardClient() Dashboard {
+func (r *request) DashboardClient() Dashboard {
 	return r.dashboardClient
+}
+
+// Path is path that Octant is requesting. It is scoped to the plugin.
+// i.e. If Octant wants to render /content/plugin/foo, Path will be
+// `/foo`.
+func (r *request) Path() string {
+	return r.path
 }
 
 type route struct {

--- a/pkg/plugin/service/router_test.go
+++ b/pkg/plugin/service/router_test.go
@@ -21,16 +21,16 @@ func TestRouter_Match(t *testing.T) {
 	}
 
 	router := NewRouter()
-	router.HandleFunc("/nested1/nested2", func(request *Request) (component.ContentResponse, error) {
+	router.HandleFunc("/nested1/nested2", func(request Request) (component.ContentResponse, error) {
 		return genContentResponse("nested2"), nil
 	})
-	router.HandleFunc("/nested1", func(request *Request) (component.ContentResponse, error) {
+	router.HandleFunc("/nested1", func(request Request) (component.ContentResponse, error) {
 		return genContentResponse("nested1"), nil
 	})
-	router.HandleFunc("/glob*", func(request *Request) (component.ContentResponse, error) {
+	router.HandleFunc("/glob*", func(request Request) (component.ContentResponse, error) {
 		return genContentResponse("glob"), nil
 	})
-	router.HandleFunc("/", func(request *Request) (component.ContentResponse, error) {
+	router.HandleFunc("/", func(request Request) (component.ContentResponse, error) {
 		return genContentResponse("root"), nil
 	})
 
@@ -81,10 +81,10 @@ func TestRouter_Match(t *testing.T) {
 			}
 			require.True(t, ok)
 
-			request := &Request{
+			request := &request{
 				baseRequest:     newBaseRequest(context.Background(), "plugin-name"),
 				dashboardClient: nil,
-				Path:            test.path,
+				path:            test.path,
 			}
 			got, err := handleFunc(request)
 			require.NoError(t, err)


### PR DESCRIPTION
Signed-off-by: Wayne Witzel III <wayne@riotousliving.com>

**What this PR does / why we need it**:
Adds a Request interface for plugins to allow easy mocking/faking of the service.Request type. This allows plugins to properly unit test their route handlers when they are accessing things like the Context.

A sample plugin was created to test this new interface: https://github.com/wwitzel3/octant-actions-plugin

**Which issue(s) this PR fixes**
- Fixes #491 

**Special notes for your reviewer**: This is a breaking API change :warning:

cc: @GarySmith 