### PR TITLE
Wait for plugin grpc client to be ready before use

### DIFF
--- a/changelogs/unreleased/713-bryanl
+++ b/changelogs/unreleased/713-bryanl
@@ -1,0 +1,1 @@
+Configure grpc client to wait for server to be ready before sending requests

--- a/internal/api/navigation_manager.go
+++ b/internal/api/navigation_manager.go
@@ -142,8 +142,7 @@ func NavigationGenerator(ctx context.Context, state octant.State, config Navigat
 			contentPath := m.ContentPath()
 			navList, err := m.Navigation(ctx, namespace, contentPath)
 			if err != nil {
-				fmt.Printf("err in navigation: %s", err)
-				return err
+				return fmt.Errorf("unable to generate navigation for module %s: %v", m.Name(), err)
 			}
 
 			mu.Lock()

--- a/pkg/plugin/api/api.go
+++ b/pkg/plugin/api/api.go
@@ -7,13 +7,13 @@ package api
 
 import (
 	"context"
-	"fmt"
 	"net"
 
 	"github.com/pkg/errors"
+	"google.golang.org/grpc"
+
 	"github.com/vmware-tanzu/octant/internal/log"
 	"github.com/vmware-tanzu/octant/pkg/plugin/api/proto"
-	"google.golang.org/grpc"
 )
 
 // API controlls the dashboard API service.
@@ -59,8 +59,7 @@ func (a *grpcAPI) Start(ctx context.Context) error {
 	logger.Debugf("dashboard plugin api is starting")
 	go func() {
 		if err := s.Serve(a.listener); err != nil {
-			fmt.Println("it broke?", err)
-			logger.Errorf("unable to serve GRPC: %v", err)
+			logger.WithErr(err).Errorf("unable to serve GRPC")
 			return
 		}
 	}()

--- a/pkg/plugin/api/client.go
+++ b/pkg/plugin/api/client.go
@@ -43,7 +43,6 @@ type ClientOption func(c *Client)
 // Client is a dashboard service API client.
 type Client struct {
 	DashboardConnection DashboardConnection
-	// dashboardClientFactory DashboardClientFactory
 }
 
 var _ Service = (*Client)(nil)

--- a/pkg/plugin/grpc.go
+++ b/pkg/plugin/grpc.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/pkg/errors"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/status"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -55,7 +56,7 @@ func (c *GRPCClient) Content(ctx context.Context, contentPath string) (component
 			Path: contentPath,
 		}
 
-		resp, err := c.client.Content(ctx, req)
+		resp, err := c.client.Content(ctx, req, grpc.WaitForReady(true))
 		if err != nil {
 			return errors.Wrap(err, "grpc client content")
 		}
@@ -86,7 +87,7 @@ func (c *GRPCClient) HandleAction(ctx context.Context, payload action.Payload) e
 			Payload: data,
 		}
 
-		_, err = c.client.HandleAction(ctx, req)
+		_, err = c.client.HandleAction(ctx, req, grpc.WaitForReady(true))
 		if err != nil {
 			if s, isStatus := status.FromError(err); isStatus {
 				return errors.Errorf("grpc error: %s", s.Message())
@@ -111,7 +112,7 @@ func (c *GRPCClient) Navigation(ctx context.Context) (navigation.Navigation, err
 	err := c.run(func() error {
 		req := &dashboard.NavigationRequest{}
 
-		resp, err := c.client.Navigation(ctx, req)
+		resp, err := c.client.Navigation(ctx, req, grpc.WaitForReady(true))
 		if err != nil {
 			return errors.Wrap(err, "grpc client response")
 		}
@@ -137,7 +138,7 @@ func (c *GRPCClient) Register(ctx context.Context, dashboardAPIAddress string) (
 			DashboardAPIAddress: dashboardAPIAddress,
 		}
 
-		resp, err := c.client.Register(ctx, registerRequest)
+		resp, err := c.client.Register(ctx, registerRequest, grpc.WaitForReady(true))
 		if err != nil {
 			spew.Dump(err)
 			return errors.WithMessage(err, "unable to call register function")
@@ -171,7 +172,7 @@ func (c *GRPCClient) ObjectStatus(ctx context.Context, object runtime.Object) (O
 			return err
 		}
 
-		resp, err := c.client.ObjectStatus(ctx, in)
+		resp, err := c.client.ObjectStatus(ctx, in, grpc.WaitForReady(true))
 		if err != nil {
 			return errors.Wrap(err, "grpc client object status")
 		}
@@ -205,7 +206,7 @@ func (c *GRPCClient) Print(ctx context.Context, object runtime.Object) (PrintRes
 			return err
 		}
 
-		resp, err := c.client.Print(ctx, in)
+		resp, err := c.client.Print(ctx, in, grpc.WaitForReady(true))
 		if err != nil {
 			return errors.Wrap(err, "grpc client print")
 		}
@@ -266,7 +267,7 @@ func (c *GRPCClient) PrintTab(ctx context.Context, object runtime.Object) (TabRe
 			return err
 		}
 
-		resp, err := c.client.PrintTab(ctx, in)
+		resp, err := c.client.PrintTab(ctx, in, grpc.WaitForReady(true))
 		if err != nil {
 			return errors.Wrap(err, "grpc client print tab")
 		}

--- a/pkg/plugin/grpc_test.go
+++ b/pkg/plugin/grpc_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -92,7 +93,7 @@ func Test_GRPCClient_Content(t *testing.T) {
 		}
 
 		mocks.protoClient.EXPECT().
-			Content(gomock.Any(), req).
+			Content(gomock.Any(), req, grpc.WaitForReady(true)).
 			Return(resp, nil)
 
 		client := mocks.genClient()
@@ -115,7 +116,7 @@ func Test_GRPCClient_Navigation(t *testing.T) {
 		}
 
 		mocks.protoClient.EXPECT().
-			Navigation(gomock.Any(), req).
+			Navigation(gomock.Any(), req, grpc.WaitForReady(true)).
 			Return(resp, nil)
 
 		client := mocks.genClient()
@@ -147,7 +148,7 @@ func Test_GRPCClient_Register(t *testing.T) {
 			},
 		}
 
-		mocks.protoClient.EXPECT().Register(gomock.Any(), gomock.Any()).Return(resp, nil)
+		mocks.protoClient.EXPECT().Register(gomock.Any(), gomock.Any(), grpc.WaitForReady(true)).Return(resp, nil)
 
 		client := mocks.genClient()
 		apiAddress := "localhost:54321"
@@ -200,7 +201,7 @@ func Test_GRPCClient_Print(t *testing.T) {
 			},
 			Items: itemsData,
 		}
-		mocks.protoClient.EXPECT().Print(gomock.Any(), gomock.Eq(objectRequest)).Return(printResponse, nil)
+		mocks.protoClient.EXPECT().Print(gomock.Any(), gomock.Eq(objectRequest), grpc.WaitForReady(true)).Return(printResponse, nil)
 
 		client := mocks.genClient()
 		ctx := context.Background()
@@ -244,7 +245,7 @@ func Test_GRPCClient_PrintTab(t *testing.T) {
 		}
 
 		mocks.protoClient.EXPECT().
-			PrintTab(gomock.Any(), gomock.Eq(objectRequest)).
+			PrintTab(gomock.Any(), gomock.Eq(objectRequest), grpc.WaitForReady(true)).
 			Return(tabResponse, nil)
 
 		client := mocks.genClient()
@@ -296,7 +297,7 @@ func Test_GRPCClient_ObjectStatus(t *testing.T) {
 			ObjectStatus: statusData,
 		}
 
-		mocks.protoClient.EXPECT().ObjectStatus(gomock.Any(), gomock.Eq(objectRequest)).Return(objectStatusResponse, nil)
+		mocks.protoClient.EXPECT().ObjectStatus(gomock.Any(), gomock.Eq(objectRequest), grpc.WaitForReady(true)).Return(objectStatusResponse, nil)
 
 		client := mocks.genClient()
 		ctx := context.Background()

--- a/pkg/plugin/manager.go
+++ b/pkg/plugin/manager.go
@@ -11,6 +11,7 @@ package plugin
 
 import (
 	"context"
+	"fmt"
 	"os/exec"
 	"path/filepath"
 	"sort"
@@ -453,7 +454,7 @@ func (m *Manager) Print(ctx context.Context, object runtime.Object) (*PrintRespo
 	}()
 
 	if err := runner.Run(ctx, object, m.store.ClientNames()); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("print runner failed: %w", err)
 	}
 	close(ch)
 

--- a/pkg/plugin/runner.go
+++ b/pkg/plugin/runner.go
@@ -7,6 +7,7 @@ package plugin
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
@@ -72,7 +73,7 @@ func (pr *DefaultRunner) Run(ctx context.Context, object runtime.Object, clientN
 		fn := func(name string) func() error {
 			return func() error {
 				if err := pr.RunFunc(ctx, name, gvk, object); err != nil {
-					return errors.Wrap(err, "running")
+					return fmt.Errorf("running on %s: %w", name, err)
 				}
 
 				return nil


### PR DESCRIPTION
Configure GRPC client functions to wait for the server to be ready
before attempting to send requests. This removes a whole class
of `grpc` errors that users may get printed to their console.

This change also removes some unused code and reformats errors.

Fixes: #713

Signed-off-by: bryanl <bryanliles@gmail.com>

