### PR TITLE
Ignore go build and doc main files

### DIFF
--- a/build.go
+++ b/build.go
@@ -1,3 +1,5 @@
+// +build ignore
+
 /*
 Copyright (c) 2019 the Octant contributors. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0

--- a/doc.go
+++ b/doc.go
@@ -1,1 +1,3 @@
+// +build ignore
+
 package octant


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds build ignore tags to `build.go` and `doc.go`

**Which issue(s) this PR fixes**
- Fixes #720 