### PR TITLE
Fix CRD conversion for navigation

### DIFF
--- a/changelogs/unreleased/796-GuessWhoSamFoo
+++ b/changelogs/unreleased/796-GuessWhoSamFoo
@@ -1,0 +1,1 @@
+Used json serialization instead of unstructured converter due to upstream int/float conversion failure


### PR DESCRIPTION
**What this PR does / why we need it**:
Related to #799

Although the previous `JSONObjectToYAMLObject` was merged, the core issue is still in upstream (https://github.com/kubernetes/kubernetes/issues/87675). Instead of using a forked unstructured converter, we should use a different method of conversion.

**Which issue(s) this PR fixes**
- Fixes #787 

