### PR TITLE
Remove setup-go path steps and bump setup-node versions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,17 +13,10 @@ jobs:
   go_linter:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v1
+      - uses: actions/setup-go@v2
         with:
-          go-version: 1.13.x
+          go-version: 1.14.x
       - uses: actions/checkout@v2
-      - name: Set GOPATH
-        # temporary fix
-        # see https://github.com/actions/setup-go/issues/14
-        run: |
-          echo "##[set-env name=GOPATH;]$(dirname $GITHUB_WORKSPACE)"
-          echo "##[add-path]$(dirname $GITHUB_WORKSPACE)/bin"
-        shell: bash
       - name: go vet
         env:
           GOFLAGS: -mod=vendor
@@ -32,7 +25,7 @@ jobs:
   eslint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-node@v1.1.0
+      - uses: actions/setup-node@v1
       - uses: actions/checkout@v2
       - name: eslint
         run: |

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -7,8 +7,8 @@ jobs:
     name: Build nightly
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-node@v1.1.0
-      - uses: actions/setup-go@v1
+      - uses: actions/setup-node@v1
+      - uses: actions/setup-go@v2
         with:
           go-version: '1.14'
       - uses: actions/checkout@v2
@@ -17,12 +17,6 @@ jobs:
           cd web
           npm ci
           npm run-script build
-      - name: Set GOPATH
-        # temporary fix
-        # see https://github.com/actions/setup-go/issues/14
-        run: |
-          echo "##[set-env name=GOPATH;]$(dirname $GITHUB_WORKSPACE)"
-          echo "##[add-path]$(dirname $GITHUB_WORKSPACE)/bin"
         shell: bash
       - name: Go tools
         env:

--- a/.github/workflows/preflight-checks.yaml
+++ b/.github/workflows/preflight-checks.yaml
@@ -21,17 +21,10 @@ jobs:
     runs-on: ${{ matrix.platform }}
     name: Golang tests on ${{ matrix.platform }}
     steps:
-      - uses: actions/setup-go@v1
+      - uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go-version }}
       - uses: actions/checkout@v2
-      - name: Set GOPATH
-        # temporary fix
-        # see https://github.com/actions/setup-go/issues/14
-        run: |
-          echo "##[set-env name=GOPATH;]$(dirname $GITHUB_WORKSPACE)"
-          echo "##[add-path]$(dirname $GITHUB_WORKSPACE)/bin"
-        shell: bash
       - name: run_go_tests
         env:
           GOFLAGS: -mod=vendor
@@ -42,17 +35,10 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v1
+      - uses: actions/setup-go@v2
         with:
           go-version: 1.14.x
       - uses: actions/checkout@v2
-      - name: Set GOPATH
-        # temporary fix
-        # see https://github.com/actions/setup-go/issues/14
-        run: |
-          echo "##[set-env name=GOPATH;]$(dirname $GITHUB_WORKSPACE)"
-          echo "##[add-path]$(dirname $GITHUB_WORKSPACE)/bin"
-        shell: bash
       - name: Get tag
         run: echo ::set-env name=GITHUB_TAG::${GITHUB_REF/refs\/tags\//}
       - name: Verify tag
@@ -67,7 +53,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     name: Karma tests on ${{ matrix.platform }}
     steps:
-      - uses: actions/setup-node@v1.1.0
+      - uses: actions/setup-node@v1
       - uses: actions/checkout@v2
       - name: run_karma
         run: |
@@ -85,8 +71,8 @@ jobs:
     runs-on: ${{ matrix.platform }}
     name: Build on ${{ matrix.platform }}
     steps:
-      - uses: actions/setup-node@v1.1.0
-      - uses: actions/setup-go@v1
+      - uses: actions/setup-node@v1
+      - uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go-version }}
       - uses: actions/checkout@v2
@@ -95,12 +81,6 @@ jobs:
           cd web
           npm ci
           npm run-script build
-      - name: Set GOPATH
-        # temporary fix
-        # see https://github.com/actions/setup-go/issues/14
-        run: |
-          echo "##[set-env name=GOPATH;]$(dirname $GITHUB_WORKSPACE)"
-          echo "##[add-path]$(dirname $GITHUB_WORKSPACE)/bin"
         shell: bash
       - name: Go tools
         env:

--- a/.github/workflows/verify-generated.yaml
+++ b/.github/workflows/verify-generated.yaml
@@ -14,18 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2
         with:
-          go-version: 1.13.x
+          go-version: 1.14.x
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Set GOPATH
-        # temporary fix
-        # see https://github.com/actions/setup-go/issues/14
-        run: |
-          echo "##[set-env name=GOPATH;]$(dirname $GITHUB_WORKSPACE)"
-          echo "##[add-path]$(dirname $GITHUB_WORKSPACE)/bin"
-        shell: bash
       - name: Verify generated code
         run: ci/check-generated-mocks.sh
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Simplifies github actions config. Unpins the minor version from setup-node so it can take advantage of download retries (https://github.com/actions/setup-node/commit/83c9f7a7df54d6b57455f7c57ac414f2ae5fb8de).

**Which issue(s) this PR fixes**
- Fixes #821

