### PR TITLE
Check for persistent volume before generating link

### DIFF
--- a/changelogs/unreleased/795-GuessWhoSamFoo
+++ b/changelogs/unreleased/795-GuessWhoSamFoo
@@ -1,0 +1,1 @@
+Fixed bug where pending PVCs prevents content from loading


### PR DESCRIPTION
**What this PR does / why we need it**:
Do not generate a link for persistent volume claims links until persistent volume can be found.

**Which issue(s) this PR fixes**
- Fixes #794 