### PR TITLE
Extract creation of frontend/backend handlers

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -71,7 +71,7 @@ func serveAsJSON(w http.ResponseWriter, v interface{}, logger log.Logger) {
 
 // Service is an API service.
 type Service interface {
-	Handler(ctx context.Context) (*mux.Router, error)
+	Handler(ctx context.Context) (http.Handler, error)
 	ForceUpdate() error
 }
 
@@ -143,7 +143,7 @@ func (a *API) ForceUpdate() error {
 }
 
 // Handler returns a HTTP handler for the service.
-func (a *API) Handler(ctx context.Context) (*mux.Router, error) {
+func (a *API) Handler(ctx context.Context) (http.Handler, error) {
 	router := mux.NewRouter()
 	router.Use(rebindHandler(ctx, acceptedHosts()))
 

--- a/internal/api/fake/mock_service.go
+++ b/internal/api/fake/mock_service.go
@@ -7,7 +7,7 @@ package fake
 import (
 	context "context"
 	gomock "github.com/golang/mock/gomock"
-	mux "github.com/gorilla/mux"
+	http "net/http"
 	reflect "reflect"
 )
 
@@ -49,10 +49,10 @@ func (mr *MockServiceMockRecorder) ForceUpdate() *gomock.Call {
 }
 
 // Handler mocks base method
-func (m *MockService) Handler(arg0 context.Context) (*mux.Router, error) {
+func (m *MockService) Handler(arg0 context.Context) (http.Handler, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Handler", arg0)
-	ret0, _ := ret[0].(*mux.Router)
+	ret0, _ := ret[0].(http.Handler)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/octant/handler.go
+++ b/pkg/octant/handler.go
@@ -1,0 +1,110 @@
+/*
+ *  Copyright (c) 2020 the Octant contributors. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package octant
+
+import (
+	"context"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+
+	"github.com/gorilla/handlers"
+	"github.com/gorilla/mux"
+
+	"github.com/vmware-tanzu/octant/internal/api"
+	"github.com/vmware-tanzu/octant/internal/log"
+)
+
+// HandlerFactory is a factory that generate's Octant's HTTP handler. Octant has
+// a frontend and backend handler and they will both be populated in the
+// generated handler.
+type HandlerFactory struct {
+	frontendHandler func(ctx context.Context) (http.Handler, error)
+	backendHandler  func(ctx context.Context) (http.Handler, error)
+}
+
+// NewHandlerFactory creates an instance of HandlerFactory.
+func NewHandlerFactory(optionList ...Option) *HandlerFactory {
+	opts := buildOptions(optionList...)
+
+	hf := HandlerFactory{
+		frontendHandler: opts.frontendHandler,
+		backendHandler:  opts.backendHandler,
+	}
+
+	return &hf
+}
+
+// Handler returns an HTTP handler.
+func (hf *HandlerFactory) Handler(ctx context.Context) (http.Handler, error) {
+	router := mux.NewRouter()
+
+	backendHandler, err := hf.backendHandler(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	frontendHandler, err := hf.frontendHandler(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	router.PathPrefix(api.PathPrefix).Handler(backendHandler)
+
+	router.PathPrefix("/").Handler(frontendHandler)
+
+	allowedOrigins := handlers.AllowedOrigins([]string{"*"})
+	allowedHeaders := handlers.AllowedHeaders([]string{"Accept", "Accept-Language", "Content-Language", "Origin", "Content-Type"})
+	allowedMethods := handlers.AllowedMethods([]string{"GET", "HEAD", "POST", "PUT", "DELETE", "OPTIONS"})
+
+	return handlers.CORS(allowedOrigins, allowedHeaders, allowedMethods)(router), nil
+}
+
+// ProxiedFrontendHandler creates an HTTP handler that proxies to a target URL.
+type ProxiedFrontendHandler struct {
+	handler *httputil.ReverseProxy
+}
+
+var _ http.Handler = &ProxiedFrontendHandler{}
+
+// NewProxiedFrontend creates an instance of ProxiedFrontendHandler. It will return an
+// error if the proxy can not be created.
+func NewProxiedFrontend(ctx context.Context, targetURL string) (*ProxiedFrontendHandler, error) {
+	logger := log.From(ctx)
+	logger.With("proxy-url", targetURL).
+		Infof("Creating reverse proxy for Octant's frontend")
+
+	handler, err := createProxyTarget(targetURL)
+	if err != nil {
+		return nil, err
+	}
+
+	pf := ProxiedFrontendHandler{
+		handler: handler,
+	}
+
+	return &pf, nil
+}
+
+// ServeHTTP allows ProxiedFrontendHandler to satisfy the http.Handler interface.
+func (p ProxiedFrontendHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	p.handler.ServeHTTP(w, r)
+}
+
+func createProxyTarget(targetURL string) (*httputil.ReverseProxy, error) {
+	target, err := url.Parse(targetURL)
+	if err != nil {
+		return nil, err
+	}
+
+	if target.Scheme == "" {
+		target.Scheme = "http"
+	}
+
+	handler := httputil.NewSingleHostReverseProxy(target)
+	return handler, nil
+}

--- a/pkg/octant/handler_test.go
+++ b/pkg/octant/handler_test.go
@@ -1,0 +1,187 @@
+/*
+ *  Copyright (c) 2020 the Octant contributors. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package octant
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandlerFactory_Handler(t *testing.T) {
+	frontend := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "frontend")
+	})
+
+	backend := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "backend")
+	})
+
+	proxied := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "proxied")
+	})
+
+	proxiedTs := httptest.NewServer(proxied)
+	defer proxiedTs.Close()
+
+	tests := []struct {
+		name         string
+		options      []Option
+		wantFrontend string
+		wantBackend  string
+		wantErr      bool
+	}{
+		{
+			name: "wire backend and frontend by default",
+			options: []Option{
+				func(o *options) {
+					o.frontendHandler = func(ctx context.Context) (handler http.Handler, err error) {
+						return frontend, nil
+					}
+					o.backendHandler = func(ctx context.Context) (handler http.Handler, err error) {
+						return backend, nil
+					}
+				},
+			},
+			wantFrontend: "frontend",
+			wantBackend:  "backend",
+		},
+		{
+			name: "proxy frontend",
+			options: []Option{
+				func(o *options) {
+					o.backendHandler = func(ctx context.Context) (handler http.Handler, err error) {
+						return backend, nil
+					}
+				},
+				FrontendURL(proxiedTs.URL),
+			},
+			wantFrontend: "proxied",
+			wantBackend:  "backend",
+		},
+		{
+			name: "frontend factory returns an error",
+			options: []Option{
+				func(o *options) {
+					o.frontendHandler = func(ctx context.Context) (handler http.Handler, err error) {
+						return nil, fmt.Errorf("error")
+					}
+					o.backendHandler = func(ctx context.Context) (handler http.Handler, err error) {
+						return backend, nil
+					}
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "backend factory returns an error",
+			options: []Option{
+				func(o *options) {
+					o.frontendHandler = func(ctx context.Context) (handler http.Handler, err error) {
+						return frontend, nil
+					}
+					o.backendHandler = func(ctx context.Context) (handler http.Handler, err error) {
+						return nil, fmt.Errorf("error")
+					}
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			hf := NewHandlerFactory(test.options...)
+
+			ctx := context.Background()
+
+			h, err := hf.Handler(ctx)
+			if test.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			ts := httptest.NewServer(h)
+			defer ts.Close()
+
+			frontendPath := genTestURL(t, ts.URL, "/")
+			backendPath := genTestURL(t, ts.URL, "api", "v1", "foo")
+
+			resFrontend, err := http.Get(frontendPath)
+			require.NoError(t, err)
+
+			resBackend, err := http.Get(backendPath)
+			require.NoError(t, err)
+
+			require.Equal(t, test.wantFrontend, string(readFromCloser(t, resFrontend.Body)))
+			require.Equal(t, test.wantBackend, string(readFromCloser(t, resBackend.Body)))
+		})
+	}
+}
+
+func TestNewProxiedFrontend(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "content")
+	})
+
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	tests := []struct {
+		name      string
+		targetURL string
+		wantErr   bool
+	}{
+		{
+			name:      "in general",
+			targetURL: ts.URL,
+		},
+		{
+			name:      "URL without scheme",
+			targetURL: "example.com",
+		},
+		{
+			name:      "invalid URL",
+			targetURL: "%",
+			wantErr:   true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			_, err := NewProxiedFrontend(ctx, test.targetURL)
+			if test.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func readFromCloser(t *testing.T, rc io.ReadCloser) []byte {
+	data, err := ioutil.ReadAll(rc)
+	require.NoError(t, err)
+	return data
+}
+
+func genTestURL(t *testing.T, base string, parts ...string) string {
+	u, err := url.Parse(base)
+	require.NoError(t, err)
+
+	u.Path = path.Join(append([]string{u.Path}, parts...)...)
+	return u.String()
+}

--- a/pkg/octant/options.go
+++ b/pkg/octant/options.go
@@ -1,0 +1,77 @@
+/*
+ *  Copyright (c) 2020 the Octant contributors. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package octant
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/vmware-tanzu/octant/web"
+)
+
+// options is an internal set of options that can be used to configure Octant. These are
+// consolidated options so there is not a need to have a separate set of options
+// for multiple types. options is not exported as these options should be accessible from
+// outside of this package.
+type options struct {
+	// frontendHandler is a function that creates a frontend handler.
+	frontendHandler func(ctx context.Context) (http.Handler, error)
+	// backendHandler is a function that creates a backend handler.
+	backendHandler func(ctx context.Context) (http.Handler, error)
+}
+
+// buildOptions builds an options struct from a list of functional options.
+func buildOptions(list ...Option) options {
+	opts := options{
+		frontendHandler: defaultFrontendHandler,
+		backendHandler: func(ctx context.Context) (handler http.Handler, err error) {
+			return nil, fmt.Errorf("backend handler is not configured")
+		},
+	}
+
+	for _, o := range list {
+		o(&opts)
+	}
+
+	return opts
+}
+
+// Option is a functional option for configuring Octant.
+type Option func(o *options)
+
+// FrontendURL configures Octant to use a proxy for rendering its frontend.
+func FrontendURL(proxyURL string) Option {
+	return func(o *options) {
+		o.frontendHandler = func(ctx context.Context) (handler http.Handler, err error) {
+			if proxyURL == "" {
+				o.frontendHandler = defaultFrontendHandler
+				return
+			}
+
+			pfh, err := NewProxiedFrontend(ctx, proxyURL)
+			if err != nil {
+				return nil, err
+			}
+
+			return pfh, nil
+		}
+	}
+}
+
+// BackendHandler sets the handler for Octant's backend.
+func BackendHandler(fn func(ctx context.Context) (http.Handler, error)) Option {
+	return func(o *options) {
+		o.backendHandler = fn
+	}
+}
+
+// defaultFrontendHandler is the default factory for creating a frontend handler.
+// TODO: this namespace should not know about the web namespace.
+func defaultFrontendHandler(ctx context.Context) (http.Handler, error) {
+	return web.Handler()
+}


### PR DESCRIPTION
Signed-off-by: bryanl <bryanliles@gmail.com>

**What this PR does / why we need it**:

This change extracts the creation of Octant's frontend and backend
handlers from pkg/dash. It also introduces a new namespace,
github.com/vmware-octant/pkg/octant. This package will eventually become
the home for Octant's top-level domain objects.

A new options construct is introduced in `pkg/octant`. It's objective
is to persistent a consistent set of options that can be used to
configure Octant's behavior. In the initial version, fields for frontend
and backend HTTP handlers have been added.

This change is transitionary as its purpose to start the process of
detangling `pkg/dash`.

**Release note**:
```
Extract creation of frontend/backend handlers from dash init
```
