### PR TITLE
Logging UI improvements

### DIFF
--- a/web/src/app/modules/shared/components/smart/logs/logs.component.spec.ts
+++ b/web/src/app/modules/shared/components/smart/logs/logs.component.spec.ts
@@ -75,6 +75,34 @@ describe('LogsComponent', () => {
     const selectHighlights: DebugElement[] = fixture.debugElement.queryAll(
       By.css('.highlight')
     );
+    expect(selectHighlights.length).toEqual(75);
+    expect(selectHighlights[0].nativeElement.innerText).toEqual('test');
+  });
+
+  it('should filter for positive lookahead regex', () => {
+    component.filterText = '(?=Just)';
+    component.shouldDisplayTimestamp = false;
+    component.containerLogs = addLogsToList([]);
+    fixture.detectChanges();
+
+    const selectHighlights: DebugElement[] = fixture.debugElement.queryAll(
+      By.css('.highlight')
+    );
+    expect(selectHighlights.length).toEqual(15);
+    expect(selectHighlights[0].nativeElement.innerText).toEqual(
+      'Just for test'
+    );
+  });
+
+  it('should filter case insensitive', () => {
+    component.filterText = 'JUST';
+    component.shouldDisplayTimestamp = false;
+    component.containerLogs = addLogsToList([]);
+    fixture.detectChanges();
+
+    const selectHighlights: DebugElement[] = fixture.debugElement.queryAll(
+      By.css('.highlight')
+    );
     expect(selectHighlights.length).toEqual(15);
     expect(selectHighlights[0].nativeElement.innerText).toEqual('Just');
   });


### PR DESCRIPTION
Signed-off-by: Milan Klanjsek <mklanjsek@pivotal.io>

**What this PR does / why we need it**:
A few small Logging UI improvements:
- Added filtering support for positive lookahead regex expressions (#856),
- Filtering and search are now case insensitive (#871),
- Showing timestamps is now off by default (#872),
- It's now possible to search/filter on container names,  

**Which issue(s) this PR fixes**
- Fixes #856, #871, #872

**Special notes for your reviewer**:
Note on lookahead regex support: since lookahead regex expressions only assert the existence and start of the matched block, there is a difficulty in determining the end of the selection, so it will highlight text to the end of the current section.
