### PR TITLE
Send no-cache, no-store headers for root (index) request

### DIFF
--- a/pkg/octant/handler.go
+++ b/pkg/octant/handler.go
@@ -56,6 +56,7 @@ func (hf *HandlerFactory) Handler(ctx context.Context) (http.Handler, error) {
 	router.PathPrefix(api.PathPrefix).Handler(backendHandler)
 
 	router.PathPrefix("/").Handler(frontendHandler)
+	router.Use(noCacheRootMiddleware)
 
 	allowedOrigins := handlers.AllowedOrigins([]string{"*"})
 	allowedHeaders := handlers.AllowedHeaders([]string{"Accept", "Accept-Language", "Content-Language", "Origin", "Content-Type"})

--- a/pkg/octant/handler_test.go
+++ b/pkg/octant/handler_test.go
@@ -120,6 +120,8 @@ func TestHandlerFactory_Handler(t *testing.T) {
 			backendPath := genTestURL(t, ts.URL, "api", "v1", "foo")
 
 			resFrontend, err := http.Get(frontendPath)
+			noCache := resFrontend.Header.Get("Cache-Control")
+			require.Equal(t, "no-cache, no-store", noCache)
 			require.NoError(t, err)
 
 			resBackend, err := http.Get(backendPath)

--- a/pkg/octant/options.go
+++ b/pkg/octant/options.go
@@ -75,3 +75,13 @@ func BackendHandler(fn func(ctx context.Context) (http.Handler, error)) Option {
 func defaultFrontendHandler(ctx context.Context) (http.Handler, error) {
 	return web.Handler()
 }
+
+func noCacheRootMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.EscapedPath()
+		if path == "/" {
+			w.Header().Set("Cache-Control", "no-cache, no-store")
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -5,6 +5,9 @@
   <title>Octant</title>
   <base href="/">
 
+  <!-- Older IE clients need no-cache -->
+  <meta http-equiv="cache-control" content="no-cache" />
+  <meta http-equiv="cache-control" content="no-store" />
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
 </head>


### PR DESCRIPTION
Signed-off-by: Wayne Witzel III <wayne@riotousliving.com>


**What this PR does / why we need it**:
Prevents caching of the root index file, which causes caching of timestamped asset files. This current behavior causes users to need to hard refresh to see Octant changes.

**Which issue(s) this PR fixes**
- Fixes #912 
