### PR TITLE
Fixed case where unclaimed persistent volume causes panic

### DIFF
--- a/changelogs/unreleased/889-GuessWhoSamFoo
+++ b/changelogs/unreleased/889-GuessWhoSamFoo
@@ -1,0 +1,1 @@
+Fixed case where unclaimed persistent volumes causes panic

--- a/internal/printer/persistentvolume.go
+++ b/internal/printer/persistentvolume.go
@@ -213,6 +213,10 @@ func getBoundPersistentVolumeClaim(ctx context.Context, pv *corev1.PersistentVol
 	pvc := &corev1.PersistentVolumeClaim{}
 
 	cr := pv.Spec.ClaimRef
+	if cr == nil {
+		return nil, nil
+	}
+
 	key := store.Key{
 		APIVersion: cr.APIVersion,
 		Kind:       cr.Kind,
@@ -244,6 +248,9 @@ func createBoundPersistentVolumeClaimLink(ctx context.Context, pv *corev1.Persis
 	}
 
 	cr := pv.Spec.ClaimRef
+	if cr == nil {
+		return component.NewLink("", "", ""), nil
+	}
 	claimText := fmt.Sprintf("%s/%s", cr.Namespace, cr.Name)
 	claimLink, err := options.Link.ForObject(pvc, claimText)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Persistent volumes with nil claimRef should return an empty link.

**Which issue(s) this PR fixes**
- Fixes #880

