### PR TITLE
Set CRD watcher to watch current context after switching

### DIFF
--- a/changelogs/unreleased/751-GuessWhoSamFoo
+++ b/changelogs/unreleased/751-GuessWhoSamFoo
@@ -1,0 +1,1 @@
+Fixed bug where CRD links stop working after switching contexts

--- a/internal/modules/overview/overview.go
+++ b/internal/modules/overview/overview.go
@@ -90,6 +90,8 @@ func (co *Overview) SetContext(ctx context.Context, contextName string) error {
 	}
 
 	co.watchedCRDs = []*unstructured.Unstructured{}
+	crdWatcher := co.dashConfig.CRDWatcher()
+	crdWatcher.Watch(ctx)
 
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
CRD links stop working after switching contexts.

**Which issue(s) this PR fixes**
- Fixes #672 
