### PR TITLE
Fixed initial active tab to use first tab if url fragment is missing

### DIFF
--- a/changelogs/unreleased/868-GuessWhoSamFoo
+++ b/changelogs/unreleased/868-GuessWhoSamFoo
@@ -1,0 +1,2 @@
+Fixed initial active tab to use first tab if url fragment is missing
+

--- a/web/src/app/modules/shared/components/presentation/tabs/tabs.component.ts
+++ b/web/src/app/modules/shared/components/presentation/tabs/tabs.component.ts
@@ -56,6 +56,8 @@ export class TabsComponent implements OnChanges, OnInit {
     const { fragment } = this.activatedRoute.snapshot;
     if (fragment) {
       this.activeTab = fragment;
+    } else {
+      this.activeTab = this.tabs[0]?.accessor;
     }
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Initial loading of tabs no longer has a fragment so the UI will need to set active by index.

**Which issue(s) this PR fixes**
- Fixes #867 

