### PR TITLE
fix container logs when the log lines are not timestamped

### DIFF
--- a/changelogs/unreleased/649-wwitzel3
+++ b/changelogs/unreleased/649-wwitzel3
@@ -1,0 +1,1 @@
+Fix container logs when the log content does not contain a timestamp.

--- a/internal/api/container_logs.go
+++ b/internal/api/container_logs.go
@@ -20,7 +20,7 @@ import (
 )
 
 type logEntry struct {
-	Timestamp time.Time `json:"timestamp,omitempty"`
+	Timestamp *time.Time `json:"timestamp,omitempty"`
 	Message   string    `json:"message,omitempty"`
 }
 
@@ -51,14 +51,16 @@ func containerLogsHandler(ctx context.Context, dashConfig config.Dash) http.Hand
 
 		go func() {
 			for line := range lines {
+				entry := logEntry{Message: line}
 				parts := strings.SplitN(line, " ", 2)
 				logTime, err := time.Parse(time.RFC3339, parts[0])
 				if err == nil {
-					entries = append(entries, logEntry{
-						Timestamp: logTime,
+					entry = logEntry{
+						Timestamp: &logTime,
 						Message:   parts[1],
-					})
+					}
 				}
+				entries = append(entries, entry)
 			}
 
 			done <- true

--- a/internal/modules/overview/logviewer/logviewer.go
+++ b/internal/modules/overview/logviewer/logviewer.go
@@ -47,6 +47,10 @@ func ToComponent(object runtime.Object) (component.Component, error) {
 		containerNames = append(containerNames, c.Name)
 	}
 
+	for _, c := range pod.Spec.EphemeralContainers {
+		containerNames = append(containerNames, c.Name)
+	}
+
 	logsComponent := component.NewLogs(pod.Namespace, pod.Name, containerNames)
 
 	return logsComponent, nil

--- a/web/src/app/modules/shared/components/smart/logs/logs.component.html
+++ b/web/src/app/modules/shared/components/smart/logs/logs.component.html
@@ -37,8 +37,11 @@
         No logs
       </ng-container>
       <div class="container-log code language-bash" *ngFor="let log of filterFunction(containerLogs); trackBy: identifyLog">
-        <div class="container-log-timestamp" *ngIf="shouldDisplayTimestamp"
+        <div class="container-log-timestamp" *ngIf="shouldDisplayTimestamp && log.timestamp != null"
              [innerHTML]="'['+highlightText(log.timestamp | date:'long')+']'">
+        </div>
+        <div class="container-log-timestamp" *ngIf="shouldDisplayTimestamp && log.timestamp == null"
+             [innerHTML]="'[timestamp unavailable]'">
         </div>
         <div class="container-log-message" [innerHTML]="highlightText(log.message)">
         </div>


### PR DESCRIPTION
Signed-off-by: Wayne Witzel III <wayne@riotousliving.com>


**What this PR does / why we need it**:
AKS VirtualNode containers (maybe others?) log entries are not timestamped. This caused our timestamp parsing to result in an error and hide log lines.

**Which issue(s) this PR fixes**
- Fixes #649
- Fixes #729 
