### PR TITLE
Tooltips for labels and selectors

### DIFF
--- a/changelogs/unreleased/884-mklanjsek
+++ b/changelogs/unreleased/884-mklanjsek
@@ -1,0 +1,1 @@
+Added tooltips for selectors and labels

--- a/web/src/app/modules/shared/components/presentation/overflow-labels/overflow-labels.component.html
+++ b/web/src/app/modules/shared/components/presentation/overflow-labels/overflow-labels.component.html
@@ -1,14 +1,18 @@
 <div class="labels-wrapper" *ngIf="labels">
   <div class="labels-container">
     <ng-container *ngFor="let label of showLabels; trackBy: trackByIdentity">
-        <span
-          *ngFor="let item of label | keyvalue; trackBy: trackByIdentity"
-          class="label label-light-blue clickable"
-          [title]="item.key+':'+item.value"
-          (click)="filterLabel(item.key, item.value)"
+      <ng-container *ngFor="let item of label | keyvalue; trackBy: trackByIdentity">
+        <span class="tooltip tooltip-wrapper tooltip-md"
         >
-          {{ item.key }}:{{ item.value }}
+          <span
+            class="label label-light-blue clickable"
+            (click)="filterLabel(item.key, item.value)"
+          >
+            {{ item.key }}:{{ item.value }}
+          </span>
+          <span class="tooltip-content" [ngStyle]="{'margin-top': getScrollPos()}">{{ item.key }}:{{ item.value }}</span>
         </span>
+      </ng-container>
     </ng-container>
   </div>
 

--- a/web/src/app/modules/shared/components/presentation/overflow-labels/overflow-labels.component.scss
+++ b/web/src/app/modules/shared/components/presentation/overflow-labels/overflow-labels.component.scss
@@ -2,6 +2,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+@import '../../../../../../styles';
+
 .labels-wrapper {
   display: flex;
   align-items: center;
@@ -10,12 +12,19 @@
     display: grid;
     grid-auto-flow: column;
 
+    .tooltip-wrapper {
+      margin: 0 .3rem 0 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
     .label {
       display: inline-block;
       line-height: 0.9rem;
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
+      width: 100%;
 
       &.clickable {
         cursor: pointer;

--- a/web/src/app/modules/shared/components/presentation/overflow-labels/overflow-labels.component.ts
+++ b/web/src/app/modules/shared/components/presentation/overflow-labels/overflow-labels.component.ts
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import trackByIdentity from 'src/app/util/trackBy/trackByIdentity';
 import { LabelFilterService } from '../../../services/label-filter/label-filter.service';
+import { ContentService } from '../../../services/content/content.service';
+import { Subscription } from 'rxjs';
 
 interface Labels {
   [key: string]: string;
@@ -15,7 +17,7 @@ interface Labels {
   templateUrl: './overflow-labels.component.html',
   styleUrls: ['./overflow-labels.component.scss'],
 })
-export class OverflowLabelsComponent {
+export class OverflowLabelsComponent implements OnInit, OnDestroy {
   @Input() numberShownLabels = 2;
   @Input() set labels(labels: Labels) {
     this.labelList = labels;
@@ -41,10 +43,31 @@ export class OverflowLabelsComponent {
   showLabels: Labels[];
   overflowLabels: Labels[];
   trackByIdentity = trackByIdentity;
+  scrollPosition = 0;
+  private contentSubscription: Subscription;
 
   filterLabel(key: string, value: string) {
     this.labelFilter.add({ key, value });
   }
 
-  constructor(private labelFilter: LabelFilterService) {}
+  constructor(
+    private labelFilter: LabelFilterService,
+    private contentService: ContentService
+  ) {}
+
+  ngOnInit() {
+    this.contentSubscription = this.contentService.viewScrollPos.subscribe(
+      position => {
+        this.scrollPosition = position;
+      }
+    );
+  }
+
+  ngOnDestroy() {
+    this.contentSubscription.unsubscribe();
+  }
+
+  getScrollPos() {
+    return `${-this.scrollPosition - 64}px`;
+  }
 }

--- a/web/src/app/modules/shared/components/presentation/overflow-selectors/overflow-selectors.component.html
+++ b/web/src/app/modules/shared/components/presentation/overflow-selectors/overflow-selectors.component.html
@@ -1,8 +1,11 @@
 <div class="selectors-wrapper" *ngIf="selectors">
   <div class="selectors-container">
     <ng-container *ngFor="let selector of showSelectors; trackBy: trackByIdentity">
-      <span class="label label-orange">
-        {{ selector.config.key }}:{{ selector.config.value }}
+      <span class="tooltip tooltip-wrapper tooltip-md">
+        <span class="label label-orange">
+          {{ selector.config.key }}:{{ selector.config.value }}
+        </span>
+        <span class="tooltip-content" [ngStyle]="{'margin-top': getScrollPos()}">{{ selector.config.key }}:{{ selector.config.value }}</span>
       </span>
     </ng-container>
   </div>

--- a/web/src/app/modules/shared/components/presentation/overflow-selectors/overflow-selectors.component.scss
+++ b/web/src/app/modules/shared/components/presentation/overflow-selectors/overflow-selectors.component.scss
@@ -2,6 +2,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+@import '../../../../../../styles';
+
 .selectors-wrapper {
   display: flex;
   align-items: center;
@@ -10,12 +12,19 @@
     display: grid;
     grid-auto-flow: column;
 
+    .tooltip-wrapper {
+      margin: 0 .3rem 0 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
     .label {
       display: inline-block;
       line-height: 0.9rem;
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
+      width: 100%;
 
       &.clickable {
         cursor: pointer;

--- a/web/src/app/modules/shared/components/presentation/overflow-selectors/overflow-selectors.component.ts
+++ b/web/src/app/modules/shared/components/presentation/overflow-selectors/overflow-selectors.component.ts
@@ -56,7 +56,6 @@ export class OverflowSelectorsComponent implements OnInit, OnDestroy {
     this.contentSubscription = this.contentService.viewScrollPos.subscribe(
       position => {
         this.scrollPosition = position;
-        console.log('POSITION ->>', position);
       }
     );
   }

--- a/web/src/app/modules/shared/components/presentation/overflow-selectors/overflow-selectors.component.ts
+++ b/web/src/app/modules/shared/components/presentation/overflow-selectors/overflow-selectors.component.ts
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import trackByIdentity from 'src/app/util/trackBy/trackByIdentity';
+import { ContentService } from '../../../services/content/content.service';
+import { Subscription } from 'rxjs';
 
 interface Selector {
   metadata: {
@@ -20,7 +22,7 @@ interface Selector {
   templateUrl: './overflow-selectors.component.html',
   styleUrls: ['./overflow-selectors.component.scss'],
 })
-export class OverflowSelectorsComponent {
+export class OverflowSelectorsComponent implements OnInit, OnDestroy {
   @Input() numberShownSelectors = 2;
   @Input() set selectors(selectors: Selector[]) {
     this.selectorsList = selectors;
@@ -45,4 +47,25 @@ export class OverflowSelectorsComponent {
   showSelectors: Selector[];
   overflowSelectors: Selector[];
   trackByIdentity = trackByIdentity;
+  scrollPosition = 0;
+  private contentSubscription: Subscription;
+
+  constructor(private contentService: ContentService) {}
+
+  ngOnInit() {
+    this.contentSubscription = this.contentService.viewScrollPos.subscribe(
+      position => {
+        this.scrollPosition = position;
+        console.log('POSITION ->>', position);
+      }
+    );
+  }
+
+  ngOnDestroy() {
+    this.contentSubscription.unsubscribe();
+  }
+
+  getScrollPos() {
+    return `${-this.scrollPosition - 64}px`;
+  }
 }

--- a/web/src/app/modules/shared/components/presentation/overflow-selectors/overflow-selectors.component.ts
+++ b/web/src/app/modules/shared/components/presentation/overflow-selectors/overflow-selectors.component.ts
@@ -2,7 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import {
+  AfterViewChecked,
+  Component,
+  ElementRef,
+  Input,
+  OnDestroy,
+  OnInit,
+  ViewChild,
+} from '@angular/core';
 import trackByIdentity from 'src/app/util/trackBy/trackByIdentity';
 import { ContentService } from '../../../services/content/content.service';
 import { Subscription } from 'rxjs';
@@ -22,11 +30,32 @@ interface Selector {
   templateUrl: './overflow-selectors.component.html',
   styleUrls: ['./overflow-selectors.component.scss'],
 })
-export class OverflowSelectorsComponent implements OnInit, OnDestroy {
-  @Input() numberShownSelectors = 2;
+export class OverflowSelectorsComponent
+  implements OnInit, OnDestroy, AfterViewChecked {
   @Input() set selectors(selectors: Selector[]) {
     this.selectorsList = selectors;
+    this.updateSelectors();
+  }
 
+  get selectors(): Selector[] {
+    return this.selectorsList;
+  }
+
+  constructor(
+    private contentService: ContentService,
+    private rootElement: ElementRef
+  ) {}
+  @Input() numberShownSelectors = 2;
+
+  private selectorsList: Selector[];
+  showSelectors: Selector[];
+  overflowSelectors: Selector[];
+  trackByIdentity = trackByIdentity;
+  scrollPosition = 0;
+  private contentSubscription: Subscription;
+  componentWidth = 0;
+
+  private updateSelectors() {
     if (this.numberShownSelectors <= this.selectorsList.length) {
       this.showSelectors = this.selectorsList.slice(
         0,
@@ -39,18 +68,6 @@ export class OverflowSelectorsComponent implements OnInit, OnDestroy {
       this.showSelectors = this.selectorsList;
     }
   }
-  get selectors(): Selector[] {
-    return this.selectorsList;
-  }
-
-  private selectorsList: Selector[];
-  showSelectors: Selector[];
-  overflowSelectors: Selector[];
-  trackByIdentity = trackByIdentity;
-  scrollPosition = 0;
-  private contentSubscription: Subscription;
-
-  constructor(private contentService: ContentService) {}
 
   ngOnInit() {
     this.contentSubscription = this.contentService.viewScrollPos.subscribe(
@@ -62,6 +79,15 @@ export class OverflowSelectorsComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     this.contentSubscription.unsubscribe();
+  }
+
+  ngAfterViewChecked(): void {
+    if (this.componentWidth !== this.rootElement.nativeElement.clientWidth) {
+      this.numberShownSelectors =
+        this.rootElement.nativeElement.clientWidth > 150 ? 2 : 1;
+      this.updateSelectors();
+      this.componentWidth = this.rootElement.nativeElement.clientWidth;
+    }
   }
 
   getScrollPos() {

--- a/web/src/app/modules/shared/services/content/content.service.ts
+++ b/web/src/app/modules/shared/services/content/content.service.ts
@@ -88,6 +88,7 @@ export class ContentService {
   }
 
   setContentPath(contentPath: string, params: Params) {
+    this.viewScrollPos.next(0);
     if (contentPath === this.previousContentPath) {
       return;
     }

--- a/web/src/app/modules/shared/services/content/content.service.ts
+++ b/web/src/app/modules/shared/services/content/content.service.ts
@@ -34,6 +34,7 @@ const emptyContentResponse: ContentResponse = {
 export class ContentService {
   defaultPath = new BehaviorSubject<string>('');
   current = new BehaviorSubject<ContentResponse>(emptyContentResponse);
+  viewScrollPos = new BehaviorSubject<number>(0);
 
   private previousContentPath = '';
 
@@ -107,5 +108,9 @@ export class ContentService {
       content,
     };
     this.current.next(contentResponse);
+  }
+
+  setScrollPos(pos: number) {
+    this.viewScrollPos.next(pos);
   }
 }

--- a/web/src/app/modules/sugarloaf/components/smart/content/content.component.html
+++ b/web/src/app/modules/sugarloaf/components/smart/content/content.component.html
@@ -1,4 +1,4 @@
-<div clrFocusOnViewInit class="content-component">
+<div clrFocusOnViewInit class="content-component" (scroll)="onScroll($event)">
   <ng-container *ngIf="hasReceivedContent">
     <ng-container
       *ngIf="hasTabs; then withTabs; else withoutTabs"

--- a/web/src/app/modules/sugarloaf/components/smart/content/content.component.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/content/content.component.ts
@@ -132,4 +132,8 @@ export class ContentComponent implements OnInit, OnDestroy {
     this.hasReceivedContent = true;
     this.iconName = this.iconService.load(contentResponse.content);
   };
+
+  onScroll(event) {
+    this.contentService.setScrollPos(event.target.scrollTop);
+  }
 }

--- a/web/src/sass/_variables.scss
+++ b/web/src/sass/_variables.scss
@@ -6,10 +6,14 @@
 :host-context(body) {
   --label-color: #0065ab;
   --selector-color: #00968b;
+  --selection-color: var(--clr-color-neutral-400);
+  --tooltip-text-color: black;
 }
 
 // Color variables for Dark Theme.
 :host-context(body.dark) {
   --label-color: #49afd9;
   --selector-color: #00968b;
+  --selection-color: #324f62;
+  --tooltip-text-color: #EAEDEF;
 }

--- a/web/src/styles.scss
+++ b/web/src/styles.scss
@@ -23,3 +23,26 @@
 .datagrid-cell .markdown p, .card-block .markdown p {
   margin-top: 0;
 }
+
+// work around clarity tooltip limitations
+.tooltip-content {
+  color: var(--tooltip-text-color)!important;
+  background-color: var(--selection-color)!important;
+  z-index: 503;
+  position: fixed;
+  bottom: unset;
+  left: unset;
+  right: unset;
+  top: unset;
+  margin-top: -64px;
+  margin-left: 32px;
+  width: auto!important;
+  height: auto;
+  transition: opacity 0.5s 0.25s ease-in;
+  padding: 6px 9px;
+}
+
+.tooltip-content:before {
+  border-left-color: var(--selection-color)!important;
+  border-top-color: var(--selection-color)!important;
+}

--- a/web/src/styles.scss
+++ b/web/src/styles.scss
@@ -28,6 +28,7 @@
 .tooltip-content {
   color: var(--tooltip-text-color)!important;
   background-color: var(--selection-color)!important;
+  display: block;
   z-index: 503;
   position: fixed;
   bottom: unset;


### PR DESCRIPTION
Signed-off-by: Milan Klanjsek <mklanjsek@pivotal.io>


**What this PR does / why we need it**:
Added proper tooltips for selectors and labels. Found a pretty good way to work around Clarity tooltip/grid limitations.  The tooltips are necessary after we started using ellipses to shorten the labels.
 
**Which issue(s) this PR fixes**
- Fixes #884

