### PR TITLE
Make filtering (including Regex) case sensitive (#702)

### DIFF
--- a/changelogs/unreleased/702-mklanjsek
+++ b/changelogs/unreleased/702-mklanjsek
@@ -1,0 +1,1 @@
+Make filtering (including Regex) case sensitive

--- a/web/src/app/modules/shared/components/smart/logs/logs.component.spec.ts
+++ b/web/src/app/modules/shared/components/smart/logs/logs.component.spec.ts
@@ -5,6 +5,8 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { LogsComponent } from './logs.component';
 import { LogEntry } from 'src/app/modules/shared/models/content';
+import { By } from '@angular/platform-browser';
+import { DebugElement } from '@angular/core';
 
 /**
  * Adds 15 logs to the provided list.
@@ -60,5 +62,18 @@ describe('LogsComponent', () => {
     expect(nativeElement.scrollTop).toEqual(
       nativeElement.scrollHeight - nativeElement.offsetHeight
     );
+  });
+
+  it('should filter messages based on regex expression', () => {
+    component.filterText = '([A-Z])\\w+';
+    component.shouldDisplayTimestamp = false;
+    component.containerLogs = addLogsToList([]);
+    fixture.detectChanges();
+
+    const selectHighlights: DebugElement[] = fixture.debugElement.queryAll(
+      By.css('.highlight')
+    );
+    expect(selectHighlights.length).toEqual(15);
+    expect(selectHighlights[0].nativeElement.innerText).toEqual('Just');
   });
 });

--- a/web/src/app/modules/shared/components/smart/logs/logs.component.ts
+++ b/web/src/app/modules/shared/components/smart/logs/logs.component.ts
@@ -162,7 +162,7 @@ export class LogsComponent implements OnInit, OnDestroy, AfterViewChecked {
     let highlighted = text;
 
     if (this.filterText) {
-      highlighted = text.replace(new RegExp(this.filterText, 'gi'), match => {
+      highlighted = text.replace(new RegExp(this.filterText, 'g'), match => {
         return '<span class="highlight">' + match + '</span>';
       });
     }
@@ -174,14 +174,14 @@ export class LogsComponent implements OnInit, OnDestroy, AfterViewChecked {
       if (this.shouldDisplayTimestamp) {
         return logs.filter(
           log =>
-            log.message.match(new RegExp(this.filterText, 'gi')) ||
+            log.message.match(new RegExp(this.filterText, 'g')) ||
             formatDate(log.timestamp, 'long', 'en-US').match(
-              new RegExp(this.filterText, 'gi')
+              new RegExp(this.filterText, 'g')
             )
         );
       }
       return logs.filter(log =>
-        log.message.match(new RegExp(this.filterText, 'gi'))
+        log.message.match(new RegExp(this.filterText, 'g'))
       );
     }
 


### PR DESCRIPTION
Signed-off-by: Milan Klanjsek <mklanjsek@pivotal.io>

**What this PR does / why we need it**:
Log filter is now case sensitive
- Fixes #702
 