### PR TITLE
Make heading anchors actually visible/usable

### DIFF
--- a/site/_includes/anchor_headings.html
+++ b/site/_includes/anchor_headings.html
@@ -1,6 +1,6 @@
 {% capture headingsWorkspace %}
   {% comment %}
-    Version 1.0.4
+    Version 1.0.6
       https://github.com/allejo/jekyll-anchor-headings
 
     "Be the pull request you wish to see in the world." ~Ben Balter
@@ -13,7 +13,8 @@
 
     Optional Parameters:
       * beforeHeading (bool)   : false  - Set to true if the anchor should be placed _before_ the heading's content
-      * anchorAttrs   (string) :  ''    - Any custom HTML attributes that will be added to the `<a>` tag; you may NOT use `href`, `class` or `title`
+      * anchorAttrs   (string) :  ''    - Any custom HTML attributes that will be added to the `<a>` tag; you may NOT use `href`, `class` or `title`;
+                                          the `%heading%` placeholder is available
       * anchorBody    (string) :  ''    - The content that will be placed inside the anchor; the `%heading%` placeholder is available
       * anchorClass   (string) :  ''    - The class(es) that will be used for each anchor. Separate multiple classes with a space
       * anchorTitle   (string) :  ''    - The `title` attribute that will be used for anchors
@@ -43,11 +44,15 @@
     {% assign nextChar = node | replace: '"', '' | strip | slice: 0, 1 %}
     {% assign headerLevel = nextChar | times: 1 %}
 
-    <!-- If the level is cast to 0, it means it's not a h1-h6 tag, so let's try to fix it -->
+    <!-- If the level is cast to 0, it means it's not a h1-h6 tag, so let's see if we need to fix it -->
     {% if headerLevel == 0 %}
-      {% if nextChar != '<' and nextChar != '' %}
+      <!-- Split up the node based on closing angle brackets and get the first one. -->
+      {% assign firstChunk = node | split: '>' | first %}
+
+      <!-- If the first chunk does NOT contain a '<', that means we've broken another HTML tag that starts with 'h' -->
+      {% unless firstChunk contains '<' %}
         {% capture node %}<h{{ node }}{% endcapture %}
-      {% endif %}
+      {% endunless %}
 
       {% capture edited_headings %}{{ edited_headings }}{{ node }}{% endcapture %}
       {% continue %}
@@ -76,7 +81,7 @@
       {% endif %}
 
       {% if include.anchorAttrs %}
-        {% capture anchor %}{{ anchor }} {{ include.anchorAttrs }}{% endcapture %}
+        {% capture anchor %}{{ anchor }} {{ include.anchorAttrs | replace: '%heading%', header }}{% endcapture %}
       {% endif %}
 
       {% capture anchor %}<a {{ anchor }}>{{ include.anchorBody | replace: '%heading%', header | default: '' }}</a>{% endcapture %}

--- a/site/_layouts/docs.html
+++ b/site/_layouts/docs.html
@@ -31,7 +31,12 @@
               </div>
               <div class="col-md-8">
               <div class="documentation-container">
-                {% include anchor_headings.html html=content %}
+                {% include anchor_headings.html
+                     html=content
+                     anchorClass="anchor-link"
+                     anchorBody='<i class="fas fa-link"></i><noscript>#</noscript>'
+                     anchorAttrs='aria-label="Link to &quot;%heading%&quot;"'
+                %}
               </div>
               </div>
             </div>

--- a/site/_scss/site/common/_type.scss
+++ b/site/_scss/site/common/_type.scss
@@ -6,6 +6,11 @@ h4,
 h5,
 h6 {
   font-weight: $font-weight-medium;
+
+  a.anchor-link {
+    font-size: 0.55em;
+    vertical-align: middle;
+  }
 }
 
 h1,


### PR DESCRIPTION
**What this PR does / why we need it**:

Greetings octant devs! I'm the author of `jekyll-anchor-headings` and I noticed that you're using my project in your Jekyll site; which is awesome! However, looks like there's nothing being rendered in the anchors themselves.

Like so:

![image](https://user-images.githubusercontent.com/1246453/78961352-09745480-7aa6-11ea-8108-389351142b9a.png)

I don't know *how* you wanted to design it, but here's a PR that adds some icons to the anchors. I also bumped the version of the snippet.

![image](https://user-images.githubusercontent.com/1246453/78961362-109b6280-7aa6-11ea-85c3-14ab8ad1d912.png)

**Which issue(s) this PR fixes**

None that I could find.

**Special notes for your reviewer**:

None.

**Release note**:

```
release-note
```
