### PR TITLE
Show service account secrets

### DIFF
--- a/internal/printer/clusterrole.go
+++ b/internal/printer/clusterrole.go
@@ -115,7 +115,7 @@ func createClusterRolePolicyRulesView(clusterRole *rbacv1.ClusterRole) (*compone
 }
 
 func printPolicyRules(rules []rbacv1.PolicyRule) (*component.Table, error) {
-	breakdownRules := []rbacv1.PolicyRule{}
+	var breakdownRules []rbacv1.PolicyRule
 	for _, rule := range rules {
 		breakdownRules = append(breakdownRules, BreakdownRule(rule)...)
 	}

--- a/internal/testutil/generator.go
+++ b/internal/testutil/generator.go
@@ -282,11 +282,17 @@ func CreateExtReplicaSet(name string) *extv1beta1.ReplicaSet {
 }
 
 // CreateSecret creates a secret
-func CreateSecret(name string) *corev1.Secret {
-	return &corev1.Secret{
+func CreateSecret(name string, options ...func(*corev1.Secret)) *corev1.Secret {
+	s := &corev1.Secret{
 		TypeMeta:   genTypeMeta(gvk.Secret),
 		ObjectMeta: genObjectMeta(name, true),
 	}
+
+	for _, option := range options {
+		option(s)
+	}
+
+	return s
 }
 
 // CreateService creates a service
@@ -298,11 +304,17 @@ func CreateService(name string) *corev1.Service {
 }
 
 // CreateServiceAccount creates a service account
-func CreateServiceAccount(name string) *corev1.ServiceAccount {
-	return &corev1.ServiceAccount{
+func CreateServiceAccount(name string, options ...func(*corev1.ServiceAccount)) *corev1.ServiceAccount {
+	sa := &corev1.ServiceAccount{
 		TypeMeta:   genTypeMeta(gvk.ServiceAccount),
 		ObjectMeta: genObjectMeta(name, true),
 	}
+
+	for _, option := range options {
+		option(sa)
+	}
+
+	return sa
 }
 
 // CreateStatefulSet creates a stateful set

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -131,3 +131,4 @@ func RequireErrorOrNot(t *testing.T, wantErr bool, err error) {
 	}
 	require.NoError(t, err)
 }
+


### PR DESCRIPTION
**What this PR does / why we need it**:
This change shows service account secrets. Additionally, it shows the policy table for a service account.

**Release note**:
```
Show secrets and policies associated with a service account
```
