### PR TITLE
Fixed truncation issues with namespace and context selectors

### DIFF
--- a/changelogs/unreleased/737-mklanjsek
+++ b/changelogs/unreleased/737-mklanjsek
@@ -1,0 +1,1 @@
+Fixed truncation issues with namespace and context selectors

--- a/web/src/app/modules/shared/components/smart/context-selector/context-selector.component.html
+++ b/web/src/app/modules/shared/components/smart/context-selector/context-selector.component.html
@@ -2,17 +2,18 @@
 </ng-container>
 
 <ng-template #contextMenu>
-  <clr-dropdown [clrCloseMenuOnItemClick]="true">
-    <button type="button" clrDropdownTrigger>
+  <clr-dropdown class= "dropdown-top" [clrCloseMenuOnItemClick]="true">
+    <button class="dropdown-button" type="button" clrDropdownTrigger>
       <clr-icon shape="cluster"></clr-icon>
       {{ selected }}
       <clr-icon shape="caret down"></clr-icon>
     </button>
-    <clr-dropdown-menu *clrIfOpen [clrPosition]="'bottom-right'">
+    <clr-dropdown-menu class="dropdown-top" *clrIfOpen [clrPosition]="'bottom-right'">
       <label class="dropdown-header">Contexts</label>
 
       <ng-container *ngFor="let context of contexts; trackBy: trackByFn">
         <button
+          class="dropdown-button"
           type="button"
           [ngClass]="contextClass(context)"
           clrDropdownItem

--- a/web/src/app/modules/shared/components/smart/context-selector/context-selector.component.scss
+++ b/web/src/app/modules/shared/components/smart/context-selector/context-selector.component.scss
@@ -1,6 +1,16 @@
 /* Copyright (c) 2019 the Octant contributors. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+.dropdown-top {
+  max-width: 10rem;
+}
+
+.dropdown-button {
+  max-width: 9rem;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  padding: 0.15rem 0.4rem 0.15rem 1rem;
+}
 
 .dropdown > .dropdown-toggle {
   line-height: 2.5rem;

--- a/web/src/app/modules/sugarloaf/components/smart/container/container.component.scss
+++ b/web/src/app/modules/sugarloaf/components/smart/container/container.component.scss
@@ -21,6 +21,8 @@
 
   .header {
     background: var(--navigation-background-color);
+    flex-wrap: wrap;
+    height: auto;
 
     .header-nav {
       padding-left: 1rem;

--- a/web/src/app/modules/sugarloaf/components/smart/namespace/namespace.component.html
+++ b/web/src/app/modules/sugarloaf/components/smart/namespace/namespace.component.html
@@ -1,16 +1,17 @@
 <div class="app-namespace-selector">
   <ng-template [ngIf]="showDropdown()" [ngIfElse]="hideDropdown">
-    <clr-dropdown [clrCloseMenuOnItemClick]="true">
-      <button type="button" clrDropdownTrigger>
+    <clr-dropdown class= "dropdown-top" [clrCloseMenuOnItemClick]="true">
+      <button type="button" class="dropdown-button" clrDropdownTrigger>
         <clr-icon shape="namespace"></clr-icon>
       {{ currentNamespace }}
         <clr-icon shape="caret down"></clr-icon>
       </button>
-      <clr-dropdown-menu *clrIfOpen [clrPosition]="'bottom-right'">
+      <clr-dropdown-menu class= "dropdown-top" *clrIfOpen [clrPosition]="'bottom-right'">
         <label class="dropdown-header">Namespaces</label>
         <ng-container *ngFor="let namespace of namespaces;trackBy: trackByIdentity">
           <button
             type="button"
+            class="dropdown-button"
             [ngClass]="namespaceClass(namespace)"
             clrDropdownItem
             (click)="selectNamespace(namespace)">

--- a/web/src/app/modules/sugarloaf/components/smart/namespace/namespace.component.scss
+++ b/web/src/app/modules/sugarloaf/components/smart/namespace/namespace.component.scss
@@ -2,6 +2,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+.dropdown-top {
+  max-width: 10rem;
+}
+
+.dropdown-button {
+  max-width: 9rem;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  padding: 0.15rem 0.4rem 0.15rem 1rem;
+}
+
 .dropdown > .dropdown-toggle {
   line-height: 2.5rem;
   color: white;

--- a/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.scss
+++ b/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.scss
@@ -109,16 +109,18 @@
 
   .flyout {
     display: flex;
-    border: 1px solid var(--navigation-border-color);
+    border-color: var(--navigation-border-color);
+    border-style: solid;
+    border-width: 0px 1px 1px 1px;
     border-radius: 0px 4px 4px 0px;
     flex-direction: column;
     z-index: 502;
     position: fixed;
-    margin-top: -31px;
+    margin-top: -30px;
     margin-left: 48px;
     background-color: var(--flyout-background-color, #1b2a32);
     color: var(--flyout-color);
-    padding: 0px 0px 0px 0px;
+    padding: 0px;
   }
 
   .tooltip-override {


### PR DESCRIPTION
Improved header layout to address truncation issues with long names or small screen sizes.

Signed-off-by: Milan Klanjsek <mklanjsek@pivotal.io>

**What this PR does / why we need it**:
- Limit context selector size, use ellipses for long selector names,
- Same treatment for the namespace selector,
- Make header break into two rows for smaller screens,
- Improved navigation flyout sizing, 


**Which issue(s) this PR fixes**
- Fixes #737

