### PR TITLE
Fix content response adding duplicate plugin tabs

### DIFF
--- a/changelogs/unreleased/728-GuessWhoSamFoo
+++ b/changelogs/unreleased/728-GuessWhoSamFoo
@@ -1,0 +1,1 @@
+Fixed content response registering duplicate plugins

--- a/internal/describer/object.go
+++ b/internal/describer/object.go
@@ -146,9 +146,9 @@ func (d *Object) Describe(ctx context.Context, namespace string, options Options
 		return *cr, nil
 	}
 
-	for _, tab := range tabs {
-		tab.Contents.SetAccessor(tab.Name)
-		cr.Add(&tab.Contents)
+	for i := range tabs {
+		tabs[i].Contents.SetAccessor(tabs[i].Name)
+		cr.Add(&tabs[i].Contents)
 	}
 
 	return *cr, nil

--- a/pkg/plugin/manager.go
+++ b/pkg/plugin/manager.go
@@ -459,6 +459,19 @@ func (m *Manager) Print(ctx context.Context, object runtime.Object) (*PrintRespo
 	close(ch)
 
 	<-done
+
+	// Attempt to eliminate whitespace before fallback
+	sort.Slice(pr.Items, func(i, j int) bool {
+		if a, b := pr.Items[i].Width, pr.Items[j].Width; a != b {
+			return a < b
+		}
+
+		a, _ := component.TitleFromTitleComponent(pr.Items[i].View.GetMetadata().Title)
+		b, _ := component.TitleFromTitleComponent(pr.Items[j].View.GetMetadata().Title)
+
+		return a < b
+	})
+
 	return &pr, nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently Octant will only register the "last" plugin tab added duplicated across the number of plugins.

This PR also attempts to sort item responses from plugins based on component width and falling back on title.

**Which issue(s) this PR fixes**
- Fixes #691 

**Special notes for your reviewer**:
The loop needs to pass by value - not pointer.

Signed-off-by: GuessWhoSamFoo <foos@vmware.com>