### PR TITLE
Add NG_CLI_ANALYTICS instructions to HACKING

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -13,9 +13,11 @@
 
     git clone git@github.com:vmware-tanzu/octant.git
     cd octant
-    go run build.go go-install  # install Go dependencies.
-    go run build.go ci-quick    # build UI, generate UI files, and create octant binary.
-    ./build/octant   # run the Octant binary you just built
+    go run build.go go-install      # install Go dependencies.
+    export NG_CLI_ANALYTICS=false   # if you want to disable Angular CLI analytics or
+    export NG_CLI_ANALYTICS=ci      # if you want to enable Angular CLI analytics
+    go run build.go ci-quick        # build UI, generate UI files, and create octant binary.
+    ./build/octant                  # run the Octant binary you just built
 
 ## Testing
 

--- a/changelogs/unreleased/792-dotNomad
+++ b/changelogs/unreleased/792-dotNomad
@@ -1,0 +1,1 @@
+Add NG_CLI_ANALYTICS instructions to HACKING


### PR DESCRIPTION
If NG_CLI_ANALYTICS is not set Angular CLI will ask about analytics
on install causing `npm ci` and therefor `go run build.go ci-quick`
to fail. Setting NG_CLI_ANALYTICS to either false or ci will fix this

Fixes #546

Signed-off-by: Jordan Jensen <jj016u@att.com>