### PR TITLE
load summary even if actions fail to load

### DIFF
--- a/changelogs/unreleased/831-wwitzel3
+++ b/changelogs/unreleased/831-wwitzel3
@@ -1,0 +1,1 @@
+Fix bug that prevented Pod summary loading if status was nil/unknown.

--- a/internal/printer/container_test.go
+++ b/internal/printer/container_test.go
@@ -364,7 +364,7 @@ func Test_ContainerConfiguration(t *testing.T) {
 				tpo.objectStore.EXPECT().Get(ctx, gomock.Eq(key)).Return(testutil.ToUnstructured(t, configMap), nil).AnyTimes()
 			}
 
-			cc := NewContainerConfiguration(ctx, parentPod, tc.container, pf, tc.isInit, printOptions)
+			cc := NewContainerConfiguration(ctx, parentPod, tc.container, pf, IsInit(tc.isInit), WithPrintOptions(printOptions))
 			summary, err := cc.Create()
 			if tc.isErr {
 				require.Error(t, err)

--- a/internal/printer/job_template.go
+++ b/internal/printer/job_template.go
@@ -51,7 +51,7 @@ func (jt *JobTemplate) AddToFlexLayout(fl *flexlayout.FlexLayout, options Option
 	containerSection := fl.AddSection()
 
 	for _, container := range jt.jobTemplateSpec.Spec.Template.Spec.Containers {
-		containerConfig := NewContainerConfiguration(jt.context, jt.parent, &container, portForwarder, false, options)
+		containerConfig := NewContainerConfiguration(jt.context, jt.parent, &container, portForwarder, IsInit(false), WithPrintOptions(options))
 		summary, err := containerConfig.Create()
 		if err != nil {
 			return err

--- a/internal/printer/pod.go
+++ b/internal/printer/pod.go
@@ -749,7 +749,7 @@ func (p *podHandler) Containers(ctx context.Context, options Options) error {
 
 func defaultPodContainers(ctx context.Context, pod *corev1.Pod, container *corev1.Container, isInit bool, options Options) (*component.Summary, error) {
 	portForwarder := options.DashConfig.PortForwarder()
-	creator := NewContainerConfiguration(ctx, pod, container, portForwarder, isInit, options)
+	creator := NewContainerConfiguration(ctx, pod, container, portForwarder, IsInit(isInit), WithPrintOptions(options))
 	return creator.Create()
 }
 

--- a/internal/printer/pod_template.go
+++ b/internal/printer/pod_template.go
@@ -109,7 +109,13 @@ func podTemplateContainers(ctx context.Context, fl *flexlayout.FlexLayout, optio
 	width := component.WidthHalf
 
 	for index, container := range options.containers {
-		containerConfig := NewContainerConfiguration(ctx, options.parent, &container, portForwarder, options.isInit, options.printOptions)
+		containerConfig := NewContainerConfiguration(
+			ctx, options.parent, &container, portForwarder,
+			IsInit(options.isInit),
+			WithPrintOptions(options.printOptions),
+			WithActions(editContainerAction),
+		)
+
 		summary, err := containerConfig.Create()
 		if err != nil {
 			return err


### PR DESCRIPTION
Signed-off-by: Wayne Witzel III <wayne@riotousliving.com>


**What this PR does / why we need it**:

Summary tab fails to load because generating actions will can the object path function which produces an error for disconnected pods.

https://github.com/vmware-tanzu/octant/blob/master/internal/printer/container.go#L508

Log and continue.

