### PR TITLE
Fix logs in multi-context environments

### DIFF
--- a/changelogs/unreleased/683-mothershipper
+++ b/changelogs/unreleased/683-mothershipper
@@ -1,0 +1,1 @@
+Fixed issue where logs stopped working after context-switching 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -149,7 +149,7 @@ func (a *API) Handler(ctx context.Context) (*mux.Router, error) {
 
 	s := router.PathPrefix(a.prefix).Subrouter()
 
-	s.HandleFunc("/logs/namespace/{namespace}/pod/{pod}/container/{container}", containerLogsHandler(ctx, a.dashConfig.ClusterClient()))
+	s.HandleFunc("/logs/namespace/{namespace}/pod/{pod}/container/{container}", containerLogsHandler(ctx, a.dashConfig))
 
 	manager := NewWebsocketClientManager(ctx, a.actionDispatcher)
 	go manager.Run(ctx)

--- a/internal/api/container_logs.go
+++ b/internal/api/container_logs.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/vmware-tanzu/octant/internal/cluster"
+	"github.com/vmware-tanzu/octant/internal/config"
 	"github.com/vmware-tanzu/octant/internal/log"
 	"github.com/vmware-tanzu/octant/internal/modules/overview/container"
 )
@@ -28,7 +28,7 @@ type logResponse struct {
 	Entries []logEntry `json:"entries,omitempty"`
 }
 
-func containerLogsHandler(ctx context.Context, clusterClient cluster.ClientInterface) http.HandlerFunc {
+func containerLogsHandler(ctx context.Context, dashConfig config.Dash) http.HandlerFunc {
 	logger := log.From(ctx)
 
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -38,7 +38,7 @@ func containerLogsHandler(ctx context.Context, clusterClient cluster.ClientInter
 		podName := vars["pod"]
 		namespace := vars["namespace"]
 
-		kubeClient, err := clusterClient.KubernetesClient()
+		kubeClient, err := dashConfig.ClusterClient().KubernetesClient()
 		if err != nil {
 			RespondWithError(w, http.StatusInternalServerError, err.Error(), logger)
 			return


### PR DESCRIPTION
Logging was broken for multi-cluster/multi-context environments.
Everything else in the dashboard loaded fine, except the logs.

It looks like passing the ClusterClient into the log handler ends up
caching a pointer to the original cluster. Once the user has switched
contexts from the UI, the underlying ClusterClient object is swapped
out on the dashConfig object. However, the pointer is cached for the
log handler and it still tries to read from the old cluster.

The fix seems to be passing the dashConfig pointer to the log
handler, and fetching the client on each call.

Tested against our 5 EKS clusters, and observed that logs were now
working after switching contexts.


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**
- Fixes #

**Special notes for your reviewer**:

**Release note**:
```
release-note
```
