### PR TITLE
Use OnPush strategy for navigation component

### DIFF
--- a/web/src/app/modules/shared/components/presentation/datagrid/datagrid.component.ts
+++ b/web/src/app/modules/shared/components/presentation/datagrid/datagrid.component.ts
@@ -35,6 +35,8 @@ export class DatagridComponent implements OnChanges {
   lastUpdated: Date;
   filters: TableFilters;
 
+  private previousView: SimpleChanges;
+
   identifyRow = trackByIndex;
   identifyColumn = trackByIdentity;
   loading: boolean;
@@ -43,15 +45,22 @@ export class DatagridComponent implements OnChanges {
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes.view) {
-      this.title = this.viewService.viewTitleAsText(this.view);
+      if (
+        JSON.stringify(this.previousView) !==
+        JSON.stringify(changes.view.currentValue)
+      ) {
+        this.title = this.viewService.viewTitleAsText(this.view);
 
-      const current = changes.view.currentValue;
-      this.columns = current.config.columns.map(column => column.name);
-      this.rows = current.config.rows;
-      this.placeholder = current.config.emptyContent;
-      this.lastUpdated = new Date();
-      this.loading = current.config.loading;
-      this.filters = current.config.filters;
+        const current = changes.view.currentValue;
+        this.columns = current.config.columns.map(column => column.name);
+        this.rows = current.config.rows;
+        this.placeholder = current.config.emptyContent;
+        this.lastUpdated = new Date();
+        this.loading = current.config.loading;
+        this.filters = current.config.filters;
+
+        this.previousView = changes.view.currentValue;
+      }
     }
   }
 }

--- a/web/src/app/modules/shared/components/presentation/label-selector/label-selector.component.ts
+++ b/web/src/app/modules/shared/components/presentation/label-selector/label-selector.component.ts
@@ -12,6 +12,7 @@ import { LabelSelectorView, View } from 'src/app/modules/shared/models/content';
 })
 export class LabelSelectorComponent implements OnChanges {
   private v: LabelSelectorView;
+  private previousView: SimpleChanges;
 
   @Input() set view(v: View) {
     this.v = v as LabelSelectorView;
@@ -26,9 +27,16 @@ export class LabelSelectorComponent implements OnChanges {
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes.view.currentValue) {
-      const view = changes.view.currentValue as LabelSelectorView;
-      this.key = view.config.key;
-      this.value = view.config.value;
+      if (
+        JSON.stringify(this.previousView) !==
+        JSON.stringify(changes.view.currentValue)
+      ) {
+        const view = changes.view.currentValue as LabelSelectorView;
+        this.key = view.config.key;
+        this.value = view.config.value;
+
+        this.previousView = changes.view.currentValue;
+      }
     }
   }
 }

--- a/web/src/app/modules/shared/components/presentation/labels/labels.component.ts
+++ b/web/src/app/modules/shared/components/presentation/labels/labels.component.ts
@@ -14,6 +14,7 @@ import { ViewService } from '../../../services/view/view.service';
 })
 export class LabelsComponent implements OnChanges {
   private v: LabelsView;
+  private previousView: SimpleChanges;
 
   @Input() set view(v: View) {
     this.v = v as LabelsView;
@@ -31,10 +32,17 @@ export class LabelsComponent implements OnChanges {
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes.view.currentValue) {
-      const view = changes.view.currentValue as LabelsView;
+      if (
+        JSON.stringify(this.previousView) !==
+        JSON.stringify(changes.view.currentValue)
+      ) {
+        const view = changes.view.currentValue as LabelsView;
 
-      this.title = this.viewService.viewTitleAsText(view);
-      this.labels = view.config.labels;
+        this.title = this.viewService.viewTitleAsText(view);
+        this.labels = view.config.labels;
+
+        this.previousView = changes.view.currentValue;
+      }
     }
   }
 }

--- a/web/src/app/modules/sugarloaf/components/smart/container/container.component.html
+++ b/web/src/app/modules/sugarloaf/components/smart/container/container.component.html
@@ -21,6 +21,9 @@
     </header>
     <div class="content-container" [ngStyle]="style">
         <div class="navigation">
+            <div class="namespace-switcher">
+                <app-namespace></app-namespace>
+            </div>
             <app-navigation></app-navigation>
         </div>
         <div class="content-area">

--- a/web/src/app/modules/sugarloaf/components/smart/container/container.component.spec.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/container/container.component.spec.ts
@@ -17,6 +17,7 @@ import { NotifierComponent } from '../notifier/notifier.component';
 import { NavigationComponent } from '../navigation/navigation.component';
 import { ContextSelectorComponent } from '../../../../shared/components/smart/context-selector/context-selector.component';
 import { DefaultPipe } from '../../../../shared/pipes/default/default.pipe';
+import { FilterTextPipe } from '../../../pipes/filtertext/filtertext.pipe';
 import { NgSelectModule } from '@ng-select/ng-select';
 import { WebsocketService } from '../../../../shared/services/websocket/websocket.service';
 import { WebsocketServiceMock } from '../../../../shared/services/websocket/mock';
@@ -50,6 +51,7 @@ describe('AppComponent', () => {
         NavigationComponent,
         ContextSelectorComponent,
         DefaultPipe,
+        FilterTextPipe,
         ThemeSwitchButtonComponent,
         QuickSwitcherComponent,
       ],

--- a/web/src/app/modules/sugarloaf/components/smart/input-filter/input-filter.component.html
+++ b/web/src/app/modules/sugarloaf/components/smart/input-filter/input-filter.component.html
@@ -3,7 +3,7 @@
     <input
       clrInput
       class="text-input"
-      placeholder={{placeholderText}}
+      placeholder={{filters|filtertext}}
       name="input"
       [(ngModel)]="inputValue"
       (keyup.enter)="onEnter()"

--- a/web/src/app/modules/sugarloaf/components/smart/input-filter/input-filter.component.spec.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/input-filter/input-filter.component.spec.ts
@@ -12,6 +12,7 @@ import {
 import { BehaviorSubject } from 'rxjs';
 import { By } from '@angular/platform-browser';
 import { DebugElement } from '@angular/core';
+import { FilterTextPipe } from '../../../pipes/filtertext/filtertext.pipe';
 
 const labelFilterStub: Partial<LabelFilterService> = {
   filters: new BehaviorSubject<Filter[]>([]),
@@ -24,7 +25,7 @@ describe('InputFilterComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [FormsModule],
-      declarations: [InputFilterComponent],
+      declarations: [InputFilterComponent, FilterTextPipe],
       providers: [{ provide: LabelFilterService, useValue: labelFilterStub }],
     }).compileComponents();
   }));

--- a/web/src/app/modules/sugarloaf/components/smart/input-filter/input-filter.component.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/input-filter/input-filter.component.ts
@@ -63,14 +63,6 @@ export class InputFilterComponent implements OnInit, OnDestroy {
     this.labelFilterService.remove(filter);
   }
 
-  get placeholderText(): string {
-    if (this.filters && this.filters.length > 0) {
-      return `Filter by labels (${this.filters.length} applied)`;
-    } else {
-      return 'Filter by labels';
-    }
-  }
-
   onEnter() {
     const filter = this.labelFilterService.decodeFilter(this.inputValue);
     if (filter) {

--- a/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.html
+++ b/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.html
@@ -1,7 +1,3 @@
-<div class="namespace-switcher">
-    <app-namespace></app-namespace>
-</div>
-
 <clr-tree>
   <clr-tree-node
           *ngFor="let section of navigation.sections; trackBy: identifyNavigationItem"

--- a/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.ts
@@ -1,7 +1,13 @@
 // Copyright (c) 2019 the Octant contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import {
+  Component,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  OnDestroy,
+  OnInit,
+} from '@angular/core';
 import { BehaviorSubject, Subscription } from 'rxjs';
 import { Navigation, NavigationChild } from '../../../models/navigation';
 import { IconService } from '../../../../shared/services/icon/icon.service';
@@ -16,6 +22,7 @@ const emptyNavigation: Navigation = {
   selector: 'app-navigation',
   templateUrl: './navigation.component.html',
   styleUrls: ['./navigation.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class NavigationComponent implements OnInit, OnDestroy {
   behavior = new BehaviorSubject<Navigation>(emptyNavigation);
@@ -26,12 +33,18 @@ export class NavigationComponent implements OnInit, OnDestroy {
 
   constructor(
     private iconService: IconService,
-    private navigationService: NavigationService
+    private navigationService: NavigationService,
+    private cd: ChangeDetectorRef
   ) {}
 
   ngOnInit() {
     this.navigationSubscription = this.navigationService.current.subscribe(
-      navigation => (this.navigation = navigation)
+      navigation => {
+        if (this.navigation !== navigation) {
+          this.navigation = navigation;
+          this.cd.markForCheck();
+        }
+      }
     );
   }
 

--- a/web/src/app/modules/sugarloaf/pipes/filtertext/filtertext.pipe.spec.ts
+++ b/web/src/app/modules/sugarloaf/pipes/filtertext/filtertext.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { FilterTextPipe } from './filtertext.pipe';
+
+describe('FilterTextPipe', () => {
+  it('create an instance', () => {
+    const pipe = new FilterTextPipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/web/src/app/modules/sugarloaf/pipes/filtertext/filtertext.pipe.ts
+++ b/web/src/app/modules/sugarloaf/pipes/filtertext/filtertext.pipe.ts
@@ -1,0 +1,18 @@
+// Copyright (c) 2019 the Octant contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import { Pipe, PipeTransform } from '@angular/core';
+import { Filter } from '../../../shared/services/label-filter/label-filter.service';
+
+@Pipe({
+  name: 'filtertext',
+})
+export class FilterTextPipe implements PipeTransform {
+  transform(filters: Filter[]): string {
+    if (filters && filters.length > 0) {
+      return `Filter by labels (${filters.length} applied)`;
+    }
+    return 'Filter by labels';
+  }
+}

--- a/web/src/app/modules/sugarloaf/sugarloaf.module.ts
+++ b/web/src/app/modules/sugarloaf/sugarloaf.module.ts
@@ -16,6 +16,7 @@ import { NgSelectModule } from '@ng-select/ng-select';
 import { MarkdownModule, MarkedOptions } from 'ngx-markdown';
 import { SharedModule } from '../shared/shared.module';
 import { ContentComponent } from './components/smart/content/content.component';
+import { FilterTextPipe } from './pipes/filtertext/filtertext.pipe';
 
 const routes: Routes = [
   {
@@ -43,6 +44,7 @@ export class UnstripTrailingSlashLocation extends Location {
     ContentComponent,
     QuickSwitcherComponent,
     ThemeSwitchButtonComponent,
+    FilterTextPipe,
   ],
   imports: [
     CommonModule,


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR separates change detection of the navigation component from all other components. An OnPush strategy that detects updates to navigation will prevent the component from re-rendering each second.

**Which issue(s) this PR fixes**
- Part of #671 

**Special notes for your reviewer**:
`JSON.stringify` works as an object comparison operator because the order of keys are sorted from the backend. The namespace switcher is moved one level higher as namespace updates should be part of a separate change detection.

Signed-off-by: GuessWhoSamFoo <foos@vmware.com>
