### PR TITLE
Add a status indicator to text component

### DIFF
--- a/changelogs/unreleased/715-bryanl
+++ b/changelogs/unreleased/715-bryanl
@@ -1,0 +1,1 @@
+Allow text components to show status indicators

--- a/pkg/view/component/link_test.go
+++ b/pkg/view/component/link_test.go
@@ -71,7 +71,7 @@ func Test_Link_Marshal(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			actual, err := json.Marshal(tc.input)
-			isErr := (err != nil)
+			isErr := err != nil
 			if isErr != tc.isErr {
 				t.Fatalf("Unexpected error: %v", err)
 			}
@@ -87,28 +87,28 @@ func Test_Link_String(t *testing.T) {
 }
 
 func Test_Link_LessThan(t *testing.T) {
-	tests := []struct{
-		name string
-		link Link
-		other Component
+	tests := []struct {
+		name     string
+		link     Link
+		other    Component
 		expected bool
-	}	 {
+	}{
 		{
-			name: "is less",
-			link: *NewLink("", "a", "/a"),
-			other: NewLink("", "b", "/b"),
+			name:     "is less",
+			link:     *NewLink("", "a", "/a"),
+			other:    NewLink("", "b", "/b"),
 			expected: true,
 		},
 		{
-			name: "is not less",
-			link: *NewLink("", "b", "/b"),
-			other: NewLink("", "a", "/a"),
+			name:     "is not less",
+			link:     *NewLink("", "b", "/b"),
+			other:    NewLink("", "a", "/a"),
 			expected: false,
 		},
 		{
-			name: "other is not link",
-			link: *NewLink("", "b", "/b"),
-			other: nil,
+			name:     "other is not link",
+			link:     *NewLink("", "b", "/b"),
+			other:    nil,
 			expected: false,
 		},
 	}

--- a/pkg/view/component/text.go
+++ b/pkg/view/component/text.go
@@ -7,6 +7,18 @@ package component
 
 import "encoding/json"
 
+// TextStatus is the status of a text component
+type TextStatus int
+
+const (
+	// TextStatusOK
+	TextStatusOK TextStatus = 1
+	// TextStatusWarning
+	TextStatusWarning TextStatus = 2
+	// TextStatusError
+	TextStatusError TextStatus = 3
+)
+
 // Text is a component for text
 type Text struct {
 	base
@@ -15,8 +27,12 @@ type Text struct {
 
 // TextConfig is the contents of Text
 type TextConfig struct {
-	Text       string `json:"value"`
-	IsMarkdown bool   `json:"isMarkdown,omitempty"`
+	// Text is the text that will be displayed.
+	Text string `json:"value"`
+	// IsMarkdown sets if the component has markdown text.
+	IsMarkdown bool `json:"isMarkdown,omitempty"`
+	// Status sets the status of the component.
+	Status TextStatus `json:"status,omitempty"`
 }
 
 // NewText creates a text component
@@ -50,6 +66,11 @@ func (t *Text) EnableMarkdown() {
 // DisableMarkdown disables markdown for this text component.
 func (t *Text) DisableMarkdown() {
 	t.Config.IsMarkdown = false
+}
+
+// SetStatus sets the status of the text component.
+func (t *Text) SetStatus(status TextStatus) {
+	t.Config.Status = status
 }
 
 // SupportsTitle denotes this is a TextComponent.

--- a/web/src/app/modules/shared/components/presentation/indicator/indicator.component.html
+++ b/web/src/app/modules/shared/components/presentation/indicator/indicator.component.html
@@ -1,0 +1,3 @@
+<ng-container *ngIf="name(); let name">
+    <div class="indicator" [className]="name"></div>
+</ng-container>

--- a/web/src/app/modules/shared/components/presentation/indicator/indicator.component.scss
+++ b/web/src/app/modules/shared/components/presentation/indicator/indicator.component.scss
@@ -1,0 +1,28 @@
+/*!
+ *  Copyright (c) 2020 the Octant contributors. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+$circumference: 4px;
+
+.indicator {
+  height: $circumference;
+  width: $circumference;
+  border-radius: 50%;
+  display: inline-block;
+  transform: translateY(-50%);
+
+  &.ok {
+    background-color: #60b515;
+  }
+
+  &.warning {
+    background-color: #f57600;
+  }
+
+  &.error {
+    background-color: #e12200;
+  }
+}
+
+

--- a/web/src/app/modules/shared/components/presentation/indicator/indicator.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/indicator/indicator.component.spec.ts
@@ -1,0 +1,67 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import {
+  IndicatorComponent,
+  Status,
+  statusLookup,
+} from './indicator.component';
+import { Component } from '@angular/core';
+
+@Component({
+  template: '<app-indicator [status]="status"></app-indicator>',
+})
+class WrapperComponent {
+  status: number;
+}
+
+describe('IndicatorComponent', () => {
+  let component: WrapperComponent;
+  let fixture: ComponentFixture<WrapperComponent>;
+
+  let element: HTMLDivElement;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [WrapperComponent, IndicatorComponent],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(WrapperComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  [Status.Ok, Status.Warning, Status.Error].forEach(v => {
+    const name = statusLookup[v];
+
+    describe(`with ${name} status`, () => {
+      beforeEach(() => {
+        element = fixture.nativeElement;
+        component.status = v;
+        fixture.detectChanges();
+      });
+
+      it(`shows ${name} indicator`, () => {
+        expect(
+          element
+            .querySelector('app-indicator div.indicator')
+            .classList.contains(name)
+        ).toBeTruthy();
+      });
+    });
+  });
+
+  describe('with unknown status', () => {
+    beforeEach(() => {
+      element = fixture.nativeElement;
+      component.status = 0;
+      fixture.detectChanges();
+    });
+
+    it('does not show an indicator', () => {
+      console.log(element);
+      expect(element.querySelector('app-indicator div.indicator')).toBeNull();
+    });
+  });
+});

--- a/web/src/app/modules/shared/components/presentation/indicator/indicator.component.ts
+++ b/web/src/app/modules/shared/components/presentation/indicator/indicator.component.ts
@@ -1,0 +1,34 @@
+import { Component, Input, OnInit } from '@angular/core';
+
+/**
+ * Status are statuses known to indicator.
+ */
+export const Status = {
+  Ok: 1,
+  Warning: 2,
+  Error: 3,
+};
+
+export const statusLookup = {
+  [Status.Ok]: 'ok',
+  [Status.Warning]: 'warning',
+  [Status.Error]: 'error',
+};
+
+@Component({
+  selector: 'app-indicator',
+  templateUrl: './indicator.component.html',
+  styleUrls: ['./indicator.component.scss'],
+})
+export class IndicatorComponent implements OnInit {
+  @Input()
+  status: number;
+
+  constructor() {}
+
+  ngOnInit(): void {}
+
+  name() {
+    return statusLookup[this.status];
+  }
+}

--- a/web/src/app/modules/shared/components/presentation/text/text.component.html
+++ b/web/src/app/modules/shared/components/presentation/text/text.component.html
@@ -1,4 +1,7 @@
 <ng-container *ngIf="!isMarkdown; else markdown">
+    <ng-container *ngIf="hasStatus">
+        <app-indicator [status]="v.config.status"></app-indicator>
+    </ng-container>
     {{ value }}
 </ng-container>
 

--- a/web/src/app/modules/shared/components/presentation/text/text.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/text/text.component.spec.ts
@@ -7,6 +7,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { TextView } from '../../../models/content';
 import { TextComponent } from './text.component';
 import { SharedModule } from '../../../shared.module';
+import { Status } from '../indicator/indicator.component';
 
 @Component({
   template: '<app-view-text [view]="view"></app-view-text>',
@@ -44,6 +45,43 @@ describe('TextComponent', () => {
       expect(element.querySelector('app-view-text').innerHTML).toContain(
         '*text*'
       );
+    });
+
+    describe('status', () => {
+      let element: HTMLDivElement;
+
+      beforeEach(() => {
+        element = fixture.nativeElement;
+        component.view = {
+          config: { value: 'text' },
+          metadata: { type: 'text', title: [], accessor: 'accessor' },
+        };
+      });
+      describe('with status', () => {
+        beforeEach(() => {
+          component.view.config.status = Status.Ok;
+          fixture.detectChanges();
+        });
+
+        it('has an indicator component', () => {
+          expect(
+            element.querySelector('app-view-text app-indicator')
+          ).not.toBeNull();
+        });
+      });
+
+      describe('without status', () => {
+        beforeEach(() => {
+          component.view.config.status = undefined;
+          fixture.detectChanges();
+        });
+
+        it('does not have an indicator', () => {
+          expect(
+            element.querySelector('app-view-text app-indicator')
+          ).toBeNull();
+        });
+      });
     });
 
     it('should show markdown text', () => {

--- a/web/src/app/modules/shared/components/presentation/text/text.component.ts
+++ b/web/src/app/modules/shared/components/presentation/text/text.component.ts
@@ -24,6 +24,8 @@ export class TextComponent implements OnChanges {
 
   isMarkdown: boolean;
 
+  hasStatus = false;
+
   constructor() {}
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -31,6 +33,10 @@ export class TextComponent implements OnChanges {
       const view = changes.view.currentValue as TextView;
       this.value = view.config.value;
       this.isMarkdown = view.config.isMarkdown;
+
+      if (view.config.status) {
+        this.hasStatus = true;
+      }
     }
   }
 }

--- a/web/src/app/modules/shared/models/content.ts
+++ b/web/src/app/modules/shared/models/content.ts
@@ -303,6 +303,7 @@ export interface TextView extends View {
   config: {
     value: string;
     isMarkdown?: boolean;
+    status?: number;
   };
 }
 

--- a/web/src/app/modules/shared/shared.module.ts
+++ b/web/src/app/modules/shared/shared.module.ts
@@ -56,7 +56,7 @@ import { DefaultPipe } from './pipes/default/default.pipe';
 import { RouterModule } from '@angular/router';
 import { ResizableModule } from 'angular-resizable-element';
 import { hljsLanguages } from './highlight';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { IndicatorComponent } from './components/presentation/indicator/indicator.component';
 
 @NgModule({
   declarations: [
@@ -85,6 +85,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
     HeptagonGridRowComponent,
     HeptagonLabelComponent,
     IFrameComponent,
+    IndicatorComponent,
     LabelsComponent,
     LabelSelectorComponent,
     LinkComponent,


### PR DESCRIPTION
Add a status indicator to text component to allow Octant
to show if the item represented by the component is of
an ok, warning, or error status.

This is useful in conditions where double negatives are
employed.

<img width="412" alt="Screen Shot 2020-02-20 at 7 15 47 AM" src="https://user-images.githubusercontent.com/240/74937089-606c8000-53b9-11ea-9609-23f26e502a98.png">

Fixes: #715

