### PR TITLE
Summary sections can be updated

### DIFF
--- a/changelogs/unreleased/717-bryanl
+++ b/changelogs/unreleased/717-bryanl
@@ -1,0 +1,1 @@
+Summary sections can be updated

--- a/pkg/view/component/summary_test.go
+++ b/pkg/view/component/summary_test.go
@@ -15,6 +15,68 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestSummary_Add(t *testing.T) {
+	tc := []struct {
+		name      string
+		summary   *Summary
+		additions SummarySections
+		expected  []SummarySection
+	}{
+		{
+			name:     "empty with no additions",
+			summary:  NewSummary("title"),
+			expected: nil,
+		},
+		{
+			name:    "empty with additions",
+			summary: NewSummary("title"),
+			additions: SummarySections{
+				{Header: "a", Content: NewText("a")},
+			},
+			expected: SummarySections{
+				{Header: "a", Content: NewText("a")},
+			},
+		},
+		{
+			name: "existing with additions",
+			summary: NewSummary("title", SummarySection{
+				Header:  "a",
+				Content: NewText("a"),
+			}),
+			additions: SummarySections{
+				{Header: "b", Content: NewText("b")},
+			},
+			expected: SummarySections{
+				{Header: "a", Content: NewText("a")},
+				{Header: "b", Content: NewText("b")},
+			},
+		},
+		{
+			name: "existing with updates",
+			summary: NewSummary("title", []SummarySection{
+				{Header: "a", Content: NewText("a")},
+				{Header: "b", Content: NewText("b")},
+			}...),
+			additions: SummarySections{
+				{Header: "a", Content: NewText("updated")},
+			},
+			expected: SummarySections{
+				{Header: "a", Content: NewText("updated")},
+				{Header: "b", Content: NewText("b")},
+			},
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.summary.Add(tt.additions...)
+			got := tt.summary.Sections()
+
+			require.Equal(t, tt.expected, got)
+		})
+	}
+}
+
 func Test_Summary_Marshal(t *testing.T) {
 	tests := []struct {
 		name         string


### PR DESCRIPTION
Update Summary component to allow its summary sections to
be updated. To update a section, add a new item with an
existing name.

This change will allow plugins to update existing config and
status items in the object summary. This is useful for
converting text components to link components.

Fixes: #717 

Signed-off-by: bryanl <bryanliles@gmail.com>
