### PR TITLE
Use timer for change detection based on relative time

### DIFF
--- a/web/src/app/modules/shared/components/presentation/indicator/indicator.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/indicator/indicator.component.spec.ts
@@ -60,7 +60,6 @@ describe('IndicatorComponent', () => {
     });
 
     it('does not show an indicator', () => {
-      console.log(element);
       expect(element.querySelector('app-indicator div.indicator')).toBeNull();
     });
   });

--- a/web/src/app/modules/shared/components/presentation/timestamp/timestamp.component.ts
+++ b/web/src/app/modules/shared/components/presentation/timestamp/timestamp.component.ts
@@ -2,7 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
+import {
+  Component,
+  Input,
+  OnChanges,
+  OnDestroy,
+  SimpleChanges,
+} from '@angular/core';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import LocalizedFormat from 'dayjs/plugin/localizedFormat';
@@ -13,7 +19,7 @@ import { TimestampView, View } from 'src/app/modules/shared/models/content';
   templateUrl: './timestamp.component.html',
   styleUrls: ['./timestamp.component.scss'],
 })
-export class TimestampComponent implements OnChanges {
+export class TimestampComponent implements OnChanges, OnDestroy {
   private v: TimestampView;
 
   @Input() set view(v: View) {
@@ -41,5 +47,9 @@ export class TimestampComponent implements OnChanges {
           .utc()
           .format('LLLL') + ' UTC';
     }
+  }
+
+  ngOnDestroy(): void {
+    this.timestamp = null;
   }
 }

--- a/web/src/app/modules/shared/pipes/relative/relative.pipe.spec.ts
+++ b/web/src/app/modules/shared/pipes/relative/relative.pipe.spec.ts
@@ -1,8 +1,41 @@
+/*
+ * Copyright (c) 2020 the Octant contributors. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { NgZone } from '@angular/core';
 import { RelativePipe } from './relative.pipe';
 
+class NgZoneMock {
+  runOutsideAngular(fn: () => void) {
+    return fn();
+  }
+  run(fn: () => void) {
+    return fn();
+  }
+}
+
 describe('RelativePipe', () => {
+  const pipe = new RelativePipe(null, new NgZoneMock() as NgZone);
+  const now = new Date(1583971407000);
+
   it('create an instance', () => {
-    const pipe = new RelativePipe();
     expect(pipe).toBeTruthy();
+  });
+
+  it('Transform to 0s', () => {
+    expect(pipe.transform(1583971407, now)).toEqual('0s');
+  });
+
+  it('Transform to 1m', () => {
+    expect(pipe.transform(1583971346, now)).toEqual('1m');
+  });
+
+  it('Transform to 1h', () => {
+    expect(pipe.transform(1583967806, now)).toEqual('1h');
+  });
+
+  it('Transform to 1d', () => {
+    expect(pipe.transform(1583885006, now)).toEqual('1d');
   });
 });


### PR DESCRIPTION
**What this PR does / why we need it**:
The recently added impure pipe currently runs each second for every timestamp display in datagrids.

For objects created less than a minute ago, change detection will still run each second. However, datagrids displaying objects in minutes/days/hours will have see performance gains by running change detection as needed with the longest detection interval at 1hr.

**Which issue(s) this PR fixes**
- Part of #671

