### PR TITLE
fix dynamic backoff test

### DIFF
--- a/internal/objectstore/backoff_test.go
+++ b/internal/objectstore/backoff_test.go
@@ -21,6 +21,10 @@ func Test_wait(t *testing.T) {
 	key := store.Key{APIVersion: "apiVersion"}
 	entry := newBackoffEntry(key, defaultBackoff)
 	d := entry.wait()
+
 	assert.True(t, d > time.Second)
-	assert.True(t, d < (d + (time.Millisecond * 500)))
+	d = entry.wait()
+	assert.True(t, d > (time.Second * 2))
+	d = entry.wait()
+	assert.True(t, d > (time.Second * 4))
 }

--- a/internal/objectstore/dynamic_cache_test.go
+++ b/internal/objectstore/dynamic_cache_test.go
@@ -19,9 +19,8 @@ func TestDynamicCache_backoff(t *testing.T) {
 	ctx := context.TODO()
 	key := store.Key{APIVersion: gvk.Pod.Version, Kind: gvk.Pod.Kind}
 
-	d.backoff(ctx, key)
+	tD := d.backoff(ctx, key)
 	require.True(t, d.isBackingOff(ctx, key))
-	// Default back starts at 1 second + some jitter so we wait 1.2s.
-	<-time.After(time.Millisecond * 1200)
+	<-time.After(tD + (time.Millisecond * 250))
 	assert.False(t, d.isBackingOff(ctx, key))
 }


### PR DESCRIPTION
Signed-off-by: Wayne Witzel III <wayne@riotousliving.com>


**What this PR does / why we need it**:
The dynamic backoff test is too close to the real amount of time the backoff will wait. This means it sometimes fails on slower systems. Extend it by 300 to ensure that it passes on GitHub Actions CI runs.
