### PR TITLE
Labels/selectors will no longer overflow their containers

### DIFF
--- a/web/src/app/modules/shared/components/presentation/overflow-labels/overflow-labels.component.html
+++ b/web/src/app/modules/shared/components/presentation/overflow-labels/overflow-labels.component.html
@@ -1,13 +1,16 @@
 <div class="labels-wrapper" *ngIf="labels">
-  <ng-container *ngFor="let label of showLabels; trackBy: trackByIdentity">
-    <span
-      *ngFor="let item of label | keyvalue; trackBy: trackByIdentity"
-      class="label label-light-blue clickable"
-      (click)="filterLabel(item.key, item.value)"
-    >
-      {{ item.key }}:{{ item.value }}
-    </span>
-  </ng-container>
+  <div class="labels-container">
+    <ng-container *ngFor="let label of showLabels; trackBy: trackByIdentity">
+        <span
+          *ngFor="let item of label | keyvalue; trackBy: trackByIdentity"
+          class="label label-light-blue clickable"
+          [title]="item.key+':'+item.value"
+          (click)="filterLabel(item.key, item.value)"
+        >
+          {{ item.key }}:{{ item.value }}
+        </span>
+    </ng-container>
+  </div>
 
   <clr-signpost *ngIf="overflowLabels && overflowLabels.length > 0">
     <span class="badge badge-light-blue" clrSignpostTrigger>

--- a/web/src/app/modules/shared/components/presentation/overflow-labels/overflow-labels.component.scss
+++ b/web/src/app/modules/shared/components/presentation/overflow-labels/overflow-labels.component.scss
@@ -1,15 +1,9 @@
 /* Copyright (c) 2019 the Octant contributors. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-
-.labels-wrapper {
-  display: flex;
-  align-items: center;
-  flex-wrap: nowrap;
-
-  .label.clickable {
-    cursor: pointer;
-  }
+ 
+.labels-wrapper .label.clickable {
+  cursor: pointer;
 }
 
 .signpost {

--- a/web/src/app/modules/shared/components/presentation/overflow-labels/overflow-labels.component.scss
+++ b/web/src/app/modules/shared/components/presentation/overflow-labels/overflow-labels.component.scss
@@ -1,9 +1,27 @@
 /* Copyright (c) 2019 the Octant contributors. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
- 
-.labels-wrapper .label.clickable {
-  cursor: pointer;
+
+.labels-wrapper {
+  display: flex;
+  align-items: center;
+
+  .labels-container {
+    display: grid;
+    grid-auto-flow: column;
+
+    .label {
+      display: inline-block;
+      line-height: 0.9rem;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+
+      &.clickable {
+        cursor: pointer;
+      }
+    }
+  }
 }
 
 .signpost {

--- a/web/src/styles.scss
+++ b/web/src/styles.scss
@@ -10,17 +10,6 @@
 @import '~highlight.js/styles/github.css';
 @import '~@ng-select/ng-select/themes/default.theme.css';
 
-/* Clarity's Datagrid overflow is hidden making impossible to display something 
- * like a Signpost inside of it. This makes it possible.
- */ 
-clr-datagrid .datagrid-outer-wrapper {
-  &, .datagrid-inner-wrapper {
-    &, .datagrid {
-      overflow: visible;
-    }
-  }
-}
-
 // Avoid Datagrid's header sticky position.
 .datagrid-table .datagrid-header {
   position: initial;


### PR DESCRIPTION
Signed-off-by: Nicolas Farruggia <nfarruggia@vmware.com>


**What this PR does / why we need it**:
Labels/selectors will no longer overflow their containers

**Which issue(s) this PR fixes**
- Fixes #770 

**Special notes for your reviewer**:
Datagrids cells will decide the best disposition for the labels inside of it depending of available size

**Release note**:
```
release-note
```
