### PR TITLE
Add apps/v1 replicaset gvk to queryer

### DIFF
--- a/internal/queryer/queryer.go
+++ b/internal/queryer/queryer.go
@@ -292,6 +292,7 @@ func (osq *ObjectStoreQueryer) Children(ctx context.Context, owner *unstructured
 }
 
 var allowed = []schema.GroupVersionKind{
+	gvk.AppReplicaSet,
 	gvk.CronJob,
 	gvk.DaemonSet,
 	gvk.Deployment,


### PR DESCRIPTION
**What this PR does / why we need it**:
Show replica sets under deployment in resource viewer

**Which issue(s) this PR fixes**
- Fixes #673 

Signed-off-by: GuessWhoSamFoo <foos@vmware.com>
