### PR TITLE
Datagrid pagination causes octant to pause in debugger

### DIFF
--- a/changelogs/unreleased/692-bryanl
+++ b/changelogs/unreleased/692-bryanl
@@ -1,0 +1,1 @@
+Remove delay when showing datagrids with filters

--- a/changelogs/unreleased/693-bryanl
+++ b/changelogs/unreleased/693-bryanl
@@ -1,0 +1,1 @@
+Don't calculate pagination for data grid until there are rows

--- a/web/src/app/modules/shared/components/presentation/content-filter/content-filter.component.ts
+++ b/web/src/app/modules/shared/components/presentation/content-filter/content-filter.component.ts
@@ -48,7 +48,7 @@ export class ContentFilterComponent
   }
 
   isActive(): boolean {
-    return true;
+    return Object.keys(this.checkboxes).length > 0;
   }
 
   onFilterChange(name: string, e: boolean) {

--- a/web/src/app/modules/shared/components/presentation/datagrid/datagrid.component.html
+++ b/web/src/app/modules/shared/components/presentation/datagrid/datagrid.component.html
@@ -28,8 +28,10 @@
             <clr-dg-footer>
                 <clr-dg-pagination #pagination [clrDgPageSize]="10">
                     <clr-dg-page-size [clrPageSizeOptions]="[10,20,50,100]">Items per page</clr-dg-page-size>
-                    {{pagination.firstItem + 1}} - {{pagination.lastItem + 1}}
-                    of {{pagination.totalItems}} items
+                    <ng-container *ngIf="rows?.length > 0">
+                        {{pagination.firstItem + 1}} - {{pagination.lastItem + 1}}
+                        of {{pagination.totalItems}} items
+                    </ng-container>
                 </clr-dg-pagination>
 
                 <ng-container *ngIf="loading">


### PR DESCRIPTION
**What this PR does / why we need it**:
There are two issues addressed in this PR:

1. Pagination causes octant to pause the browser due to a value being changed after it is checked. The fix is to show pagination only if there are rows.
1. Data grid filters caused a slight delay if there are filtered columns (e.g., pods). This change sets a filter to active only if it has values, i.e., it is active. 

**Which issue(s) this PR fixes**
- Fixes #692 
- Fixes #693


