### PR TITLE
Fix datagrid filtering

### DIFF
--- a/web/src/app/modules/shared/components/presentation/content-filter/content-filter.component.ts
+++ b/web/src/app/modules/shared/components/presentation/content-filter/content-filter.component.ts
@@ -35,15 +35,15 @@ export class ContentFilterComponent
       .filter(([_, value]) => value)
       .map(([key, _]) => key);
 
-    if (!row[this.column]) {
+    if (!row.data[this.column]) {
       return false;
     }
 
-    if (row[this.column].metadata.type !== 'text') {
+    if (row.data[this.column].metadata.type !== 'text') {
       return false;
     }
 
-    const view = row[this.column] as TextView;
+    const view = row.data[this.column] as TextView;
     return selected.includes(view.config.value);
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the content-filter component to access data key introduced by `TableRowWithMetadata` via 3f1604eb49e86e92f47a9fba82b103724d11741c. Currently filters (e.g. pod list by phase) will filter all data because the key does not exist.