### PR TITLE
Update Light Theme header colors

### DIFF
--- a/web/src/app/modules/shared/components/smart/context-selector/context-selector.component.scss
+++ b/web/src/app/modules/shared/components/smart/context-selector/context-selector.component.scss
@@ -4,13 +4,8 @@
 
 .dropdown > .dropdown-toggle {
   line-height: 2.5rem;
-  color: #fafafa;
-  opacity: 0.65;
+  color: white;
   outline: none;
-
-  &:hover {
-    opacity: 1;
-  }
 }
 
 .dropdown {

--- a/web/src/app/modules/sugarloaf/components/smart/container/container.component.scss
+++ b/web/src/app/modules/sugarloaf/components/smart/container/container.component.scss
@@ -8,13 +8,18 @@ $navigation-width: 13rem;
     // Navigation's color variables for Light Theme.
     :host-context(body) {
       --navigation-border-color: rgb(215, 215, 215);
+      --navigation-background-color: #0079AD;
     }
     
     // Navigation's color variables for Dark Theme.
     :host-context(body.dark) {
       --navigation-border-color: #0e161b;
+      --navigation-background-color: #0e161b;
     }
+
   .header {
+    background: var(--navigation-background-color);
+
     .branding {
       min-width: $navigation-width;
     }

--- a/web/src/app/modules/sugarloaf/components/smart/input-filter/input-filter.component.scss
+++ b/web/src/app/modules/sugarloaf/components/smart/input-filter/input-filter.component.scss
@@ -11,6 +11,7 @@
     --tags-border-color: #ccc;
     --tags-font-color: black;
     --filterTag-link-color: #0079b8;
+    --input-border-color: white;
   }
   
   // Dropdown's color variables for Dark Theme.
@@ -19,6 +20,7 @@
     --tags-border-color: black;
     --tags-font-color: #adbbc4;
     --filterTag-link-color: #49afd9;
+    --input-border-color: #999;
   }
 
   &-control {
@@ -35,6 +37,16 @@
 
       & .clr-control-container {
         width: 100%;
+
+        .clr-input-wrapper .clr-input {
+          border-bottom-color: var(--input-border-color);
+          color: white;
+
+          &::placeholder {
+            color: white;
+            opacity: 1; // Fix for Firefox's placeholder opacity.
+          }
+        }
       }
     }
 

--- a/web/src/app/modules/sugarloaf/components/smart/namespace/namespace.component.scss
+++ b/web/src/app/modules/sugarloaf/components/smart/namespace/namespace.component.scss
@@ -5,7 +5,7 @@
 .app-namespace-selector {
   // Dropdown's color variables for Light Theme.
   :host-context(body) {
-    --dropdownLink-color:  #0079b8;
+    --dropdownLink-color:  white;
     --dropdownPanel-border-color: #ccc;
     --dropdownOptionSelected-bg-color: #dae4ea;
     --dropdownOption-bg-color: white;


### PR DESCRIPTION
Signed-off-by: Nicolas Farruggia <nfarruggia@vmware.com>


**What this PR does / why we need it**:

Update Light Theme header colors

**Before**
![Before](https://user-images.githubusercontent.com/53268844/74249948-b01bbf00-4cc8-11ea-9129-e52dd93b36e9.png)

**After**
![Screen Shot 2020-02-11 at 12 46 24](https://user-images.githubusercontent.com/53268844/74263893-72299580-4cde-11ea-8518-3d671c132b67.png)



**Which issue(s) this PR fixes**
- Fixes #639 

**Special notes for your reviewer**:

**Release note**:
```
release-note
```
