### PR TITLE
Fix Namespace selector colors for light theme

### DIFF
--- a/web/src/app/modules/sugarloaf/components/smart/namespace/namespace.component.scss
+++ b/web/src/app/modules/sugarloaf/components/smart/namespace/namespace.component.scss
@@ -5,7 +5,7 @@
 .app-namespace-selector {
   // Dropdown's color variables for Light Theme.
   :host-context(body) {
-    --dropdownLink-color:  white;
+    --dropdownLink-color: #575757;
     --dropdownPanel-border-color: #ccc;
     --dropdownOptionSelected-bg-color: #dae4ea;
     --dropdownOption-bg-color: white;


### PR DESCRIPTION
Signed-off-by: Nicolas Farruggia <nfarruggia@vmware.com>


**What this PR does / why we need it**:
Fix Namespace selector colors for light theme
![Screen Shot 2020-02-12 at 10 02 41](https://user-images.githubusercontent.com/53268844/74337863-e49e8200-4d7f-11ea-96b9-ceb7a08a94d5.png)


**Which issue(s) this PR fixes**
- Fixes #639 

**Special notes for your reviewer**:

**Release note**:
```
release-note
```
