### PR TITLE
Logs component collects logs for all containers #637

### DIFF
--- a/changelogs/unreleased/637-mklanjsek
+++ b/changelogs/unreleased/637-mklanjsek
@@ -1,0 +1,1 @@
+Logs component collects logs for all containers

--- a/internal/modules/overview/logviewer/logviewer.go
+++ b/internal/modules/overview/logviewer/logviewer.go
@@ -37,17 +37,7 @@ func ToComponent(object runtime.Object) (component.Component, error) {
 		return nil, errors.Errorf("can't fetch logs from a %T", object)
 	}
 
-	var containerNames []string
-
-	for _, c := range pod.Spec.InitContainers {
-		containerNames = append(containerNames, c.Name)
-	}
-
-	for _, c := range pod.Spec.Containers {
-		containerNames = append(containerNames, c.Name)
-	}
-
-	logsComponent := component.NewLogs(pod.Namespace, pod.Name, containerNames)
+	logsComponent := component.NewLogs(pod)
 
 	return logsComponent, nil
 }

--- a/internal/modules/overview/logviewer/logviewer_test.go
+++ b/internal/modules/overview/logviewer/logviewer_test.go
@@ -18,6 +18,34 @@ import (
 )
 
 func Test_ToComponent(t *testing.T) {
+	pod1:=&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod",
+			Namespace: "default",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "one"},
+				{Name: "two"},
+			},
+		},
+	}
+	pod2:=&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod",
+			Namespace: "default",
+		},
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{
+				{Name: "init"},
+			},
+			Containers: []corev1.Container{
+				{Name: "one"},
+				{Name: "two"},
+			},
+		},
+	}
+
 	cases := []struct {
 		name     string
 		object   runtime.Object
@@ -26,38 +54,13 @@ func Test_ToComponent(t *testing.T) {
 	}{
 		{
 			name: "with containers",
-			object: &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "pod",
-					Namespace: "default",
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{Name: "one"},
-						{Name: "two"},
-					},
-				},
-			},
-			expected: component.NewLogs("default", "pod", []string{"one", "two"}),
+			object: pod1,
+			expected: component.NewLogs(pod1),
 		},
 		{
 			name: "with init containers",
-			object: &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "pod",
-					Namespace: "default",
-				},
-				Spec: corev1.PodSpec{
-					InitContainers: []corev1.Container{
-						{Name: "init"},
-					},
-					Containers: []corev1.Container{
-						{Name: "one"},
-						{Name: "two"},
-					},
-				},
-			},
-			expected: component.NewLogs("default", "pod", []string{"init", "one", "two"}),
+			object: pod2,
+			expected: component.NewLogs(pod2),
 		},
 		{
 			name:   "nil",

--- a/pkg/view/component/logs.go
+++ b/pkg/view/component/logs.go
@@ -6,6 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 package component
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	"encoding/json"
 )
 
@@ -20,12 +21,23 @@ type Logs struct {
 	Config LogsConfig `json:"config,omitempty"`
 }
 
-func NewLogs(namespace, name string, containers []string) *Logs {
+func NewLogs(pod *corev1.Pod) *Logs {
+
+	var containerNames []string
+
+	for _, c := range pod.Spec.InitContainers {
+		containerNames = append(containerNames, c.Name)
+	}
+
+	for _, c := range pod.Spec.Containers {
+		containerNames = append(containerNames, c.Name)
+	}
+
 	return &Logs{
 		Config: LogsConfig{
-			Namespace:  namespace,
-			Name:       name,
-			Containers: containers,
+			Namespace:  pod.Namespace,
+			Name:       pod.Name,
+			Containers: containerNames,
 		},
 		base: newBase(typeLogs, TitleFromString("Logs")),
 	}


### PR DESCRIPTION
Signed-off-by: Milan Klanjsek <mklanjsek@pivotal.io>

**What this PR does / why we need it**:
Changed the NewLogs signature to accept only a single argument: pod for which logs are collected. That way caller will get all logs ant they can later be filtered through dropdown in the UI or additional metadata that will be available after #668 is completed.

**Which issue(s) this PR fixes**
- Fixes #637

