### PR TITLE
Log viewer: added support for ANSI escape codes [#246]

### DIFF
--- a/changelogs/unreleased/246-mklanjsek
+++ b/changelogs/unreleased/246-mklanjsek
@@ -1,0 +1,1 @@
+Log viewer: added support for ANSI escape codes

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -2335,6 +2335,11 @@
         "color-convert": "^1.9.0"
       }
     },
+    "ansi_up": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/ansi_up/-/ansi_up-4.0.4.tgz",
+      "integrity": "sha512-vRxC8q6QY918MbehO869biJW4tiunJdjOhi5fpY6NLOliBQlZhOkKgABJKJqH+JZfb/WfjvjN1chLWI6tODerw=="
+    },
     "anymatch": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",

--- a/web/package.json
+++ b/web/package.json
@@ -41,6 +41,7 @@
     "@types/cytoscape": "^3.8.6",
     "@webcomponents/custom-elements": "^1.3.1",
     "angular-resizable-element": "^3.2.6",
+    "ansi_up": "^4.0.4",
     "core-js": "^2.6.11",
     "cytoscape": "^3.12.1",
     "cytoscape-dagre": "^2.2.2",

--- a/web/src/app/modules/shared/components/smart/logs/logs.component.html
+++ b/web/src/app/modules/shared/components/smart/logs/logs.component.html
@@ -35,9 +35,9 @@
       </ng-container>
       <div class="container-log code language-bash" *ngFor="let log of filterFunction(containerLogs); trackBy: identifyLog">
         <div class="container-log-timestamp" *ngIf="shouldDisplayTimestamp"
-             [innerHTML]="'['+highlightText(log.timestamp | date:'long')+']'">
+             [innerHTML]="'['+highlightText(log.timestamp | date:'long')+']' | ansipipe">
         </div>
-        <div class="container-log-message" [innerHTML]="highlightText(log.message)">
+        <div class="container-log-message" [innerHTML]="highlightText(log.message) | ansipipe">
         </div>
       </div>
     </div>

--- a/web/src/app/modules/shared/components/smart/logs/logs.component.integration.spec.ts
+++ b/web/src/app/modules/shared/components/smart/logs/logs.component.integration.spec.ts
@@ -13,6 +13,7 @@ import { LogEntry, LogsView } from 'src/app/modules/shared/models/content';
 import getAPIBase from 'src/app/modules/shared/services/common/getAPIBase';
 import { PodLogsService } from 'src/app/modules/shared/pod-logs/pod-logs.service';
 import { LogsComponent } from './logs.component';
+import { AnsiPipe } from '../../../pipes/ansiPipe/ansi.pipe';
 
 const API_BASE = getAPIBase();
 
@@ -52,7 +53,7 @@ describe('LogsComponent <-> PodsLogsService', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [LogsComponent],
+      declarations: [LogsComponent, AnsiPipe],
       providers: [PodLogsService],
     }).compileComponents();
   }));

--- a/web/src/app/modules/shared/components/smart/logs/logs.component.spec.ts
+++ b/web/src/app/modules/shared/components/smart/logs/logs.component.spec.ts
@@ -7,6 +7,7 @@ import { LogsComponent } from './logs.component';
 import { LogEntry } from 'src/app/modules/shared/models/content';
 import { By } from '@angular/platform-browser';
 import { DebugElement } from '@angular/core';
+import { AnsiPipe } from '../../../pipes/ansiPipe/ansi.pipe';
 
 /**
  * Adds 15 logs to the provided list.
@@ -31,7 +32,7 @@ describe('LogsComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [LogsComponent],
+      declarations: [LogsComponent, AnsiPipe],
     }).compileComponents();
   }));
 

--- a/web/src/app/modules/shared/pipes/ansiPipe/ansi.pipe.spec.ts
+++ b/web/src/app/modules/shared/pipes/ansiPipe/ansi.pipe.spec.ts
@@ -1,0 +1,27 @@
+import { BrowserModule, DomSanitizer } from '@angular/platform-browser';
+import { inject, TestBed } from '@angular/core/testing';
+import { AnsiPipe } from './ansi.pipe';
+import { SecurityContext } from '@angular/core';
+
+describe('AnsiPipe', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [BrowserModule],
+    });
+  });
+
+  it('create an instance', inject(
+    [DomSanitizer],
+    (domSanitizer: DomSanitizer) => {
+      const pipe = new AnsiPipe(domSanitizer);
+      expect(pipe).toBeTruthy();
+
+      const ansiString = 'Hello \x1B[1;33;41m[o]\x1B[0m';
+      const sanitizedValue = pipe.transform(ansiString);
+
+      expect(domSanitizer.sanitize(SecurityContext.HTML, sanitizedValue)).toBe(
+        'Hello <span style="font-weight:bold;color:rgb(187,187,0);background-color:rgb(187,0,0)">[o]</span>'
+      );
+    }
+  ));
+});

--- a/web/src/app/modules/shared/pipes/ansiPipe/ansi.pipe.ts
+++ b/web/src/app/modules/shared/pipes/ansiPipe/ansi.pipe.ts
@@ -1,0 +1,33 @@
+import { Pipe, PipeTransform, SecurityContext } from '@angular/core';
+import {
+  DomSanitizer,
+  SafeHtml,
+  SafeResourceUrl,
+  SafeScript,
+  SafeStyle,
+  SafeUrl,
+} from '@angular/platform-browser';
+import { default as AnsiUp } from 'ansi_up';
+
+@Pipe({
+  name: 'ansipipe',
+})
+export class AnsiPipe implements PipeTransform {
+  ansiUp = new AnsiUp();
+
+  constructor(private sanitizer: DomSanitizer) {
+    this.ansiUp.escape_for_html = false;
+  }
+
+  public transform(
+    value: string
+  ): SafeHtml | SafeStyle | SafeScript | SafeUrl | SafeResourceUrl {
+    
+    if (value.includes('\x1B')) {  // ANSI string
+      return this.sanitizer.bypassSecurityTrustHtml(
+        this.ansiUp.ansi_to_html(value)
+      );
+    }
+    return value;
+  }
+}

--- a/web/src/app/modules/shared/pipes/ansiPipe/ansi.pipe.ts
+++ b/web/src/app/modules/shared/pipes/ansiPipe/ansi.pipe.ts
@@ -22,8 +22,8 @@ export class AnsiPipe implements PipeTransform {
   public transform(
     value: string
   ): SafeHtml | SafeStyle | SafeScript | SafeUrl | SafeResourceUrl {
-    
-    if (value.includes('\x1B')) {  // ANSI string
+    if (value.includes('\x1B')) {
+      // ANSI string
       return this.sanitizer.bypassSecurityTrustHtml(
         this.ansiUp.ansi_to_html(value)
       );

--- a/web/src/app/modules/shared/shared.module.ts
+++ b/web/src/app/modules/shared/shared.module.ts
@@ -52,11 +52,11 @@ import { HeptagonComponent } from './components/smart/heptagon/heptagon.componen
 import { ContextSelectorComponent } from './components/smart/context-selector/context-selector.component';
 import { SliderViewComponent } from './components/smart/slider-view/slider-view.component';
 import { SafePipe } from './pipes/safe/safe.pipe';
+import { AnsiPipe } from './pipes/ansiPipe/ansi.pipe';
 import { DefaultPipe } from './pipes/default/default.pipe';
 import { RouterModule } from '@angular/router';
 import { ResizableModule } from 'angular-resizable-element';
 import { hljsLanguages } from './highlight';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 @NgModule({
   declarations: [
@@ -98,6 +98,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
     QuadrantComponent,
     ResourceViewerComponent,
     SafePipe,
+    AnsiPipe,
     SelectorsComponent,
     SingleStatComponent,
     SliderViewComponent,


### PR DESCRIPTION
Signed-off-by: Milan Klanjsek <mklanjsek@pivotal.io>

**What this PR does / why we need it**:
Added support for ANSI escape codes

**Which issue(s) this PR fixes**
- Fixes #246

**Special notes for your reviewer**:
This is hard to reproduce without an app that emits ANSI codes to logs.  I tested by temporarly adding the escaped prefix to log output.  Also added a unit test that verifies it works.

