### PR TITLE
Sync monaco with octant theme loading

### DIFF
--- a/web/src/app/components/smart/home/home.component.spec.ts
+++ b/web/src/app/components/smart/home/home.component.spec.ts
@@ -1,20 +1,37 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { HomeComponent } from './home.component';
-import { MonacoEditorComponent, MonacoProviderService } from 'ng-monaco-editor';
+import {
+  MonacoEditorComponent,
+  MonacoProviderService,
+  MonacoEditorConfig,
+} from 'ng-monaco-editor';
+import { themeServiceStub } from 'src/app/testing/theme-service-stub';
+import { ThemeService } from 'src/app/modules/sugarloaf/components/smart/theme-switch/theme-switch.service';
 
 describe('HomeComponent', () => {
   let component: HomeComponent;
   let fixture: ComponentFixture<HomeComponent>;
+  let themeService: ThemeService;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      providers: [MonacoProviderService, MonacoEditorComponent],
+      providers: [
+        {
+          provide: ThemeService,
+          useValue: themeServiceStub,
+        },
+        MonacoProviderService,
+        MonacoEditorComponent,
+        MonacoEditorConfig,
+      ],
       declarations: [HomeComponent],
     }).compileComponents();
   }));
 
   beforeEach(() => {
+    themeService = TestBed.inject(ThemeService);
+
     fixture = TestBed.createComponent(HomeComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -22,5 +39,17 @@ describe('HomeComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should use themeService', () => {
+    expect(themeService.currentType()).toBe('light');
+  });
+
+  it('should load light theme when component mounts', () => {
+    spyOn(themeService, 'loadTheme');
+    component.ngOnInit();
+
+    expect(themeService.currentType()).toBe('light');
+    expect(themeService.loadTheme).toHaveBeenCalled();
   });
 });

--- a/web/src/app/components/smart/home/home.component.ts
+++ b/web/src/app/components/smart/home/home.component.ts
@@ -1,4 +1,6 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, Renderer2 } from '@angular/core';
+import { ThemeService } from 'src/app/modules/sugarloaf/components/smart/theme-switch/theme-switch.service';
+import { MonacoProviderService } from 'ng-monaco-editor';
 
 @Component({
   selector: 'app-home',
@@ -6,7 +8,13 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./home.component.sass'],
 })
 export class HomeComponent implements OnInit {
-  constructor() {}
+  constructor(
+    private monacoService: MonacoProviderService,
+    private renderer: Renderer2,
+    private themeService: ThemeService
+  ) {}
 
-  ngOnInit() {}
+  ngOnInit() {
+    this.themeService.loadTheme(this.monacoService, this.renderer);
+  }
 }

--- a/web/src/app/modules/shared/components/smart/editor/editor.component.ts
+++ b/web/src/app/modules/shared/components/smart/editor/editor.component.ts
@@ -5,10 +5,12 @@ SPDX-License-Identifier: Apache-2.0
 
 import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { EditorView, View } from 'src/app/modules/shared/models/content';
+import { ThemeService } from '../../../../sugarloaf/components/smart/theme-switch/theme-switch.service';
 
 interface Options {
   readOnly: boolean;
   language: string;
+  theme: string;
 }
 
 @Component({
@@ -30,7 +32,7 @@ export class EditorComponent implements OnChanges {
   value: string;
   options: Options;
 
-  constructor() {
+  constructor(private themeService: ThemeService) {
     this.options = {} as Options;
   }
 
@@ -40,6 +42,8 @@ export class EditorComponent implements OnChanges {
       this.value = view.config.value;
       this.options.readOnly = view.config.readOnly;
       this.options.language = view.config.language;
+      this.options.theme =
+        this.themeService.currentType() === 'dark' ? 'vs-dark' : 'vs';
     }
   }
 }

--- a/web/src/app/modules/sugarloaf/components/smart/theme-switch/theme-switch-button.component.html
+++ b/web/src/app/modules/sugarloaf/components/smart/theme-switch/theme-switch-button.component.html
@@ -1,6 +1,6 @@
 <div class="switch-button-container">
   <button id="switchButton" class="btn btn-link btn-inverse" (click)="switchTheme()">
-    <clr-icon [attr.shape]="isLightThemeEnabled() ? 'moon' : 'sun'"></clr-icon>
-    {{ isLightThemeEnabled() ? 'dark' : 'light' }}
+    <clr-icon [attr.shape]="lightThemeEnabled ? 'moon' : 'sun'"></clr-icon>
+    {{ lightThemeEnabled ? 'dark' : 'light' }}
   </button>
 </div>

--- a/web/src/app/modules/sugarloaf/components/smart/theme-switch/theme-switch-button.component.spec.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/theme-switch/theme-switch-button.component.spec.ts
@@ -32,50 +32,34 @@ describe('ThemeSwitchButtonComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should load light theme when component mounts if there is not a stored value', () => {
-    spyOn(component, 'loadTheme');
-    component.ngOnInit();
-
-    expect(component.themeType).toBe('light');
-    expect(component.loadTheme).toHaveBeenCalled();
-  });
-
-  it('should load right theme when component mounts if there is a stored value', () => {
-    spyOn(component, 'loadTheme');
-    localStorage.setItem('theme', 'dark');
-    component.ngOnInit();
-
-    expect(component.themeType).toBe('dark');
-    expect(component.loadTheme).toHaveBeenCalled();
-  });
-
   it('should indicate if the light theme is active or not', () => {
-    component.themeType = 'light';
-    expect(component.isLightThemeEnabled()).toBe(true);
+    component.lightThemeEnabled = true;
+    expect(component.lightThemeEnabled).toBe(true);
 
-    component.themeType = 'dark';
-    expect(component.isLightThemeEnabled()).toBe(false);
+    component.lightThemeEnabled = false;
+    expect(component.lightThemeEnabled).toBe(false);
   });
 
   it('should switch theme', () => {
-    component.themeType = 'light';
+    component.lightThemeEnabled = false;
+    localStorage.setItem('theme', 'dark');
     component.switchTheme();
 
-    expect(component.themeType).toBe('dark');
-    expect(localStorage.getItem('theme')).toBe('dark');
-
-    component.switchTheme();
-
-    expect(component.themeType).toBe('light');
     expect(localStorage.getItem('theme')).toBe('light');
+    expect(component.lightThemeEnabled).toBe(true);
+
+    component.switchTheme();
+
+    expect(localStorage.getItem('theme')).toBe('dark');
+    expect(component.lightThemeEnabled).toBe(false);
   });
 
   it('should render the right button', () => {
-    component.themeType = 'light';
+    component.lightThemeEnabled = true;
     fixture.detectChanges();
     const switchButton = fixture.debugElement.query(By.css('#switchButton'))
       .nativeElement;
 
-    expect(switchButton.innerHTML).toContain('dark');
+    expect(switchButton.innerHTML).toContain('light');
   });
 });

--- a/web/src/app/modules/sugarloaf/components/smart/theme-switch/theme-switch-button.component.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/theme-switch/theme-switch-button.component.ts
@@ -47,11 +47,6 @@ export class ThemeSwitchButtonComponent implements OnInit {
       this.renderer.removeClass(document.body, t.type)
     );
     this.renderer.addClass(document.body, theme.type);
-    if (this.isLightThemeEnabled()) {
-      this.monacoService.changeTheme('vs');
-    } else {
-      this.monacoService.changeTheme('vs-dark');
-    }
   }
 
   switchTheme() {

--- a/web/src/app/modules/sugarloaf/components/smart/theme-switch/theme-switch-button.component.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/theme-switch/theme-switch-button.component.ts
@@ -2,14 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 import { Component, OnInit, Renderer2 } from '@angular/core';
-import {
-  darkTheme,
-  defaultTheme,
-  lightTheme,
-  Theme,
-  ThemeService,
-  ThemeType,
-} from './theme-switch.service';
+import { ThemeService, ThemeType } from './theme-switch.service';
 import { MonacoProviderService } from 'ng-monaco-editor';
 
 @Component({
@@ -21,6 +14,8 @@ import { MonacoProviderService } from 'ng-monaco-editor';
 export class ThemeSwitchButtonComponent implements OnInit {
   themeType: ThemeType;
 
+  lightThemeEnabled: boolean;
+
   constructor(
     private themeService: ThemeService,
     private monacoService: MonacoProviderService,
@@ -29,38 +24,11 @@ export class ThemeSwitchButtonComponent implements OnInit {
 
   ngOnInit() {
     this.themeType = this.themeService.currentType();
-    this.loadTheme();
-  }
-
-  isLightThemeEnabled(): boolean {
-    // TODO: this should be in the theme service.
-    return this.themeType === 'light';
-  }
-
-  loadTheme() {
-    // TODO: this should be in the theme service.
-    const theme: Theme = this.isLightThemeEnabled() ? lightTheme : darkTheme;
-
-    this.themeService.loadCSS(theme.assetPath);
-
-    [darkTheme, lightTheme].forEach(t =>
-      this.renderer.removeClass(document.body, t.type)
-    );
-    this.renderer.addClass(document.body, theme.type);
+    this.lightThemeEnabled = this.themeService.isLightThemeEnabled();
   }
 
   switchTheme() {
-    // TODO: this should be in the theme service.
-    if (this.isLightThemeEnabled()) {
-      this.themeType = 'dark';
-      localStorage.setItem('theme', 'dark');
-      this.monacoService.changeTheme('vs-dark');
-    } else {
-      this.themeType = 'light';
-      localStorage.setItem('theme', 'light');
-      this.monacoService.changeTheme('vs');
-    }
-
-    this.loadTheme();
+    this.lightThemeEnabled = !this.lightThemeEnabled;
+    this.themeService.switchTheme(this.monacoService, this.renderer);
   }
 }

--- a/web/src/app/testing/theme-service-stub.ts
+++ b/web/src/app/testing/theme-service-stub.ts
@@ -5,4 +5,6 @@ import { ThemeService } from '../modules/sugarloaf/components/smart/theme-switch
 
 export const themeServiceStub: Partial<ThemeService> = {
   loadCSS: () => void 0,
+  loadTheme: () => void 0,
+  currentType: () => 'light',
 };


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR allows monaco to load the correct theme.

Moving the `loadCSS` function to the home component rather than the theme switcher button rendered later in the lifecycle fixes the flash of unstyled content.

**Which issue(s) this PR fixes**
- Fixes #763 
- Fixes #685 

**Release note**:
No release note added as it is a follow up item from #723 
