### PR TITLE
error logging should be debug to avoid spam

### DIFF
--- a/internal/terminal/manager.go
+++ b/internal/terminal/manager.go
@@ -155,7 +155,7 @@ func (tm *manager) Create(ctx context.Context, logger log.Logger, key store.Key,
 		err = rc.Stream(opts)
 		if err != nil {
 			t.SetExitMessage(fmt.Sprintf("%s", err))
-			logger.Errorf("streaming: %+v", err)
+			logger.Debugf("streaming: %+v", err)
 		}
 		t.Stop()
 		logger.Debugf("stopping stream command")


### PR DESCRIPTION
Signed-off-by: Wayne Witzel III <wayne@riotousliving.com>


**What this PR does / why we need it**:
The terminal already displays the actually error. We don't need verbose output except for when debugging. This causes useless CLI terminal spam.

![image](https://user-images.githubusercontent.com/27317/78934642-48d87c00-7a79-11ea-9871-a8377dec45a5.png)
