### PR TITLE
Moved tooltips for timestamps to left if not enough space

### DIFF
--- a/changelogs/unreleased/715-bryanl
+++ b/changelogs/unreleased/715-bryanl
@@ -1,0 +1,1 @@
+Allow text components to show status indicators

--- a/changelogs/unreleased/715-bryanl
+++ b/changelogs/unreleased/715-bryanl
@@ -1,1 +1,0 @@
-Allow text components to show status indicators

--- a/changelogs/unreleased/779-mklanjsek
+++ b/changelogs/unreleased/779-mklanjsek
@@ -1,0 +1,1 @@
+Moved tooltip for timestamps to left side if not enough space

--- a/web/src/app/modules/shared/components/presentation/timestamp/timestamp.component.html
+++ b/web/src/app/modules/shared/components/presentation/timestamp/timestamp.component.html
@@ -1,6 +1,6 @@
 <clr-tooltip>
-  <span clrTooltipTrigger>{{ timestamp | relative }}</span>
-  <clr-tooltip-content clrPosition="right" clrSize="lg" *clrIfOpen>
+  <span  #timestampRef clrTooltipTrigger>{{ timestamp | relative }}</span>
+  <clr-tooltip-content [clrPosition]="tooltipPosition" clrSize="md" *clrIfOpen>
     <span>{{ humanReadable }}</span>
   </clr-tooltip-content>
 </clr-tooltip>

--- a/web/src/app/modules/shared/components/presentation/timestamp/timestamp.component.ts
+++ b/web/src/app/modules/shared/components/presentation/timestamp/timestamp.component.ts
@@ -57,7 +57,7 @@ export class TimestampComponent implements OnChanges, OnDestroy {
       this.humanReadable =
         dayjs(this.timestamp * 1000)
           .utc()
-          .format('LLLL') + ' UTC';
+          .format('llll') + ' UTC';
     }
   }
 

--- a/web/src/app/modules/shared/components/presentation/timestamp/timestamp.component.ts
+++ b/web/src/app/modules/shared/components/presentation/timestamp/timestamp.component.ts
@@ -4,10 +4,12 @@
 
 import {
   Component,
+  ElementRef,
   Input,
   OnChanges,
   OnDestroy,
   SimpleChanges,
+  ViewChild,
 } from '@angular/core';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
@@ -22,6 +24,7 @@ import { TimestampView, View } from 'src/app/modules/shared/models/content';
 export class TimestampComponent implements OnChanges, OnDestroy {
   private v: TimestampView;
 
+  @ViewChild('timestampRef', { static: true }) timestampRef: ElementRef;
   @Input() set view(v: View) {
     this.v = v as TimestampView;
   }
@@ -31,10 +34,19 @@ export class TimestampComponent implements OnChanges, OnDestroy {
 
   timestamp: number;
   humanReadable: string;
+  age: string;
 
   constructor() {
     dayjs.extend(utc);
     dayjs.extend(LocalizedFormat);
+  }
+
+  get tooltipPosition(): string {
+    const gutterWidth = 300;
+    const { nativeElement } = this.timestampRef;
+    const timestampLeft = nativeElement.getBoundingClientRect().left;
+
+    return timestampLeft > window.outerWidth - gutterWidth ? 'left' : 'right';
   }
 
   ngOnChanges(changes: SimpleChanges): void {


### PR DESCRIPTION
Make sure the timestamp tooltips fit inside the view.  They will now show up on the left side if necessary.

Note: Tooltips were quite huge so I also reduced the tooltips size from large to medium.