### PR TITLE
Use Labels overflow pattern

### DIFF
--- a/web/src/app/modules/shared/components/presentation/labels/labels.component.html
+++ b/web/src/app/modules/shared/components/presentation/labels/labels.component.html
@@ -2,17 +2,13 @@
   <div class="label-with-title clr-col-md-12">
     <h3>{{ title }}</h3>
     <div class="view-labels">
-      <span *ngFor="let key of labelKeys; trackBy: trackByIdentity" class="label label-light-blue clickable" (click)="click(key, labels[key])">
-        {{ key }}:{{ labels[key] }}
-      </span>
+      <app-overflow-labels *ngIf="labels" [labels]="labels"></app-overflow-labels>
     </div>
   </div>
 </ng-template>
 <ng-template #noTitle>
   <div class="view-labels">
-    <span *ngFor="let key of labelKeys; trackBy: trackByIdentity" class="label label-light-blue clickable" (click)="click(key, labels[key])">
-      {{ key }}:{{ labels[key] }}
-    </span>
+    <app-overflow-labels *ngIf="labels" [labels]="labels"></app-overflow-labels>
   </div>
 </ng-template>
 

--- a/web/src/app/modules/shared/components/presentation/labels/labels.component.ts
+++ b/web/src/app/modules/shared/components/presentation/labels/labels.component.ts
@@ -28,10 +28,7 @@ export class LabelsComponent implements OnChanges {
   labels: { [key: string]: string };
   trackByIdentity = trackByIdentity;
 
-  constructor(
-    private labelFilter: LabelFilterService,
-    private viewService: ViewService
-  ) {}
+  constructor(private viewService: ViewService) {}
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes.view.currentValue) {
@@ -39,11 +36,6 @@ export class LabelsComponent implements OnChanges {
 
       this.title = this.viewService.viewTitleAsText(view);
       this.labels = view.config.labels;
-      this.labelKeys = Object.keys(this.labels);
     }
-  }
-
-  click(key: string, value: string) {
-    this.labelFilter.add({ key, value });
   }
 }

--- a/web/src/app/modules/shared/components/presentation/labels/labels.component.ts
+++ b/web/src/app/modules/shared/components/presentation/labels/labels.component.ts
@@ -4,7 +4,6 @@
 
 import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { LabelsView, View } from 'src/app/modules/shared/models/content';
-import { LabelFilterService } from 'src/app/modules/shared/services/label-filter/label-filter.service';
 import trackByIdentity from 'src/app/util/trackBy/trackByIdentity';
 import { ViewService } from '../../../services/view/view.service';
 

--- a/web/src/app/modules/shared/components/presentation/overflow-labels/overflow-labels.component.html
+++ b/web/src/app/modules/shared/components/presentation/overflow-labels/overflow-labels.component.html
@@ -1,0 +1,29 @@
+<div class="labels-wrapper" *ngIf="labels">
+  <ng-container *ngFor="let label of showLabels; trackBy: trackByIdentity">
+    <span
+      *ngFor="let item of label | keyvalue; trackBy: trackByIdentity"
+      class="label label-light-blue clickable"
+      (click)="filterLabel(item.key, item.value)">
+      {{ item.key }}:{{ item.value }}
+    </span>
+  </ng-container>
+
+  <clr-signpost>
+    <span
+      *ngIf="overflowLabels && overflowLabels.length > 0"
+      class="badge badge-light-blue"
+      clrSignpostTrigger>
+      {{ overflowLabels.length }}+
+    </span>
+    <clr-signpost-content *clrIfOpen>
+      <ng-container *ngFor="let label of overflowLabels; trackBy: trackByIdentity">
+        <span
+          *ngFor="let item of label | keyvalue; trackBy: trackByIdentity"
+          class="label label-light-blue clickable"
+          (click)="filterLabel(item.key, item.value)">
+          {{ item.key }}:{{ item.value }}
+        </span>
+      </ng-container>
+    </clr-signpost-content>
+  </clr-signpost> 
+</div>

--- a/web/src/app/modules/shared/components/presentation/overflow-labels/overflow-labels.component.html
+++ b/web/src/app/modules/shared/components/presentation/overflow-labels/overflow-labels.component.html
@@ -8,9 +8,8 @@
     </span>
   </ng-container>
 
-  <clr-signpost>
+  <clr-signpost *ngIf="overflowLabels && overflowLabels.length > 0">
     <span
-      *ngIf="overflowLabels && overflowLabels.length > 0"
       class="badge badge-light-blue"
       clrSignpostTrigger>
       {{ overflowLabels.length }}+

--- a/web/src/app/modules/shared/components/presentation/overflow-labels/overflow-labels.component.scss
+++ b/web/src/app/modules/shared/components/presentation/overflow-labels/overflow-labels.component.scss
@@ -1,0 +1,29 @@
+/* Copyright (c) 2019 the Octant contributors. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+ 
+.labels-wrapper {
+  display: flex;
+  align-items: center;
+  flex-wrap: nowrap;
+
+  .label.clickable {
+    cursor: pointer;
+  }
+}
+
+.signpost {
+  // Clarity's Signpost trigger has no padding, so this is to fix badge's padding.
+  .badge.badge-light-blue.signpost-trigger {
+    padding: 0 0.2rem;
+  }
+
+  // To avoid horizontal scroll-bar inside of the signpost content body.
+  ::ng-deep .signpost-wrap .signpost-content-body {
+    padding: 1rem;
+
+    .label:not(:last-child) {
+      margin-bottom: 0.2rem;
+    }
+  }
+}

--- a/web/src/app/modules/shared/components/presentation/overflow-labels/overflow-labels.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/overflow-labels/overflow-labels.component.spec.ts
@@ -1,0 +1,80 @@
+// Copyright (c) 2019 the Octant contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { OverflowLabelsComponent } from './overflow-labels.component';
+import { By } from '@angular/platform-browser';
+import { LabelFilterService } from '../../../services/label-filter/label-filter.service';
+
+describe('OverflowLabelsComponent', () => {
+  let component: OverflowLabelsComponent;
+  let fixture: ComponentFixture<OverflowLabelsComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [OverflowLabelsComponent],
+      providers: [LabelFilterService],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(OverflowLabelsComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should display only two labels with a +1 badge', () => {
+    component.labels = {
+      ['keyOne']: 'valueOne',
+      ['keyTwo']: 'valueTwo',
+      ['keyThree']: 'valueThree',
+    };
+    fixture.detectChanges();
+    const renderedLabels = document.getElementsByClassName('label');
+
+    expect(component.overflowLabels.length).toEqual(1);
+    expect(component.showLabels.length).toEqual(2);
+    expect(renderedLabels.length).toEqual(2);
+  });
+
+  it('should display all labels if the number is less or equal than the number to display', () => {
+    component.labels = {
+      ['keyOne']: 'valueOne',
+    };
+    fixture.detectChanges();
+    const renderedLabels = document.getElementsByClassName('label');
+
+    expect(component.overflowLabels).toBeUndefined();
+    expect(component.showLabels.length).toEqual(1);
+    expect(renderedLabels.length).toEqual(1);
+  });
+
+  it('should call addFilter method when clicking on a label', () => {
+    spyOn(component, 'filterLabel');
+    component.labels = {
+      ['keyOne']: 'valueOne',
+    };
+    fixture.detectChanges();
+    const firstLabel = fixture.debugElement.query(By.css('.label'))
+      .nativeElement;
+
+    firstLabel.click();
+    expect(component.filterLabel).toHaveBeenCalledWith('keyOne', 'valueOne');
+  });
+
+  it('should add the correct filter', () => {
+    const debugElement = fixture.debugElement;
+    const labelFilterService = debugElement.injector.get(LabelFilterService);
+    spyOn(labelFilterService, 'add');
+    component.filterLabel('keyOne', 'valueOne');
+
+    expect(labelFilterService.add).toHaveBeenCalledWith({
+      key: 'keyOne',
+      value: 'valueOne',
+    });
+  });
+});

--- a/web/src/app/modules/shared/components/presentation/overflow-labels/overflow-labels.component.ts
+++ b/web/src/app/modules/shared/components/presentation/overflow-labels/overflow-labels.component.ts
@@ -1,0 +1,47 @@
+// Copyright (c) 2019 the Octant contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import { Component, Input, OnInit } from '@angular/core';
+import trackByIdentity from 'src/app/util/trackBy/trackByIdentity';
+import { LabelFilterService } from '../../../services/label-filter/label-filter.service';
+
+interface Labels {
+  [key: string]: string;
+}
+
+@Component({
+  selector: 'app-overflow-labels',
+  templateUrl: './overflow-labels.component.html',
+  styleUrls: ['./overflow-labels.component.scss'],
+})
+export class OverflowLabelsComponent implements OnInit {
+  @Input() labels: Labels;
+  @Input() numberShownLabels = 2;
+
+  showLabels: Labels[];
+  overflowLabels: Labels[];
+  trackByIdentity = trackByIdentity;
+
+  ngOnInit() {
+    const labelsEntries = Object.entries({ ...this.labels });
+
+    if (this.numberShownLabels <= labelsEntries.length) {
+      this.showLabels = labelsEntries
+        .slice(0, this.numberShownLabels)
+        .map(label => ({ [label[0]]: label[1] }));
+
+      this.overflowLabels = labelsEntries
+        .slice(this.numberShownLabels)
+        .map(label => ({ [label[0]]: label[1] }));
+    } else {
+      this.showLabels = labelsEntries.map(label => ({ [label[0]]: label[1] }));
+    }
+  }
+
+  filterLabel(key: string, value: string) {
+    this.labelFilter.add({ key, value });
+  }
+
+  constructor(private labelFilter: LabelFilterService) {}
+}

--- a/web/src/app/modules/shared/components/presentation/overflow-labels/overflow-labels.component.ts
+++ b/web/src/app/modules/shared/components/presentation/overflow-labels/overflow-labels.component.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import trackByIdentity from 'src/app/util/trackBy/trackByIdentity';
 import { LabelFilterService } from '../../../services/label-filter/label-filter.service';
 
@@ -15,16 +15,11 @@ interface Labels {
   templateUrl: './overflow-labels.component.html',
   styleUrls: ['./overflow-labels.component.scss'],
 })
-export class OverflowLabelsComponent implements OnInit {
-  @Input() labels: Labels;
+export class OverflowLabelsComponent {
   @Input() numberShownLabels = 2;
-
-  showLabels: Labels[];
-  overflowLabels: Labels[];
-  trackByIdentity = trackByIdentity;
-
-  ngOnInit() {
-    const labelsEntries = Object.entries({ ...this.labels });
+  @Input() set labels(labels: Labels) {
+    this.labelList = labels;
+    const labelsEntries = Object.entries({ ...this.labelList });
 
     if (this.numberShownLabels <= labelsEntries.length) {
       this.showLabels = labelsEntries
@@ -38,6 +33,14 @@ export class OverflowLabelsComponent implements OnInit {
       this.showLabels = labelsEntries.map(label => ({ [label[0]]: label[1] }));
     }
   }
+  get labels(): Labels {
+    return this.labelList;
+  }
+
+  private labelList: Labels;
+  showLabels: Labels[];
+  overflowLabels: Labels[];
+  trackByIdentity = trackByIdentity;
 
   filterLabel(key: string, value: string) {
     this.labelFilter.add({ key, value });

--- a/web/src/app/modules/shared/shared.module.ts
+++ b/web/src/app/modules/shared/shared.module.ts
@@ -63,6 +63,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { MonacoEditorModule } from 'ng-monaco-editor';
 import { FormatPathPipe } from './pipes/formatpath/formatpath.pipe';
 import { RelativePipe } from './pipes/relative/relative.pipe';
+import { OverflowLabelsComponent } from './components/presentation/overflow-labels/overflow-labels.component';
 
 @NgModule({
   declarations: [
@@ -120,6 +121,7 @@ import { RelativePipe } from './pipes/relative/relative.pipe';
     TimestampComponent,
     TitleComponent,
     YamlComponent,
+    OverflowLabelsComponent,
   ],
   imports: [
     ClarityModule,
@@ -188,6 +190,7 @@ import { RelativePipe } from './pipes/relative/relative.pipe';
     TimestampComponent,
     TitleComponent,
     YamlComponent,
+    OverflowLabelsComponent,
   ],
 })
 export class SharedModule {}

--- a/web/src/styles.scss
+++ b/web/src/styles.scss
@@ -8,5 +8,20 @@
 @import './sass/mixins';
 @import './sass/variables';
 @import '~highlight.js/styles/github.css';
-@import "~@ng-select/ng-select/themes/default.theme.css";
+@import '~@ng-select/ng-select/themes/default.theme.css';
 
+/* Clarity's Datagrid overflow is hidden making impossible to display something 
+ * like a Signpost inside of it. This makes it possible.
+ */ 
+clr-datagrid .datagrid-outer-wrapper {
+  &, .datagrid-inner-wrapper {
+    &, .datagrid {
+      overflow: visible;
+    }
+  }
+}
+
+// Avoid Datagrid's header sticky position.
+.datagrid-table .datagrid-header {
+  position: initial;
+}


### PR DESCRIPTION
Signed-off-by: Nicolas Farruggia <nfarruggia@vmware.com>


**What this PR does / why we need it**:
Adopt the label overflow/badge pattern used in Clarity so when there are lots of labels or selectors, it doesn't make datagrid columns or cards much larger than they need to be anymore.

Before
![Before](https://user-images.githubusercontent.com/53268844/76216595-aade6100-61ef-11ea-9c25-1902db77f9bb.png)

After
![After](https://user-images.githubusercontent.com/53268844/76216613-b2056f00-61ef-11ea-8030-72b8673338c6.png)


**Which issue(s) this PR fixes**
- Fixes #636 

**Special notes for your reviewer**:
Had to make some changes to Clarity styles to allow this behaviour since datagrids don't allow overflow content.

**Release note**:
```
release-note
```
