### PR TITLE
Use dynamic cache for objectstore get as fallback

### DIFF
--- a/internal/objectstore/dynamic_cache.go
+++ b/internal/objectstore/dynamic_cache.go
@@ -347,7 +347,11 @@ func (dc *DynamicCache) Get(ctx context.Context, key store.Key) (*unstructured.U
 	object, err := dc.getFromInformer(ctx, key)
 	if err != nil {
 		if kerrors.IsNotFound(err) {
-			return nil, nil
+			object, err := dc.getFromDynamicClient(ctx, key)
+			if err != nil {
+				return nil, err
+			}
+			return object, nil
 		}
 
 		return nil, err

--- a/internal/printer/persistentvolume.go
+++ b/internal/printer/persistentvolume.go
@@ -74,7 +74,7 @@ func PersistentVolumeHandler(ctx context.Context, pv *v1.PersistentVolume, optio
 	}
 
 	if err := pvh.Status(ctx, options); err != nil {
-		return nil, errors.Wrap(err, "print persisten volume claims")
+		return nil, errors.Wrap(err, "print persistent volume claims")
 	}
 
 	return obj.ToComponent(ctx, options)


### PR DESCRIPTION
**What this PR does / why we need it**:
Octant sometimes starts with a `volumes not found` error message on start before the dynamic cache can finish sync of objects. This PR allows the get method to also use DynamicClient similar to list.

Signed-off-by: GuessWhoSamFoo <foos@vmware.com>


