### PR TITLE
Fix Timestamp tooltips and overflow elements problems

### DIFF
--- a/web/src/app/modules/shared/components/presentation/overflow-labels/overflow-labels.component.html
+++ b/web/src/app/modules/shared/components/presentation/overflow-labels/overflow-labels.component.html
@@ -21,7 +21,7 @@
     </ng-container>
   </div>
 
-  <clr-signpost *ngIf="overflowLabels && overflowLabels.length > 0">
+  <clr-signpost *ngIf="overflowLabels?.length > 0">
     <span class="badge badge-light-blue" clrSignpostTrigger>
       {{ overflowLabels.length }}+
     </span>

--- a/web/src/app/modules/shared/components/presentation/overflow-labels/overflow-labels.component.ts
+++ b/web/src/app/modules/shared/components/presentation/overflow-labels/overflow-labels.component.ts
@@ -64,7 +64,9 @@ export class OverflowLabelsComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    this.contentSubscription.unsubscribe();
+    if (this.contentSubscription) {
+      this.contentSubscription.unsubscribe();
+    }
   }
 
   getScrollPos() {

--- a/web/src/app/modules/shared/components/presentation/overflow-selectors/overflow-selectors.component.html
+++ b/web/src/app/modules/shared/components/presentation/overflow-selectors/overflow-selectors.component.html
@@ -16,7 +16,7 @@
     </ng-container>
   </div>
 
-  <clr-signpost *ngIf="overflowSelectors && overflowSelectors.length > 0">
+  <clr-signpost *ngIf="overflowSelectors?.length > 0">
     <span class="badge badge-orange" clrSignpostTrigger>
       {{ overflowSelectors.length }}+
     </span>

--- a/web/src/app/modules/shared/components/presentation/overflow-selectors/overflow-selectors.component.ts
+++ b/web/src/app/modules/shared/components/presentation/overflow-selectors/overflow-selectors.component.ts
@@ -78,7 +78,9 @@ export class OverflowSelectorsComponent
   }
 
   ngOnDestroy() {
-    this.contentSubscription.unsubscribe();
+    if (this.contentSubscription) {
+      this.contentSubscription.unsubscribe();
+    }
   }
 
   ngAfterViewChecked(): void {

--- a/web/src/app/modules/shared/components/presentation/timestamp/timestamp.component.html
+++ b/web/src/app/modules/shared/components/presentation/timestamp/timestamp.component.html
@@ -1,6 +1,6 @@
-<clr-tooltip>
-  <span #timestampRef clrTooltipTrigger>{{ timestamp | relative }}</span>
-  <clr-tooltip-content [clrPosition]="tooltipPosition" clrSize="md" *clrIfOpen>
-    <span>{{ humanReadable }}</span>
-  </clr-tooltip-content>
-</clr-tooltip>
+<span class="tooltip tooltip-wrapper tooltip-md">
+  <span>{{ timestamp | relative }}</span>
+     <span class="tooltip-content" [ngStyle]="{ 'margin-top': getScrollPos() }">
+       <span>{{ humanReadable }}</span>
+     </span>
+</span>

--- a/web/src/app/modules/shared/components/presentation/timestamp/timestamp.component.scss
+++ b/web/src/app/modules/shared/components/presentation/timestamp/timestamp.component.scss
@@ -1,3 +1,8 @@
 /* Copyright (c) 2019 the Octant contributors. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+@import '../../../../../../styles';
+
+.tooltip-wrapper {
+  margin: 0 .3rem 0 0;
+}

--- a/web/src/app/modules/shared/components/presentation/timestamp/timestamp.component.ts
+++ b/web/src/app/modules/shared/components/presentation/timestamp/timestamp.component.ts
@@ -76,6 +76,8 @@ export class TimestampComponent implements OnInit, OnChanges, OnDestroy {
 
   ngOnDestroy(): void {
     this.timestamp = null;
-    this.contentSubscription.unsubscribe();
+    if (this.contentSubscription) {
+      this.contentSubscription.unsubscribe();
+    }
   }
 }


### PR DESCRIPTION
Timestamp tooltips and overflow elements had some issues that are now addressed:

- Fixed Timestamp tooltip visibility issues,
- Converted Timestamp tooltip to use new tooltips like elsewhere,
- Stopped flipping the Timestamp tooltip - improved layout of new toolltip eliminates need for that,
- Fixed problem with selector/label overflow elements throwing exceptions on startup,   

Signed-off-by: Milan Klanjsek <mklanjsek@pivotal.io>
