### PR TITLE
[HOLD] Change sidebar to new design

### DIFF
--- a/internal/modules/clusteroverview/clusteroverview.go
+++ b/internal/modules/clusteroverview/clusteroverview.go
@@ -179,29 +179,41 @@ func (co *ClusterOverview) ContentPath() string {
 func (co *ClusterOverview) Navigation(ctx context.Context, namespace string, root string) ([]navigation.Navigation, error) {
 	navigationEntries := octant.NavigationEntries{
 		Lookup: map[string]string{
-			"Namespaces":         "namespaces",
-			"Custom Resources":   "custom-resources",
-			"RBAC":               "rbac",
-			"Nodes":              "nodes",
-			"Persistent Volumes": "persistent-volumes",
-			"Port Forwards":      "port-forward",
-			"Terminals":          "terminal",
+			"Namespaces":       "namespaces",
+			"Custom Resources": "custom-resources",
+			"RBAC":             "rbac",
+			"Nodes":            "nodes",
+			"Storage":          "storage",
+			"Port Forwards":    "port-forward",
+			"Terminals":        "terminal",
 		},
 		EntriesFuncs: map[string]octant.EntriesFunc{
-			"Namespaces":         nil,
-			"Custom Resources":   navigation.CRDEntries,
-			"RBAC":               rbacEntries,
-			"Nodes":              nil,
-			"Persistent Volumes": nil,
-			"Port Forwards":      nil,
-			"Terminals":          nil,
+			"Overview":         nil,
+			"Namespaces":       nil,
+			"Custom Resources": navigation.CRDEntries,
+			"RBAC":             rbacEntries,
+			"Nodes":            nil,
+			"Storage":          storageEntries,
+			"Port Forwards":    nil,
+			"Terminals":        nil,
+		},
+		IconMap: map[string]string{
+			"Overview":         icon.Overview,
+			"Namespaces":       icon.Namespaces,
+			"Custom Resources": icon.CustomResources,
+			"RBAC":             icon.RBAC,
+			"Nodes":            icon.Nodes,
+			"Storage":          icon.ConfigAndStorage,
+			"Port Forwards":    icon.PortForwards,
+			"Terminals":        icon.Terminals,
 		},
 		Order: []string{
+			"Overview",
 			"Namespaces",
 			"Custom Resources",
 			"RBAC",
 			"Nodes",
-			"Persistent Volumes",
+			"Storage",
 			"Port Forwards",
 			"Terminals",
 		},
@@ -211,14 +223,12 @@ func (co *ClusterOverview) Navigation(ctx context.Context, namespace string, roo
 
 	nf := octant.NewNavigationFactory("", root, objectStore, navigationEntries)
 
-	entries, err := nf.Generate(ctx, "Cluster Overview", icon.ClusterOverview, "", true)
+	entries, err := nf.Generate(ctx, "Cluster", true)
 	if err != nil {
 		return nil, err
 	}
 
-	return []navigation.Navigation{
-		*entries,
-	}, nil
+	return entries, nil
 }
 
 func (co *ClusterOverview) SetNamespace(namespace string) error {
@@ -239,12 +249,27 @@ func (co *ClusterOverview) Generators() []octant.Generator {
 
 func rbacEntries(ctx context.Context, prefix, namespace string, objectStore store.Store, _ bool) ([]navigation.Navigation, bool, error) {
 	neh := navigation.EntriesHelper{}
-	neh.Add("Cluster Roles", "cluster-roles", icon.ClusterOverviewClusterRole,
+	neh.Add("Overview", "", false)
+	neh.Add("Cluster Roles", "cluster-roles",
 		loading.IsObjectLoading(ctx, namespace, store.KeyFromGroupVersionKind(gvk.ClusterRole), objectStore))
-	neh.Add("Cluster Role Bindings", "cluster-role-bindings", icon.ClusterOverviewClusterRoleBinding,
+	neh.Add("Cluster Role Bindings", "cluster-role-bindings",
 		loading.IsObjectLoading(ctx, namespace, store.KeyFromGroupVersionKind(gvk.ClusterRoleBinding), objectStore))
 
-	children, err := neh.Generate(prefix)
+	children, err := neh.Generate(prefix, namespace, "")
+	if err != nil {
+		return nil, false, err
+	}
+
+	return children, false, nil
+}
+
+func storageEntries(ctx context.Context, prefix, namespace string, objectStore store.Store, _ bool) ([]navigation.Navigation, bool, error) {
+	neh := navigation.EntriesHelper{}
+	neh.Add("Overview", "", false)
+	neh.Add("Persistent Volumes", "persistent-volumes",
+		loading.IsObjectLoading(ctx, namespace, store.KeyFromGroupVersionKind(gvk.PersistentVolume), objectStore))
+
+	children, err := neh.Generate(prefix, namespace, "")
 	if err != nil {
 		return nil, false, err
 	}

--- a/internal/modules/clusteroverview/clusteroverview.go
+++ b/internal/modules/clusteroverview/clusteroverview.go
@@ -188,7 +188,7 @@ func (co *ClusterOverview) Navigation(ctx context.Context, namespace string, roo
 			"Terminals":        "terminal",
 		},
 		EntriesFuncs: map[string]octant.EntriesFunc{
-			"Overview":         nil,
+			"Dashboard":        nil,
 			"Namespaces":       nil,
 			"Custom Resources": navigation.CRDEntries,
 			"RBAC":             rbacEntries,
@@ -198,7 +198,7 @@ func (co *ClusterOverview) Navigation(ctx context.Context, namespace string, roo
 			"Terminals":        nil,
 		},
 		IconMap: map[string]string{
-			"Overview":         icon.Overview,
+			"Dashboard":        icon.Overview,
 			"Namespaces":       icon.Namespaces,
 			"Custom Resources": icon.CustomResources,
 			"RBAC":             icon.RBAC,
@@ -208,7 +208,7 @@ func (co *ClusterOverview) Navigation(ctx context.Context, namespace string, roo
 			"Terminals":        icon.Terminals,
 		},
 		Order: []string{
-			"Overview",
+			"Dashboard",
 			"Namespaces",
 			"Custom Resources",
 			"RBAC",
@@ -228,7 +228,9 @@ func (co *ClusterOverview) Navigation(ctx context.Context, namespace string, roo
 		return nil, err
 	}
 
-	return entries, nil
+	return []navigation.Navigation{
+		*entries,
+	}, nil
 }
 
 func (co *ClusterOverview) SetNamespace(namespace string) error {

--- a/internal/modules/clusteroverview/objects.go
+++ b/internal/modules/clusteroverview/objects.go
@@ -58,8 +58,8 @@ var (
 		IconName:              icon.ClusterOverviewNode,
 	})
 
-	persistentVolumeDescriber = describer.NewResource(describer.ResourceOptions{
-		Path:           "/persistent-volumes",
+	storagePersistentVolumeDescriber = describer.NewResource(describer.ResourceOptions{
+		Path:           "/storage/persistent-volumes",
 		ObjectStoreKey: store.Key{APIVersion: "v1", Kind: "PersistentVolume"},
 		ListType:       &v1.PersistentVolumeList{},
 		ObjectType:     &v1.PersistentVolume{},
@@ -67,6 +67,12 @@ var (
 		ClusterWide:    true,
 		IconName:       icon.ClusterOverviewPersistentVolume,
 	})
+
+	storageDescriber = describer.NewSection(
+		"/storage",
+		"Storage",
+		storagePersistentVolumeDescriber,
+	)
 
 	namespacesDescriber = describer.NewResource(describer.ResourceOptions{
 		Path:                  "/namespaces",
@@ -89,7 +95,7 @@ var (
 		customResourcesDescriber,
 		rbacDescriber,
 		nodesDescriber,
-		persistentVolumeDescriber,
+		storageDescriber,
 		portForwardDescriber,
 		terminalDescriber,
 	)

--- a/internal/modules/clusteroverview/path.go
+++ b/internal/modules/clusteroverview/path.go
@@ -40,7 +40,7 @@ func gvkPath(namespace, apiVersion, kind, name string) (string, error) {
 	case apiVersion == "v1" && kind == "Node":
 		p = "/nodes"
 	case apiVersion == "v1" && kind == "PersistentVolume":
-		p = "/persistent-volumes"
+		p = "/storage/persistent-volumes"
 	default:
 		return "", errors.Errorf("unknown object %s %s", apiVersion, kind)
 	}

--- a/internal/modules/configuration/configuration.go
+++ b/internal/modules/configuration/configuration.go
@@ -95,16 +95,10 @@ func (c *Configuration) ContentPath() string {
 func (c *Configuration) Navigation(ctx context.Context, namespace, root string) ([]navigation.Navigation, error) {
 	return []navigation.Navigation{
 		{
-			Title:    "Configuration",
-			Path:     path.Join(c.ContentPath(), "/"),
-			IconName: icon.Configuration,
-			Children: []navigation.Navigation{
-				{
-					Title:    "Plugins",
-					Path:     path.Join(c.ContentPath(), "plugins"),
-					IconName: icon.ConfigurationPlugin,
-				},
-			},
+			Module:   "Configuration",
+			Title:    "Plugin",
+			Path:     path.Join(c.ContentPath(), "plugins"),
+			IconName: icon.ConfigurationPlugin,
 		},
 	}, nil
 }

--- a/internal/modules/configuration/configuration.go
+++ b/internal/modules/configuration/configuration.go
@@ -95,10 +95,15 @@ func (c *Configuration) ContentPath() string {
 func (c *Configuration) Navigation(ctx context.Context, namespace, root string) ([]navigation.Navigation, error) {
 	return []navigation.Navigation{
 		{
-			Module:   "Configuration",
-			Title:    "Plugin",
-			Path:     path.Join(c.ContentPath(), "plugins"),
-			IconName: icon.ConfigurationPlugin,
+			Title: "Configuration",
+			Path:  "",
+			Children: []navigation.Navigation{
+				{
+					Title:    "Plugin",
+					Path:     path.Join(c.ContentPath(), "plugins"),
+					IconName: icon.ConfigurationPlugin,
+				},
+			},
 		},
 	}, nil
 }

--- a/internal/modules/overview/navigation.go
+++ b/internal/modules/overview/navigation.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/vmware-tanzu/octant/internal/gvk"
 	"github.com/vmware-tanzu/octant/internal/loading"
-	"github.com/vmware-tanzu/octant/pkg/icon"
 	"github.com/vmware-tanzu/octant/pkg/navigation"
 	"github.com/vmware-tanzu/octant/pkg/store"
 )
@@ -29,24 +28,25 @@ var (
 func workloadEntries(ctx context.Context, prefix, namespace string, objectStore store.Store, _ bool) ([]navigation.Navigation, bool, error) {
 	neh := navigation.EntriesHelper{}
 
-	neh.Add("Cron Jobs", "cron-jobs", icon.OverviewCronJob,
+	neh.Add("Overview", "", false)
+	neh.Add("Cron Jobs", "cron-jobs",
 		loading.IsObjectLoading(ctx, namespace, store.KeyFromGroupVersionKind(gvk.CronJob), objectStore))
-	neh.Add("Daemon Sets", "daemon-sets", icon.OverviewDaemonSet,
+	neh.Add("Daemon Sets", "daemon-sets",
 		loading.IsObjectLoading(ctx, namespace, store.KeyFromGroupVersionKind(gvk.DaemonSet), objectStore))
-	neh.Add("Deployments", "deployments", icon.OverviewDeployment,
+	neh.Add("Deployments", "deployments",
 		loading.IsObjectLoading(ctx, namespace, store.KeyFromGroupVersionKind(gvk.Deployment), objectStore))
-	neh.Add("Jobs", "jobs", icon.OverviewJob,
+	neh.Add("Jobs", "jobs",
 		loading.IsObjectLoading(ctx, namespace, store.KeyFromGroupVersionKind(gvk.Job), objectStore))
-	neh.Add("Pods", "pods", icon.OverviewPod,
+	neh.Add("Pods", "pods",
 		loading.IsObjectLoading(ctx, namespace, store.KeyFromGroupVersionKind(gvk.Pod), objectStore))
-	neh.Add("Replica Sets", "replica-sets", icon.OverviewReplicaSet,
+	neh.Add("Replica Sets", "replica-sets",
 		loading.IsObjectLoading(ctx, namespace, store.KeyFromGroupVersionKind(gvk.ExtReplicaSet), objectStore))
-	neh.Add("Replication Controllers", "replication-controllers", icon.OverviewReplicationController,
+	neh.Add("Replication Controllers", "replication-controllers",
 		loading.IsObjectLoading(ctx, namespace, store.KeyFromGroupVersionKind(gvk.ReplicationController), objectStore))
-	neh.Add("Stateful Sets", "stateful-sets", icon.OverviewStatefulSet,
+	neh.Add("Stateful Sets", "stateful-sets",
 		loading.IsObjectLoading(ctx, namespace, store.KeyFromGroupVersionKind(gvk.StatefulSet), objectStore))
 
-	children, err := neh.Generate(prefix)
+	children, err := neh.Generate(prefix, namespace, "")
 	if err != nil {
 		return nil, false, err
 	}
@@ -56,14 +56,15 @@ func workloadEntries(ctx context.Context, prefix, namespace string, objectStore 
 
 func discoAndLBEntries(ctx context.Context, prefix, namespace string, objectStore store.Store, _ bool) ([]navigation.Navigation, bool, error) {
 	neh := navigation.EntriesHelper{}
-	neh.Add("Horizontal Pod Autoscalers", "horizontal-pod-autoscalers", icon.OverviewHorizontalPodAutoscaler,
+	neh.Add("Overview", "", false)
+	neh.Add("Horizontal Pod Autoscalers", "horizontal-pod-autoscalers",
 		loading.IsObjectLoading(ctx, namespace, store.KeyFromGroupVersionKind(gvk.HorizontalPodAutoscaler), objectStore))
-	neh.Add("Ingresses", "ingresses", icon.OverviewIngress,
+	neh.Add("Ingresses", "ingresses",
 		loading.IsObjectLoading(ctx, namespace, store.KeyFromGroupVersionKind(gvk.Ingress), objectStore))
-	neh.Add("Services", "services", icon.OverviewService,
+	neh.Add("Services", "services",
 		loading.IsObjectLoading(ctx, namespace, store.KeyFromGroupVersionKind(gvk.Service), objectStore))
 
-	children, err := neh.Generate(prefix)
+	children, err := neh.Generate(prefix, namespace, "")
 	if err != nil {
 		return nil, false, err
 	}
@@ -73,16 +74,18 @@ func discoAndLBEntries(ctx context.Context, prefix, namespace string, objectStor
 
 func configAndStorageEntries(ctx context.Context, prefix, namespace string, objectStore store.Store, _ bool) ([]navigation.Navigation, bool, error) {
 	neh := navigation.EntriesHelper{}
-	neh.Add("Config Maps", "config-maps", icon.OverviewConfigMap,
+
+	neh.Add("Overview", "", false)
+	neh.Add("Config Maps", "config-maps",
 		loading.IsObjectLoading(ctx, namespace, store.KeyFromGroupVersionKind(gvk.ConfigMap), objectStore))
-	neh.Add("Persistent Volume Claims", "persistent-volume-claims", icon.OverviewPersistentVolumeClaim,
+	neh.Add("Persistent Volume Claims", "persistent-volume-claims",
 		loading.IsObjectLoading(ctx, namespace, store.KeyFromGroupVersionKind(gvk.PersistentVolumeClaim), objectStore))
-	neh.Add("Secrets", "secrets", icon.OverviewSecret,
+	neh.Add("Secrets", "secrets",
 		loading.IsObjectLoading(ctx, namespace, store.KeyFromGroupVersionKind(gvk.Secret), objectStore))
-	neh.Add("Service Accounts", "service-accounts", icon.OverviewServiceAccount,
+	neh.Add("Service Accounts", "service-accounts",
 		loading.IsObjectLoading(ctx, namespace, store.KeyFromGroupVersionKind(gvk.ServiceAccount), objectStore))
 
-	children, err := neh.Generate(prefix)
+	children, err := neh.Generate(prefix, namespace, "")
 	if err != nil {
 		return nil, false, err
 	}
@@ -93,12 +96,13 @@ func configAndStorageEntries(ctx context.Context, prefix, namespace string, obje
 func rbacEntries(ctx context.Context, prefix, namespace string, objectStore store.Store, _ bool) ([]navigation.Navigation, bool, error) {
 	neh := navigation.EntriesHelper{}
 
-	neh.Add("Roles", "roles", icon.OverviewRole,
+	neh.Add("Overview", "", false)
+	neh.Add("Roles", "roles",
 		loading.IsObjectLoading(ctx, namespace, store.KeyFromGroupVersionKind(gvk.Role), objectStore))
-	neh.Add("Role Bindings", "role-bindings", icon.OverviewRoleBinding,
+	neh.Add("Role Bindings", "role-bindings",
 		loading.IsObjectLoading(ctx, namespace, store.KeyFromGroupVersionKind(gvk.RoleBinding), objectStore))
 
-	children, err := neh.Generate(prefix)
+	children, err := neh.Generate(prefix, namespace, "")
 	if err != nil {
 		return nil, false, err
 	}

--- a/internal/modules/overview/overview.go
+++ b/internal/modules/overview/overview.go
@@ -196,7 +196,7 @@ func (co *Overview) Navigation(ctx context.Context, namespace, root string) ([]n
 	navigationEntries := octant.NavigationEntries{
 		Lookup: navPathLookup,
 		EntriesFuncs: map[string]octant.EntriesFunc{
-			"Overview":                     nil,
+			"Dashboard":                    nil,
 			"Workloads":                    workloadEntries,
 			"Discovery and Load Balancing": discoAndLBEntries,
 			"Config and Storage":           configAndStorageEntries,
@@ -205,7 +205,7 @@ func (co *Overview) Navigation(ctx context.Context, namespace, root string) ([]n
 			"Events":                       nil,
 		},
 		IconMap: map[string]string{
-			"Overview":                     icon.Overview,
+			"Dashboard":                    icon.Overview,
 			"Workloads":                    icon.Workloads,
 			"Discovery and Load Balancing": icon.DiscoveryAndLoadBalancing,
 			"Config and Storage":           icon.ConfigAndStorage,
@@ -214,7 +214,7 @@ func (co *Overview) Navigation(ctx context.Context, namespace, root string) ([]n
 			"Events":                       icon.Events,
 		},
 		Order: []string{
-			"Overview",
+			"Dashboard",
 			"Workloads",
 			"Discovery and Load Balancing",
 			"Config and Storage",
@@ -228,12 +228,14 @@ func (co *Overview) Navigation(ctx context.Context, namespace, root string) ([]n
 
 	nf := octant.NewNavigationFactory(namespace, root, objectStore, navigationEntries)
 
-	entries, err := nf.Generate(ctx, "", false)
+	entries, err := nf.Generate(ctx, "Overview", false)
 	if err != nil {
 		return nil, err
 	}
 
-	return entries, nil
+	return []navigation.Navigation{
+		*entries,
+	}, nil
 }
 
 // Generators allow modules to send events to the frontend.

--- a/internal/modules/overview/overview.go
+++ b/internal/modules/overview/overview.go
@@ -196,6 +196,7 @@ func (co *Overview) Navigation(ctx context.Context, namespace, root string) ([]n
 	navigationEntries := octant.NavigationEntries{
 		Lookup: navPathLookup,
 		EntriesFuncs: map[string]octant.EntriesFunc{
+			"Overview":                     nil,
 			"Workloads":                    workloadEntries,
 			"Discovery and Load Balancing": discoAndLBEntries,
 			"Config and Storage":           configAndStorageEntries,
@@ -203,7 +204,17 @@ func (co *Overview) Navigation(ctx context.Context, namespace, root string) ([]n
 			"RBAC":                         rbacEntries,
 			"Events":                       nil,
 		},
+		IconMap: map[string]string{
+			"Overview":                     icon.Overview,
+			"Workloads":                    icon.Workloads,
+			"Discovery and Load Balancing": icon.DiscoveryAndLoadBalancing,
+			"Config and Storage":           icon.ConfigAndStorage,
+			"Custom Resources":             icon.CustomResources,
+			"RBAC":                         icon.RBAC,
+			"Events":                       icon.Events,
+		},
 		Order: []string{
+			"Overview",
 			"Workloads",
 			"Discovery and Load Balancing",
 			"Config and Storage",
@@ -217,14 +228,12 @@ func (co *Overview) Navigation(ctx context.Context, namespace, root string) ([]n
 
 	nf := octant.NewNavigationFactory(namespace, root, objectStore, navigationEntries)
 
-	entries, err := nf.Generate(ctx, "Overview", icon.Overview, "", false)
+	entries, err := nf.Generate(ctx, "", false)
 	if err != nil {
 		return nil, err
 	}
 
-	return []navigation.Navigation{
-		*entries,
-	}, nil
+	return entries, nil
 }
 
 // Generators allow modules to send events to the frontend.

--- a/internal/modules/workloads/module.go
+++ b/internal/modules/workloads/module.go
@@ -18,6 +18,7 @@ import (
 	"github.com/vmware-tanzu/octant/internal/generator"
 	"github.com/vmware-tanzu/octant/internal/module"
 	"github.com/vmware-tanzu/octant/internal/octant"
+	"github.com/vmware-tanzu/octant/pkg/icon"
 	"github.com/vmware-tanzu/octant/pkg/navigation"
 	"github.com/vmware-tanzu/octant/pkg/view/component"
 )
@@ -95,8 +96,9 @@ func (m *Module) Navigation(ctx context.Context, namespace, root string) ([]navi
 	rootPath := path.Join(m.ContentPath(), "namespace", namespace)
 
 	rootNav := navigation.Navigation{
-		Title: "Workloads",
-		Path:  rootPath,
+		Title:    "Applications",
+		Path:     rootPath,
+		IconName: icon.Applications,
 	}
 
 	return []navigation.Navigation{rootNav}, nil

--- a/pkg/icon/icon.go
+++ b/pkg/icon/icon.go
@@ -15,6 +15,21 @@ import (
 //go:generate rice embed-go
 
 const (
+	// Names of Clarity icons
+	Applications              = "application"
+	Workloads                 = "applications"
+	Overview                  = "dashboard"
+	DiscoveryAndLoadBalancing = "network-globe"
+	ConfigAndStorage          = "storage"
+	RBAC                      = "assign-user"
+	Events                    = "event"
+
+	Namespaces      = "namespace"
+	CustomResources = "file-group"
+	Nodes           = "nodes"
+	PortForwards    = "router"
+	Terminals       = "terminal"
+
 	ClusterOverview                   = "objects"
 	ClusterOverviewClusterRole        = "c-role"
 	ClusterOverviewClusterRoleBinding = "crb"
@@ -27,7 +42,6 @@ const (
 
 	CustomResourceDefinition = "crd"
 
-	Overview                        = "objects"
 	OverviewConfigMap               = "cm"
 	OverviewCronJob                 = "cronjob"
 	OverviewDaemonSet               = "ds"

--- a/pkg/navigation/navigation.go
+++ b/pkg/navigation/navigation.go
@@ -55,6 +55,7 @@ func SetLoading(isLoading bool) Option {
 
 // Navigation is a set of navigation entries.
 type Navigation struct {
+	Module     string       `json:"module,omitempty"`
 	Title      string       `json:"title,omitempty"`
 	Path       string       `json:"path,omitempty"`
 	Children   []Navigation `json:"children,omitempty"`
@@ -78,7 +79,13 @@ func New(title, navigationPath string, options ...Option) (*Navigation, error) {
 
 // CRDEntries generates navigation entries for CRDs.
 func CRDEntries(ctx context.Context, prefix, namespace string, objectStore store.Store, wantsClusterScoped bool) ([]Navigation, bool, error) {
-	var list []Navigation
+	var list = []Navigation{
+		{
+			Title:   "Overview",
+			Path:    prefix,
+			Loading: false,
+		},
+	}
 
 	loading := false
 
@@ -213,14 +220,14 @@ type EntriesHelper struct {
 }
 
 // Add adds an entry.
-func (neh *EntriesHelper) Add(title, suffix, iconName string, isLoading bool) {
+func (neh *EntriesHelper) Add(title, suffix string, isLoading bool) {
 	neh.navConfigs = append(neh.navConfigs, navConfig{
-		title: title, suffix: suffix, iconName: iconName, isLoading: isLoading,
+		title: title, suffix: suffix, isLoading: isLoading,
 	})
 }
 
 // Generate generates navigation entries.
-func (neh *EntriesHelper) Generate(prefix string) ([]Navigation, error) {
+func (neh *EntriesHelper) Generate(prefix, namespace, name string) ([]Navigation, error) {
 	var navigations []Navigation
 
 	for _, nc := range neh.navConfigs {

--- a/pkg/navigation/navigation_test.go
+++ b/pkg/navigation/navigation_test.go
@@ -7,7 +7,6 @@ package navigation
 
 import (
 	"context"
-	"fmt"
 	"path"
 	"testing"
 
@@ -38,22 +37,22 @@ func Test_NewNavigation(t *testing.T) {
 func TestEntriesHelper(t *testing.T) {
 	neh := EntriesHelper{}
 
-	neh.Add("title", "suffix", icon.OverviewService, false)
+	neh.Add("title", "suffix", false)
 
-	list, err := neh.Generate("/prefix")
+	list, err := neh.Generate("/prefix", "", "")
 	require.NoError(t, err)
 
 	expected := Navigation{
 		Title:    "title",
 		Path:     path.Join("/prefix", "suffix"),
-		IconName: fmt.Sprintf("internal:%s", icon.OverviewService),
+		IconName: "",
 	}
 
 	assert.Len(t, list, 1)
 	assert.Equal(t, expected.Title, list[0].Title)
 	assert.Equal(t, expected.Path, list[0].Path)
 	assert.Equal(t, expected.IconName, list[0].IconName)
-	assert.NotEmpty(t, list[0].IconSource)
+	assert.Empty(t, list[0].IconSource)
 }
 
 func TestCRDEntries_namespace_scoped(t *testing.T) {
@@ -103,6 +102,10 @@ func TestCRDEntries_namespace_scoped(t *testing.T) {
 	require.NoError(t, err)
 
 	namespaceExpected := []Navigation{
+		{
+			Title: "Overview",
+			Path:  "/prefix",
+		},
 		createNavForCR(t, namespaceCR.GetName()),
 	}
 
@@ -112,6 +115,10 @@ func TestCRDEntries_namespace_scoped(t *testing.T) {
 	require.NoError(t, err)
 
 	clusterExpected := []Navigation{
+		{
+			Title: "Overview",
+			Path:  "/prefix",
+		},
 		createNavForCR(t, clusterCR.GetName()),
 	}
 

--- a/web/src/app/modules/shared/services/navigation/navigation.service.ts
+++ b/web/src/app/modules/shared/services/navigation/navigation.service.ts
@@ -19,6 +19,7 @@ const emptyNavigation: Navigation = {
 })
 export class NavigationService {
   current = new BehaviorSubject<Navigation>(emptyNavigation);
+  public expandedState: BehaviorSubject<any> = new BehaviorSubject<any>({});
 
   constructor(
     private websocketService: WebsocketService,

--- a/web/src/app/modules/shared/slider/slider.service.ts
+++ b/web/src/app/modules/shared/slider/slider.service.ts
@@ -26,6 +26,6 @@ export class SliderService {
 
   resetDefault() {
     // Approximate conversion from 1.5rem
-    this.height.next(36);
+    this.height.next(32);
   }
 }

--- a/web/src/app/modules/sugarloaf/components/smart/container/container.component.html
+++ b/web/src/app/modules/sugarloaf/components/smart/container/container.component.html
@@ -15,7 +15,6 @@
             </div>
         </div>
         <div class="header-actions">
-            <app-theme-switch-button></app-theme-switch-button>
             <app-context-selector></app-context-selector>
         </div>
     </header>

--- a/web/src/app/modules/sugarloaf/components/smart/container/container.component.scss
+++ b/web/src/app/modules/sugarloaf/components/smart/container/container.component.scss
@@ -2,8 +2,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-$navigation-width: 13rem;
-
 .main-container {
     // Navigation's color variables for Light Theme.
     :host-context(body) {
@@ -19,10 +17,6 @@ $navigation-width: 13rem;
 
   .header {
     background: var(--navigation-background-color);
-
-    .branding {
-      min-width: $navigation-width;
-    }
 
     .header-nav {
       padding-left: 1rem;
@@ -52,9 +46,6 @@ $navigation-width: 13rem;
 
     .navigation {
       border-right: 1px solid var(--navigation-border-color);
-      overflow-y: auto;
-      min-width: 2rem;
-      width: $navigation-width;
     }
 
     .content-area {

--- a/web/src/app/modules/sugarloaf/components/smart/content/content.component.html
+++ b/web/src/app/modules/sugarloaf/components/smart/content/content.component.html
@@ -1,4 +1,4 @@
-<div #scrollTarget class="content-component">
+<div clrFocusOnViewInit #scrollTarget class="content-component">
     <ng-container *ngIf="hasReceivedContent">
         <ng-container *ngIf="hasTabs; then withTabs; else withoutTabs"></ng-container>
         <ng-template #withTabs>

--- a/web/src/app/modules/sugarloaf/components/smart/namespace/namespace.component.scss
+++ b/web/src/app/modules/sugarloaf/components/smart/namespace/namespace.component.scss
@@ -5,7 +5,7 @@
 .app-namespace-selector {
   // Dropdown's color variables for Light Theme.
   :host-context(body) {
-    --dropdownLink-color: #575757;
+    --dropdownLink-color: #0079b8;
     --dropdownPanel-border-color: #ccc;
     --dropdownOptionSelected-bg-color: #dae4ea;
     --dropdownOption-bg-color: white;
@@ -21,12 +21,11 @@
     --dropdownOption-font-color: #adbbc4;
   }
 
-  margin: 0.5rem 1rem 1rem 1rem;
-
   .title {
     display: block;
     margin-bottom: 0.25rem;
-    font-weight: 600;
+    font-weight: 500;
+    font-size: 0.9em;
   }
 
   .namespace-dropdown {
@@ -57,7 +56,6 @@
     }
 
     ::ng-deep .ng-dropdown-panel {
-      box-shadow: 0 1px 0.125rem rgba(0,0,0,.5);
       border-color: var(--dropdownPanel-border-color);
       background-color: var(--dropdownOption-bg-color);
 

--- a/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.html
+++ b/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.html
@@ -1,53 +1,33 @@
-<div class="namespace-switcher">
-    <app-namespace></app-namespace>
-</div>
+<clr-vertical-nav [clrVerticalNavCollapsible]="true" [(clrVerticalNavCollapsed)]="collapsed">
+    <!-- Namespace selector -->
+    <div class="namespace-switcher" *ngIf="!collapsed">
+        <app-namespace></app-namespace>
+    </div>
 
-<clr-tree>
-  <clr-tree-node
-          *ngFor="let section of navigation.sections; trackBy: identifyNavigationItem"
-          [clrExpanded]="true"
-          [clrLoading]="section.isLoading"
-          class="section">
-      <a
-              [routerLinkActiveOptions]="{exact: true}"
-              [routerLink]="formatPath(section.path)"
-              class="clr-treenode-link section"
-              routerLinkActive="active">
-          <span>
-          <clr-icon [attr.shape]="section.iconName | default:'home'"></clr-icon>
-              {{ section.title }}
-          </span>
-      </a>
+    <!-- Navigation items -->
+    <div class="navigation-items">
+        <clr-vertical-nav-group
+            routerLinkActive="active"
+            *ngFor="let section of navigation.sections; trackBy: identifyNavigationItem"
+        >
+            <clr-icon [attr.shape]="section.iconName | default:'home'" clrVerticalNavIcon></clr-icon>
+            {{ section.title }}
+            <clr-vertical-nav-group-children>
+                <a
+                    clrVerticalNavLink
+                    *ngFor="let category of section.children; trackBy: identifyNavigationItem"
+                    [routerLink]="formatPath(category.path)"
+                   routerLinkActive="active"
+                >
+                   <clr-icon [attr.shape]="itemIcon(category) | default:'folder'"></clr-icon>
+                   {{ category.title }}
+                </a>
+            </clr-vertical-nav-group-children>
+        </clr-vertical-nav-group>
+    </div>
 
-      <clr-tree-node
-              *ngFor="let category of section.children; trackBy: identifyNavigationItem"
-              [clrExpanded]="true"
-              [clrLoading]="category.isLoading">
-          <a
-                  [routerLinkActiveOptions]="{exact: true}"
-                  [routerLink]="formatPath(category.path)"
-                  class="clr-treenode-link category"
-                  routerLinkActive="active">
-        <span>
-        <clr-icon [attr.shape]="itemIcon(category) | default:'folder'"></clr-icon>
-            {{ category.title }}
-        </span>
-
-          </a>
-
-          <clr-tree-node
-                  *ngFor="let entry of category.children; trackBy: identifyNavigationItem"
-                  [clrLoading]="entry.isLoading">
-              <a
-                      [routerLink]="formatPath(entry.path)"
-                      class="clr-treenode-link item"
-                      routerLinkActive="active">
-                  <clr-icon [attr.shape]="itemIcon(entry) | default:'folder'"></clr-icon>
-                  <span>
-                      {{ entry.title }}
-                  </span>
-              </a>
-          </clr-tree-node>
-      </clr-tree-node>
-  </clr-tree-node>
-</clr-tree>
+    <!-- Theme switcher -->
+    <div class="theme-switcher" *ngIf="!collapsed">
+        <app-theme-switch-button></app-theme-switch-button>
+    </div>
+</clr-vertical-nav>

--- a/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.html
+++ b/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.html
@@ -13,6 +13,7 @@
             </ng-template>
             <ng-container *ngIf="section.children?.length > 0; else noChild">
                 <clr-vertical-nav-group
+                    *ngIf="!collapsed; else hideExpand"
                     routerLinkActive="active"
                     [clrVerticalNavGroupExpanded]="shouldExpand(i)"
                     (clrVerticalNavGroupExpandedChange)="setNavState($event, i)"
@@ -32,6 +33,12 @@
                         </a>
                     </clr-vertical-nav-group-children>
                 </clr-vertical-nav-group>
+                <ng-template #hideExpand>
+                    <a clrVerticalNavLink (click)="collapsed=false; setNavState($event, i)">
+                        <clr-icon [attr.shape]="section.iconName | default:'home'" clrVerticalNavIcon></clr-icon>
+                        {{ section.title }}
+                    </a>
+                </ng-template>
             </ng-container>
             <ng-template #noChild>
                 <a clrVerticalNavLink

--- a/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.html
+++ b/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.html
@@ -6,24 +6,44 @@
 
     <!-- Navigation items -->
     <div class="navigation-items">
-        <clr-vertical-nav-group
-            routerLinkActive="active"
-            *ngFor="let section of navigation.sections; trackBy: identifyNavigationItem"
-        >
-            <clr-icon [attr.shape]="section.iconName | default:'home'" clrVerticalNavIcon></clr-icon>
-            {{ section.title }}
-            <clr-vertical-nav-group-children>
-                <a
-                    clrVerticalNavLink
-                    *ngFor="let category of section.children; trackBy: identifyNavigationItem"
-                    [routerLink]="formatPath(category.path)"
-                   routerLinkActive="active"
+        <ng-container *ngFor="let section of navigation.sections; let i = index; trackBy: identifyNavigationItem">
+            <ng-template [ngIf]="section.module">
+                <div class="nav-divider"></div>
+                <span *ngIf="!collapsed" class="title">{{ section.module }}</span>
+            </ng-template>
+            <ng-container *ngIf="section.children?.length > 0; else noChild">
+                <clr-vertical-nav-group
+                    routerLinkActive="active"
+                    [clrVerticalNavGroupExpanded]="shouldExpand(i)"
+                    (clrVerticalNavGroupExpandedChange)="setNavState($event, i)"
                 >
-                   <clr-icon [attr.shape]="itemIcon(category) | default:'folder'"></clr-icon>
-                   {{ category.title }}
+                    <clr-icon [attr.shape]="section.iconName | default:'home'" clrVerticalNavIcon></clr-icon>
+                    {{ section.title }}
+                    <clr-vertical-nav-group-children>
+                        <a
+                            clrVerticalNavLink
+                            *ngFor="let category of section.children; trackBy: identifyNavigationItem"
+                            [routerLink]="formatPath(category.path)"
+                            [routerLinkActiveOptions]="{exact: true}"
+                            routerLinkActive="active"
+                        >
+                        <clr-icon *ngIf="itemIcon(category) as categoryIcon" [attr.shape]="categoryIcon" clrVerticalNavIcon></clr-icon>
+                        {{ category.title }}
+                        </a>
+                    </clr-vertical-nav-group-children>
+                </clr-vertical-nav-group>
+            </ng-container>
+            <ng-template #noChild>
+                <a clrVerticalNavLink
+                    [routerLinkActiveOptions]="{exact: true}"
+                    [routerLink]="formatPath(section.path)"
+                    routerLinkActive="active"
+                >
+                    <clr-icon [attr.shape]="section.iconName | default:'home'" clrVerticalNavIcon></clr-icon>
+                    {{ section.title }}
                 </a>
-            </clr-vertical-nav-group-children>
-        </clr-vertical-nav-group>
+            </ng-template>
+        </ng-container>
     </div>
 
     <!-- Theme switcher -->

--- a/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.html
+++ b/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.html
@@ -7,42 +7,59 @@
     <!-- Navigation items -->
     <div class="navigation-items">
         <ng-container *ngFor="let section of navigation.sections; let i = index; trackBy: identifyNavigationItem">
-            <ng-template [ngIf]="section.module">
+            <ng-container *ngIf="section.children; else standalone">
                 <div class="nav-divider"></div>
-                <span *ngIf="!collapsed" class="title">{{ section.module }}</span>
-            </ng-template>
-            <ng-container *ngIf="section.children?.length > 0; else noChild">
-                <clr-vertical-nav-group
-                    *ngIf="!collapsed; else hideExpand"
-                    routerLinkActive="active"
-                    [clrVerticalNavGroupExpanded]="shouldExpand(i)"
-                    (clrVerticalNavGroupExpandedChange)="setNavState($event, i)"
-                >
-                    <clr-icon [attr.shape]="section.iconName | default:'home'" clrVerticalNavIcon></clr-icon>
-                    {{ section.title }}
-                    <clr-vertical-nav-group-children>
-                        <a
-                            clrVerticalNavLink
-                            *ngFor="let category of section.children; trackBy: identifyNavigationItem"
-                            [routerLink]="formatPath(category.path)"
-                            [routerLinkActiveOptions]="{exact: true}"
-                            routerLinkActive="active"
-                        >
-                        <clr-icon *ngIf="itemIcon(category) as categoryIcon" [attr.shape]="categoryIcon" clrVerticalNavIcon></clr-icon>
-                        {{ category.title }}
-                        </a>
-                    </clr-vertical-nav-group-children>
-                </clr-vertical-nav-group>
-                <ng-template #hideExpand>
-                    <a clrVerticalNavLink (click)="collapsed=false; setNavState($event, i)">
-                        <clr-icon [attr.shape]="section.iconName | default:'home'" clrVerticalNavIcon></clr-icon>
-                        {{ section.title }}
-                    </a>
-                </ng-template>
+                    <details *ngIf="!collapsed; else hideDetails" open>
+                        <summary class="title">{{ section.title }}</summary>
+                        <ng-container *ngFor="let category of section.children; trackBy: identifyNavigationItem">
+                            <ng-container *ngIf="category.children?.length > 0; else noChild">
+                                <clr-vertical-nav-group
+                                    routerLinkActive="active"
+                                    [clrVerticalNavGroupExpanded]="shouldExpand(category.path)"
+                                    (clrVerticalNavGroupExpandedChange)="setNavState($event, category.path)"
+                                >
+                                    <clr-icon [attr.shape]="category.iconName | default:'home'" clrVerticalNavIcon></clr-icon>
+                                    {{ category.title }}
+                                    <clr-vertical-nav-group-children>
+                                        <a
+                                            clrVerticalNavLink
+                                            *ngFor="let entry of category.children; trackBy: identifyNavigationItem"
+                                            [routerLink]="formatPath(entry.path)"
+                                            [routerLinkActiveOptions]="{exact: true}"
+                                            routerLinkActive="active"
+                                        >
+                                        <clr-icon *ngIf="itemIcon(entry) as entryIcon" [attr.shape]="entryIcon" clrVerticalNavIcon></clr-icon>
+                                        {{ entry.title }}
+                                        </a>
+                                    </clr-vertical-nav-group-children>
+                                </clr-vertical-nav-group>
+                            </ng-container>
+                            <ng-template #noChild>
+                                <a clrVerticalNavLink
+                                    [routerLink]="formatPath(category.path)"
+                                    [routerLinkActiveOptions]="{exact: true}"
+                                    routerLinkActive="active"
+                                >
+                                    <clr-icon [attr.shape]="category.iconName | default:'home'" clrVerticalNavIcon></clr-icon>
+                                    {{ category.title }}
+                                </a>
+                            </ng-template>
+                        </ng-container>
+                    </details>
+                    <ng-template #hideDetails>
+                        <ng-container *ngFor="let category of section.children; trackBy: identifyNavigationItem">
+                            <a clrVerticalNavLink
+                                [routerLink]="formatPath(category.path)"
+                                [routerLinkActiveOptions]="category.children?.length > 0 ? {exact: false}: {exact: true}"
+                                routerLinkActive="active"
+                            >
+                                <clr-icon [attr.shape]="category.iconName | default:'home'" clrVerticalNavIcon></clr-icon>
+                            </a>
+                        </ng-container>
+                    </ng-template>
             </ng-container>
-            <ng-template #noChild>
+            <ng-template #standalone>
                 <a clrVerticalNavLink
-                    [routerLinkActiveOptions]="{exact: true}"
                     [routerLink]="formatPath(section.path)"
                     routerLinkActive="active"
                 >

--- a/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.scss
+++ b/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.scss
@@ -5,6 +5,19 @@
 .clr-vertical-nav {
   height: 100%;
   background: none;
+  width: inherit;
+
+  .title {
+    display: block;
+    margin-bottom: 0.25rem;
+    font-weight: 500;
+    font-size: 0.9em;
+    padding: 0 1rem 0 1rem;
+  }
+
+  .nav-divider {
+    border-top: 1px;
+  }
 
   .namespace-switcher {
     padding: 0 1rem 1rem 1rem;

--- a/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.scss
+++ b/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.scss
@@ -5,7 +5,7 @@
 .clr-vertical-nav {
   height: 100%;
   background: none;
-  width: inherit;
+  width: 300px;
 
   .title {
     display: block;

--- a/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.scss
+++ b/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.scss
@@ -13,6 +13,7 @@
     font-weight: 500;
     font-size: 0.9em;
     padding: 0 1rem 0 1rem;
+    cursor: pointer;
   }
 
   .nav-divider {

--- a/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.scss
+++ b/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.scss
@@ -2,18 +2,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-.clr-treenode-link {
-  white-space: nowrap;
-}
+.clr-vertical-nav {
+  height: 100%;
+  background: none;
 
-clr-tree-node.section {
-  margin-bottom: 18px;
-}
+  .namespace-switcher {
+    padding: 0 1rem 1rem 1rem;
+  }
 
-a.section {
-  font-weight: 600;
-}
+  .navigation-items {
+    flex-grow: 1;
+    overflow-y: auto;
+  }
 
-a.category {
-  font-weight: 600;
+  .theme-switcher {
+    padding: 0 1rem 0 0.5rem;
+  }
 }

--- a/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.spec.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.spec.ts
@@ -6,6 +6,7 @@ import { DefaultPipe } from '../../../../shared/pipes/default/default.pipe';
 import { NavigationComponent } from './navigation.component';
 import { NamespaceComponent } from '../namespace/namespace.component';
 import { NgSelectModule } from '@ng-select/ng-select';
+import { ThemeSwitchButtonComponent } from '../theme-switch/theme-switch-button.component';
 
 describe('NavigationComponent', () => {
   let component: NavigationComponent;
@@ -14,7 +15,12 @@ describe('NavigationComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [NgSelectModule],
-      declarations: [NavigationComponent, NamespaceComponent, DefaultPipe],
+      declarations: [
+        NavigationComponent,
+        NamespaceComponent,
+        DefaultPipe,
+        ThemeSwitchButtonComponent,
+      ],
     }).compileComponents();
   }));
 

--- a/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.ts
@@ -58,12 +58,12 @@ export class NavigationComponent implements OnInit, OnDestroy {
     if (!path.startsWith('/')) {
       return '/' + path;
     }
-
+    console.log(path);
     return path;
   }
 
-  setNavState($event, state: number) {
-    this.navExpandedState[state] = $event;
+  setNavState($event, key: string) {
+    this.navExpandedState[key] = $event;
     this.navigationService.expandedState.next(this.navExpandedState);
   }
 

--- a/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.ts
@@ -20,6 +20,7 @@ const emptyNavigation: Navigation = {
 })
 export class NavigationComponent implements OnInit, OnDestroy {
   behavior = new BehaviorSubject<Navigation>(emptyNavigation);
+  collapsed = false;
 
   navigation = emptyNavigation;
 

--- a/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.ts
@@ -21,6 +21,7 @@ const emptyNavigation: Navigation = {
 export class NavigationComponent implements OnInit, OnDestroy {
   behavior = new BehaviorSubject<Navigation>(emptyNavigation);
   collapsed = false;
+  navExpandedState: any;
 
   navigation = emptyNavigation;
 
@@ -33,6 +34,9 @@ export class NavigationComponent implements OnInit, OnDestroy {
     this.navigationService.current
       .pipe(untilDestroyed(this))
       .subscribe(navigation => (this.navigation = navigation));
+    this.navigationService.expandedState
+      .pipe(untilDestroyed(this))
+      .subscribe(expanded => (this.navExpandedState = expanded));
   }
 
   ngOnDestroy() {}
@@ -56,5 +60,17 @@ export class NavigationComponent implements OnInit, OnDestroy {
     }
 
     return path;
+  }
+
+  setNavState($event, state: number) {
+    this.navExpandedState[state] = $event;
+    this.navigationService.expandedState.next(this.navExpandedState);
+  }
+
+  shouldExpand(index: number) {
+    if (index.toString() in this.navExpandedState) {
+      return this.navExpandedState[index];
+    }
+    return false;
   }
 }

--- a/web/src/app/modules/sugarloaf/components/smart/theme-switch/theme-switch-button.component.scss
+++ b/web/src/app/modules/sugarloaf/components/smart/theme-switch/theme-switch-button.component.scss
@@ -1,5 +1,17 @@
 .switch-button-container {
-  height: 100%;
-  display: flex;
-  align-items: center;
+  :host-context(body) {
+    --font-color: #0079b8;
+  }
+
+  :host-context(body.dark) {
+    --font-color: #49afd9;
+  }
+  
+  button.btn.btn-link.btn-inverse {
+    color: var(--font-color);
+
+    &:active {
+      box-shadow: none;
+    }
+  }
 }

--- a/web/src/app/modules/sugarloaf/models/navigation.ts
+++ b/web/src/app/modules/sugarloaf/models/navigation.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 export interface NavigationChild {
-  module?: string;
   title: string;
   path: string;
   children?: NavigationChild[];

--- a/web/src/app/modules/sugarloaf/models/navigation.ts
+++ b/web/src/app/modules/sugarloaf/models/navigation.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 export interface NavigationChild {
+  module?: string;
   title: string;
   path: string;
   children?: NavigationChild[];


### PR DESCRIPTION
**What this PR does / why we need it**:
 This PR makes the following changes:
 - Move persistent volumes to a new `/storage` path
 - Removes icons from child navigation. Update to clarity icons
 - Renames `Workloads` module to `Applications`
 - Adds an `Overview` entry to each object group
 - Updates navigation service to track expanded groups
 - Remove nested groups from navigation factory

**Which issue(s) this PR fixes**
- Fixes #640 

**Special notes for your reviewer**:
 - [ ] Add release note
 - [ ] CSS tweaks to match design spec
 - [ ] Handle nested plugin paths

Related #537 