### PR TITLE
Set go version for nightly builds

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -9,6 +9,8 @@ jobs:
     steps:
       - uses: actions/setup-node@v1.1.0
       - uses: actions/setup-go@v1
+        with:
+          go-version: '1.14'
       - uses: actions/checkout@v2
       - name: Build node modules
         run: |


### PR DESCRIPTION
Fixes failing nightly runs due to using a go version < 1.13

See https://github.com/vmware-tanzu/octant/actions/runs/47853918

Signed-off-by: GuessWhoSamFoo <foos@vmware.com>

