### PR TITLE
Do not show empty CRD versions

### DIFF
--- a/changelogs/unreleased/688-bryanl
+++ b/changelogs/unreleased/688-bryanl
@@ -1,0 +1,1 @@
+Do not show empty CRD versions

--- a/internal/printer/customresourcedefinition.go
+++ b/internal/printer/customresourcedefinition.go
@@ -43,7 +43,7 @@ func CustomResourceDefinitionHandler(ctx context.Context, crd *unstructured.Unst
 		version := versions[i]
 
 		object.RegisterItems(ItemDescriptor{
-			Func: func() (c component.Component, err error) {
+			Func: func() (component.Component, error) {
 				crGVK, err := gvk.CustomResource(crd, version)
 				if err != nil {
 					return nil, err
@@ -57,7 +57,17 @@ func CustomResourceDefinitionHandler(ctx context.Context, crd *unstructured.Unst
 					return nil, err
 				}
 
-				return CustomResourceListHandler(crd, customResources, version, options.Link)
+				view, err := CustomResourceListHandler(crd, customResources, version, options.Link)
+				if err != nil {
+					return nil, err
+				}
+
+				if view.IsEmpty() {
+					// if view is empty, return nil so the object printer will skip it.
+					return nil, nil
+				}
+
+				return view, nil
 			},
 			Width: component.WidthFull,
 		})

--- a/internal/printer/object.go
+++ b/internal/printer/object.go
@@ -246,6 +246,11 @@ func (o *Object) ToComponent(ctx context.Context, options Options) (component.Co
 				return nil, fmt.Errorf("failed to create item view: %w", err)
 			}
 
+			if vc == nil {
+				// don't print nil objects
+				continue
+			}
+
 			if err := section.Add(vc, item.Width); err != nil {
 				return nil, fmt.Errorf("unable to add item to layout section in object printer: %w", err)
 			}

--- a/internal/printer/object_test.go
+++ b/internal/printer/object_test.go
@@ -205,6 +205,36 @@ func Test_Object_ToComponent(t *testing.T) {
 			},
 		},
 		{
+			name:   "register items (skip nil)",
+			object: deployment,
+			initFunc: func(o *Object, options *initOptions) {
+				stubPlugins(options.PluginPrinter)
+				o.RegisterItems([]ItemDescriptor{
+					{
+						Func: func() (component.Component, error) {
+							return nil, nil
+						},
+						Width: component.WidthHalf,
+					},
+					{
+						Func: func() (component.Component, error) {
+							return component.NewText("item1"), nil
+						},
+						Width: component.WidthHalf,
+					},
+				}...)
+			},
+			sections: []component.FlexLayoutSection{
+				defaultConfigSection,
+				{
+					{
+						Width: component.WidthHalf,
+						View:  component.NewText("item1"),
+					},
+				},
+			},
+		},
+		{
 			name:   "nil object",
 			object: nil,
 			isErr:  true,


### PR DESCRIPTION
Signed-off-by: bryanl <bryanliles@gmail.com>

**What this PR does / why we need it**:

Showing empty CRD versions takes up space and doesn't have a purpose.

**Which issue(s) this PR fixes**
- Fixes #688 

**Release note**:
```
Do not show empty CRD versions
```
