### PR TITLE
Fixed issues with custom resource breadcrumbs

### DIFF
--- a/changelogs/unreleased/855-mklanjsek
+++ b/changelogs/unreleased/855-mklanjsek
@@ -1,0 +1,1 @@
+Fixed issues with custom resource breadcrumbs

--- a/internal/describer/crd.go
+++ b/internal/describer/crd.go
@@ -8,7 +8,6 @@ package describer
 import (
 	"context"
 	"fmt"
-
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -104,12 +103,7 @@ func (c *crd) Describe(ctx context.Context, namespace string, options Options) (
 	if object == nil {
 		return component.EmptyContentResponse, err
 	}
-
-	title := component.Title(
-		component.NewText("Custom Resources"),
-		component.NewText(crd.GetName()),
-		component.NewText(object.GroupVersionKind().Version),
-		component.NewText(object.GetName()))
+	title := getCrdTitle(namespace, crd, object.GetName())
 
 	iconName, iconSource := loadIcon(icon.CustomResourceDefinition)
 	cr := component.NewContentResponse(title)

--- a/internal/describer/crd_list.go
+++ b/internal/describer/crd_list.go
@@ -63,10 +63,7 @@ func (cld *crdList) Describe(ctx context.Context, namespace string, options Opti
 	}
 	view.SetAccessor("summary")
 
-	title := component.Title(
-		component.NewLink("", "Cluster Overview", "/cluster-overview"),
-		component.NewLink("", "Custom Resources", "/cluster-overview/custom-resources"),
-		component.NewText(crd.GetName()))
+	title := getCrdTitle(namespace, crd, "")
 
 	contentResponse := component.NewContentResponse(title)
 	contentResponse.Add(view)

--- a/internal/describer/crd_section.go
+++ b/internal/describer/crd_section.go
@@ -7,7 +7,6 @@ package describer
 
 import (
 	"context"
-	"path"
 	"sort"
 	"sync"
 
@@ -103,12 +102,7 @@ func (csd *CRDSection) Describe(ctx context.Context, namespace string, options O
 			if count > 0 {
 				row := component.TableRow{}
 
-				ref := path.Join("/overview/namespace", namespace, "custom-resources", crd.GetName())
-				if namespace == "" {
-					ref = path.Join("/cluster-overview/custom-resources", crd.GetName())
-				}
-
-				row["Name"] = component.NewLink("", crd.GetName(), ref)
+				row["Name"] = component.NewLink("", crd.GetName(), getCrdUrl(namespace, crd))
 				row["Labels"] = component.NewLabels(crd.GetLabels())
 				row["Age"] = component.NewTimestamp(crd.GetCreationTimestamp().Time)
 

--- a/internal/describer/objects.go
+++ b/internal/describer/objects.go
@@ -50,7 +50,7 @@ func initNamespacedCRD() *CRDSection {
 	return NewCRDSection(
 		"/custom-resources",
 		"Custom Resources",
-		ResourceLink{Title: "Workloads", Url: "/overview/namespace/($NAMESPACE)/workloads"},
+		ResourceLink{Title: "Overview", Url: "/overview/namespace/($NAMESPACE)"},
 	)
 }
 

--- a/internal/describer/resource.go
+++ b/internal/describer/resource.go
@@ -8,6 +8,7 @@ package describer
 import (
 	"context"
 	"fmt"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"path"
 	"reflect"
 	"strings"
@@ -120,6 +121,33 @@ func getBreadcrumb(rootPath ResourceLink, objectTitle string, objectUrl string, 
 	}
 	title = append(title, component.NewLink("", objectTitle, objectUrl))
 	return title
+}
+
+func getCrdTitle(namespace string, crd *unstructured.Unstructured, objectName string) []component.TitleComponent {
+	var title []component.TitleComponent
+	if namespace == "" {
+		title= component.Title(component.NewLink("", "Cluster Overview", "/cluster-overview"),
+			component.NewLink("", "Custom Resources", "/cluster-overview/custom-resources"))
+	} else {
+		title = component.Title(component.NewLink("", "Overview", "/overview/namespace/"+namespace),
+			component.NewLink("", "Custom Resources", "/overview/namespace/"+namespace+"/custom-resources"))
+	}
+
+	if objectName == "" {
+		title= append(title, component.NewText(crd.GetName()))
+	} else {
+		title= append(title, component.NewLink("", crd.GetName(), getCrdUrl(namespace, crd)))
+		title= append(title, component.NewText(objectName))
+	}
+	return title
+}
+
+func getCrdUrl(namespace string, crd *unstructured.Unstructured) string {
+	ref := path.Join("/overview/namespace", namespace, "custom-resources", crd.GetName())
+	if namespace == "" {
+		ref = path.Join("/cluster-overview/custom-resources", crd.GetName())
+	}
+	return ref
 }
 
 func loadIcon(name string) (string, string) {

--- a/web/src/app/modules/shared/components/presentation/breadcrumb/breadcrumb.component.html
+++ b/web/src/app/modules/shared/components/presentation/breadcrumb/breadcrumb.component.html
@@ -12,7 +12,7 @@
         <clr-icon shape="angle" class="separator"></clr-icon>
       </ng-template>
       <ng-template #withoutLink>
-        <span>
+        <span class="breadcrumb-span">
         {{ breadcrumb.title }}
         </span>
       </ng-template>

--- a/web/src/app/modules/shared/components/presentation/breadcrumb/breadcrumb.component.scss
+++ b/web/src/app/modules/shared/components/presentation/breadcrumb/breadcrumb.component.scss
@@ -5,11 +5,16 @@
 .breadcrumb {
   &-body {
     display: flex;
+    flex-wrap: wrap;
   }
 
   &-header {
     margin-top: 0.2rem;
     line-height: 1.8rem;
+  }
+
+  &-span {
+    padding-right: 0.5rem;
   }
 
   .separator {


### PR DESCRIPTION
Signed-off-by: Milan Klanjsek <mklanjsek@pivotal.io>

**What this PR does / why we need it**:
Fixed problems with breadcrumbs rendering for both namespaced and cluster specific CRDs.

Note that in order to distinguish namespaced and cluster specific CRDs, breadcrumbs can be up to 4 levels deep.

**Which issue(s) this PR fixes**
- Fixes #855
