### PR TITLE
Fix tab error when service spec uses externalName

### DIFF
--- a/changelogs/unreleased/798-GuessWhoSamFoo
+++ b/changelogs/unreleased/798-GuessWhoSamFoo
@@ -1,0 +1,1 @@
+Fix tab errors when service spec uses externalName

--- a/internal/objectstatus/service_test.go
+++ b/internal/objectstatus/service_test.go
@@ -53,6 +53,17 @@ func Test_service(t *testing.T) {
 			},
 		},
 		{
+			name: "externalName",
+			init: func(t *testing.T, o *storefake.MockStore) runtime.Object {
+				objectFile := "service_external.yaml"
+				return testutil.LoadObjectFromFile(t, objectFile)
+			},
+			expected: ObjectStatus{
+				nodeStatus: component.NodeStatusOK,
+				Details:    []component.Component{component.NewText("Service is OK")},
+			},
+		},
+		{
 			name: "no endpoint subsets",
 			init: func(t *testing.T, o *storefake.MockStore) runtime.Object {
 				key := store.Key{

--- a/internal/objectstatus/testdata/service_external.yaml
+++ b/internal/objectstatus/testdata/service_external.yaml
@@ -1,0 +1,12 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: mysql
+  namespace: default
+spec:
+  ports:
+    - protocol: TCP
+      port: 3306
+      targetPort: 3306
+  type: ExternalName
+  externalName: host-to-external-mysql.com

--- a/internal/printer/service.go
+++ b/internal/printer/service.go
@@ -311,6 +311,10 @@ func createServiceEndpointsView(ctx context.Context, service *corev1.Service, op
 	cols := component.NewTableCols("Target", "IP", "Node Name")
 	table := component.NewTable("Endpoints", "There are no endpoints!", cols)
 
+	if service.Spec.ExternalName != "" {
+		return table, nil
+	}
+
 	object, err := o.Get(ctx, key)
 	if err != nil {
 		return nil, errors.Wrapf(err, "get endpoints for service %s", service.Name)


### PR DESCRIPTION
**What this PR does / why we need it**:
Services with `externalName` does not need to get an endpoint and should not cause tab errors as a result. There is potential to have a better story around object status in the future.

**Which issue(s) this PR fixes**
- Fixes #797 

