### PR TITLE
Change permissions of generated rice files during containerized build

### DIFF
--- a/.github/workflows/preflight-checks.yaml
+++ b/.github/workflows/preflight-checks.yaml
@@ -141,6 +141,12 @@ jobs:
         uses: actions/download-artifact@v1
         with:
           name: rice-web
+      - name: Change permissions of rice files
+        # Uploading artifact changes file permissions
+        run: |
+          chown -R $(whoami):$(whoami) .
+          mv rice-icon/rice-box.go ./pkg/icon/
+          mv rice-web/rice-box.go ./web/
       - name: Run GoReleaser
         run: |
           goreleaser --rm-dist


### PR DESCRIPTION
This is a gotcha of uploading artifacts. rice-box.go files are not embedded in the binary because the permissions are reset (wrong user for container) and not compiled via goreleaser

xr #744 

Signed-off-by: GuessWhoSamFoo <foos@vmware.com>
