### PR TITLE
Decrease link latency

### DIFF
--- a/web/src/app/app.module.ts
+++ b/web/src/app/app.module.ts
@@ -4,13 +4,14 @@
 import { Location } from '@angular/common';
 import { HttpClientModule } from '@angular/common/http';
 import { Injectable, NgModule } from '@angular/core';
-import { RouterModule } from '@angular/router';
+import { RouteReuseStrategy, RouterModule } from '@angular/router';
 import { HomeComponent } from './components/smart/home/home.component';
 import { AppRoutingModule } from './app-routing.module';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { highlightProvider } from './modules/shared/highlight';
 import { MonacoEditorModule, MonacoProviderService } from 'ng-monaco-editor';
+import { ComponentReuseStrategy } from './modules/shared/component-reuse.strategy';
 
 @Injectable()
 export class UnstripTrailingSlashLocation extends Location {
@@ -41,6 +42,7 @@ export class UnstripTrailingSlashLocation extends Location {
       useClass: UnstripTrailingSlashLocation,
     },
     highlightProvider(),
+    { provide: RouteReuseStrategy, useClass: ComponentReuseStrategy },
   ],
   bootstrap: [HomeComponent],
 })

--- a/web/src/app/modules/shared/component-reuse.strategy.ts
+++ b/web/src/app/modules/shared/component-reuse.strategy.ts
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2020 the Octant contributors. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+import {
+  ActivatedRouteSnapshot,
+  DetachedRouteHandle,
+  RouteReuseStrategy,
+} from '@angular/router';
+
+const genKey = (r: ActivatedRouteSnapshot) => {
+  return `${r.url.join('/')}`;
+};
+
+export class ComponentReuseStrategy implements RouteReuseStrategy {
+  store(route: ActivatedRouteSnapshot, handle: DetachedRouteHandle): void {}
+
+  retrieve(route: ActivatedRouteSnapshot): DetachedRouteHandle {
+    return null;
+  }
+  shouldAttach(route: ActivatedRouteSnapshot): boolean {
+    return false;
+  }
+
+  shouldDetach(route: ActivatedRouteSnapshot): boolean {
+    return false;
+  }
+
+  /**
+   * if navigating between tabs, reuse the route
+   *
+   * @param future future route
+   * @param curr current route
+   */
+  shouldReuseRoute(
+    future: ActivatedRouteSnapshot,
+    curr: ActivatedRouteSnapshot
+  ): boolean {
+    return genKey(future) === genKey(curr);
+  }
+}

--- a/web/src/app/modules/shared/components/presentation/link/link.component.html
+++ b/web/src/app/modules/shared/components/presentation/link/link.component.html
@@ -1,5 +1,5 @@
 <ng-template [ngIf]="isAbsolute" [ngIfElse]="relative">
-  <a href="{{ ref }}">{{ value }}</a>
+  <a [routerLink]="ref">{{ value }}</a>
 </ng-template>
 
 <ng-template #relative>

--- a/web/src/app/modules/sugarloaf/components/smart/content/content.component.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/content/content.component.ts
@@ -11,12 +11,12 @@ import {
 } from '@angular/core';
 import { Params, Router, UrlSegment } from '@angular/router';
 import {
+  ButtonGroupView,
   ContentResponse,
   ExtensionView,
-  View,
-  ButtonGroupView,
-  PathItem,
   LinkView,
+  PathItem,
+  View,
 } from 'src/app/modules/shared/models/content';
 import { IconService } from '../../../../shared/services/icon/icon.service';
 import { ContentService } from '../../../../shared/services/content/content.service';


### PR DESCRIPTION
**What this PR does / why we need it**:

This change does the following:
* stops Angular from reloading the whole page when clicking links
* reuses content component when navigating between tabs
* removes superfluous navigation when content path changes
* attempts to be smarter about detecting content path changes


**Release note**:
```
Decrease latency when clicking on links
```
