### PR TITLE
Fixed logs console errors when timestamp are not present

### DIFF
--- a/changelogs/unreleased/840-mklanjsek
+++ b/changelogs/unreleased/840-mklanjsek
@@ -1,0 +1,1 @@
+Fixed logs console errors when timestamp are not present

--- a/web/src/app/modules/shared/components/smart/logs/logs.component.scss
+++ b/web/src/app/modules/shared/components/smart/logs/logs.component.scss
@@ -3,6 +3,8 @@
  */
 
 .app-logs {
+  height: calc(100% - 140px);
+
   .log-actions {
     display: flex;
     margin-top: 16px;
@@ -65,6 +67,7 @@
     }
   }
   .container-logs {
+    height: 100%;
     border: 1px solid #ccc;
     border-radius: 4px;
     background-color: var(--clr-color-neutral-100);

--- a/web/src/app/modules/shared/components/smart/logs/logs.component.ts
+++ b/web/src/app/modules/shared/components/smart/logs/logs.component.ts
@@ -194,9 +194,7 @@ export class LogsComponent
         return logs.filter(
           log =>
             log.message.match(new RegExp(this.filterText, 'g')) ||
-            formatDate(log.timestamp, this.timeFormat, 'en-US').match(
-              new RegExp(this.filterText, 'g')
-            )
+            this.filterTimestamp(log)
         );
       }
       return logs.filter(log =>
@@ -269,14 +267,20 @@ export class LogsComponent
         count += (log.message.match(new RegExp(this.filterText, 'g')) || [])
           .length;
         if (this.shouldDisplayTimestamp) {
-          count += (
-            formatDate(log.timestamp, this.timeFormat, 'en-US').match(
-              new RegExp(this.filterText, 'g')
-            ) || []
-          ).length;
+          count += (this.filterTimestamp(log) || []).length;
         }
       });
     }
     this.totalSelections = count;
+  }
+
+  public filterTimestamp(log: LogEntry) {
+    if (!log.timestamp) {
+      return [];
+    }
+    const timestamp = formatDate(log.timestamp, this.timeFormat, 'en-US');
+    return timestamp && timestamp.length > 0
+      ? timestamp.match(new RegExp(this.filterText, 'g'))
+      : [];
   }
 }


### PR DESCRIPTION
Signed-off-by: Milan Klanjsek <mklanjsek@pivotal.io>
Added checks to make sure we handle absence of timestamps properly.  
While there, fixed the log container size to be same as container regardless of number of log entries. 

**Which issue(s) this PR fixes**
- Fixes #840

