### PR TITLE
allow button group to be unmarshaled from JSON

### DIFF
--- a/pkg/view/component/button.go
+++ b/pkg/view/component/button.go
@@ -2,7 +2,6 @@ package component
 
 import (
 	"encoding/json"
-
 	"github.com/vmware-tanzu/octant/pkg/action"
 )
 
@@ -18,12 +17,10 @@ type ButtonOption func(button *Button)
 // WithButtonConfirmation configured a button with a confirmation.
 func WithButtonConfirmation(title, body string) ButtonOption {
 	return func(button *Button) {
-		confirmation := Confirmation{
+		button.Confirmation = &Confirmation{
 			Title: title,
 			Body:  body,
 		}
-
-		button.Confirmation = &confirmation
 	}
 }
 

--- a/pkg/view/component/testdata/config_flexlayout.json
+++ b/pkg/view/component/testdata/config_flexlayout.json
@@ -1,17 +1,27 @@
 {
-  "sections":[
+  "sections": [
     [
       {
-        "width":24,
-        "view":{
-          "metadata":{
-            "type":"text"
+        "width": 24,
+        "view": {
+          "metadata": {
+            "type": "text"
           },
-          "config":{
-            "value":"text"
+          "config": {
+            "value": "text"
           }
         }
       }
     ]
-  ]
+  ],
+  "buttonGroup": {
+    "metadata": {
+      "type": "buttonGroup"
+    },
+    "config": {
+      "buttons": [{
+        "name": "test"
+      }]
+    }
+  }
 }

--- a/pkg/view/component/unmarshal.go
+++ b/pkg/view/component/unmarshal.go
@@ -7,7 +7,6 @@ package component
 
 import (
 	"encoding/json"
-
 	"github.com/pkg/errors"
 )
 
@@ -20,6 +19,11 @@ func unmarshal(to TypedObject) (Component, error) {
 		t := &Annotations{base: base{Metadata: to.Metadata}}
 		err = errors.Wrapf(json.Unmarshal(to.Config, &t.Config),
 			"unmarshal annotations config")
+		o = t
+	case typeButtonGroup:
+		t := &ButtonGroup{base: base{Metadata: to.Metadata}}
+		err = errors.Wrapf(json.Unmarshal(to.Config, &t.Config),
+			"unmarshal buttonGroup config")
 		o = t
 	case typeCard:
 		t := &Card{base: base{Metadata: to.Metadata}}

--- a/pkg/view/component/unmarshal_test.go
+++ b/pkg/view/component/unmarshal_test.go
@@ -94,6 +94,14 @@ func Test_unmarshal(t *testing.T) {
 							},
 						},
 					},
+					ButtonGroup: &ButtonGroup{
+						base: base{},
+						Config: ButtonGroupConfig{
+							Buttons: []Button{{
+								Name: "test",
+							}},
+						},
+					},
 				},
 				base: newBase(typeFlexLayout, nil),
 			},


### PR DESCRIPTION
Signed-off-by: Wayne Witzel III <wayne@riotousliving.com>


**What this PR does / why we need it**:
Allows ButtonGroup to be used by Plugins.

**Which issue(s) this PR fixes**
- related #646

**Special notes for your reviewer**: Example plugin https://github.com/wwitzel3/octant-actions-plugin
