### PR TITLE
Widened Log timestamp to prevent breaking up to the second line [#700]

### DIFF
--- a/changelogs/unreleased/213-mklanjsek
+++ b/changelogs/unreleased/213-mklanjsek
@@ -1,0 +1,1 @@
+Added Log search / filter

--- a/changelogs/unreleased/667-mklanjsek
+++ b/changelogs/unreleased/667-mklanjsek
@@ -1,0 +1,1 @@
+Scroll Log view to the bottom at initial load

--- a/changelogs/unreleased/700-mklanjsek
+++ b/changelogs/unreleased/700-mklanjsek
@@ -1,0 +1,1 @@
+Widened Log timestamp so it doesn't break up to the second line

--- a/web/src/app/modules/shared/components/smart/logs/logs.component.scss
+++ b/web/src/app/modules/shared/components/smart/logs/logs.component.scss
@@ -29,8 +29,8 @@
       flex-direction: row;
 
       &-timestamp {
-        min-width: 280px;
-        width: 280px;
+        min-width: 294px;
+        width: 294px;
         color: #a9b6be;
       }
 


### PR DESCRIPTION
Signed-off-by: Milan Klanjsek <mklanjsek@pivotal.io>

- Widened Log timestamp to prevent breaking up to the second line
- Fixes #700 