### PR TITLE
Add GitHub links to team member list

### DIFF
--- a/site/_contributors/01-bryan-liles.md
+++ b/site/_contributors/01-bryan-liles.md
@@ -2,5 +2,6 @@
 first_name: Bryan 
 last_name: Liles
 image: /img/contributors/bryan-liles.jpg
+github_handle: bryanl
 ---
 Engineer

--- a/site/_contributors/02-sam-foo.md
+++ b/site/_contributors/02-sam-foo.md
@@ -2,5 +2,6 @@
 first_name: Sam
 last_name: Foo
 image: /img/contributors/sam-foo.jpg
+github_handle: GuessWhoSamFoo
 ---
 Engineer

--- a/site/_contributors/03-wayne-witzel-iii.md
+++ b/site/_contributors/03-wayne-witzel-iii.md
@@ -2,5 +2,6 @@
 first_name: Wayne
 last_name: Witzel III
 image: /img/contributors/wayne-witzel-iii.jpg
+github_handle: wwitzel3
 ---
 Engineer

--- a/site/_contributors/04-milan-klanjsek.md
+++ b/site/_contributors/04-milan-klanjsek.md
@@ -2,5 +2,6 @@
 first_name: Milan
 last_name: Klanjsek
 image: /img/contributors/milan-klanjsek.jpg
+github_handle: mklanjsek
 ---
 Engineer

--- a/site/_contributors/05-stephanie-bauman.md
+++ b/site/_contributors/05-stephanie-bauman.md
@@ -2,5 +2,6 @@
 first_name: Stephanie
 last_name: Bauman
 image: /img/contributors/stephanie-bauman.jpg
+github_handle: stephbman
 ---
 Product Manager

--- a/site/_includes/contributors.html
+++ b/site/_includes/contributors.html
@@ -16,7 +16,7 @@
       <div class="media thumbnail-item">
         <img src="{{ person.image }}" class="rounded-circle" alt="Person" />
         <div class="media-body align-self-center">
-          <h6><a href="#">{{ person.first_name }} {{ person.last_name }}</a></h6>
+          <h6><a href="https://github.com/{{ person.github_handle }}">{{ person.first_name }} {{ person.last_name }}</a></h6>
         {{ person.content | markdownify }}    
         </div>
       </div>


### PR DESCRIPTION
Signed-off-by: jonasrosland <jrosland@vmware.com>


**What this PR does / why we need it**:
This will change the non-relevant links for each team member to proper links to GitHub user pages.

**Which issue(s) this PR fixes**
- Fixes #

**Special notes for your reviewer**:

**Release note**:
```
release-note
```
