### PR TITLE
Added missing label selector to protobuf key request

### DIFF
--- a/changelogs/unreleased/908-GuessWhoSamFoo
+++ b/changelogs/unreleased/908-GuessWhoSamFoo
@@ -1,0 +1,1 @@
+Added missing label selector to protobuf key request


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow plugins to list objects using label selectors as a filter

**Which issue(s) this PR fixes**
- Fixes #876 

