### PR TITLE
Avoid multiple change detections with different values from pipe

### DIFF
--- a/web/src/app/modules/shared/components/presentation/timestamp/timestamp.component.ts
+++ b/web/src/app/modules/shared/components/presentation/timestamp/timestamp.component.ts
@@ -10,6 +10,7 @@ import {
   OnDestroy,
   SimpleChanges,
   ViewChild,
+  ChangeDetectionStrategy,
 } from '@angular/core';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
@@ -20,6 +21,7 @@ import { TimestampView, View } from 'src/app/modules/shared/models/content';
   selector: 'app-view-timestamp',
   templateUrl: './timestamp.component.html',
   styleUrls: ['./timestamp.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TimestampComponent implements OnChanges, OnDestroy {
   private v: TimestampView;

--- a/web/src/app/modules/shared/pipes/relative/relative.pipe.ts
+++ b/web/src/app/modules/shared/pipes/relative/relative.pipe.ts
@@ -77,7 +77,7 @@ export class RelativePipe implements PipeTransform, OnDestroy {
   private changeDetectionFrequency(seconds: number) {
     switch (true) {
       case seconds < 60:
-        return 2;
+        return 1;
       case seconds < 3600:
         return 60;
       case seconds < 86400:


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes `Expression has changed after it was checked` type errors in console.

