### PR TITLE
fix: layout MarkdownText better in tables/cards

### DIFF
--- a/web/src/styles.scss
+++ b/web/src/styles.scss
@@ -18,3 +18,8 @@
 .clr-vertical-nav .nav-btn {
   display: none;
 }
+
+// avoid markdown text rendering badly in table/cards
+.datagrid-cell .markdown p, .card-block .markdown p {
+  margin-top: 0;
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

fixes layout so that a `component.NewMarkdownText` can be used in a table cell or card value

**Which issue(s) this PR fixes**
- Fixes #
#882
