### PR TITLE
continue if git tag -d returns error status

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -65,7 +65,7 @@ jobs:
       - name: Run goreleaser
         run: |
           git fetch --tags
-          git tag -d nightly
+          git tag -d nightly || :
           git tag nightly
           echo "$GOOGLE_APPLICATION_JSON" > /tmp/gs.json
           goreleaser -f .goreleaser-nightly.yml --rm-dist --skip-validate


### PR DESCRIPTION
Signed-off-by: Wayne Witzel III <wayne@riotousliving.com>


**What this PR does / why we need it**:

Deletes a nightly tag in the case when one has been created. In the case when one has not been created, the delete command will fail, this lets the following commands succeed.
