### PR TITLE
Added terminal support for multiple containers

### DIFF
--- a/changelogs/unreleased/916-GuessWhoSamFoo
+++ b/changelogs/unreleased/916-GuessWhoSamFoo
@@ -1,0 +1,1 @@
+Added terminal support for multiple containers

--- a/internal/api/terminal_manager.go
+++ b/internal/api/terminal_manager.go
@@ -95,7 +95,7 @@ func (s *terminalStateManager) SetActiveTerminal(state octant.State, payload act
 	key.Namespace = namespace
 
 	if s.instance != nil {
-		if s.instance.Key() == key && s.instance.Active() {
+		if s.instance.Key() == key && s.instance.Active() && s.instance.Container() == containerName {
 			s.existingInstance = true
 			s.chanInstance <- s.instance
 			return nil

--- a/internal/modules/overview/terminalviewer/terminalviewer.go
+++ b/internal/modules/overview/terminalviewer/terminalviewer.go
@@ -54,8 +54,18 @@ func (tv *terminalViewer) ToComponent() (*component.Terminal, error) {
 	}
 
 	container := ""
+	containers := []string{}
 	if len(pod.Spec.Containers) > 0 {
 		container = getFirstContainer(pod).Name
+		for _, c := range pod.Spec.Containers {
+			for _, s := range pod.Status.ContainerStatuses {
+				if s.Name == c.Name {
+					if s.State.Terminated == nil {
+						containers = append(containers, c.Name)
+					}
+				}
+			}
+		}
 	}
 
 	details := component.TerminalDetails{
@@ -63,7 +73,7 @@ func (tv *terminalViewer) ToComponent() (*component.Terminal, error) {
 		Command:   "/bin/sh",
 		Active:    true,
 	}
-	term := component.NewTerminal(pod.Namespace, "Terminal", pod.Name, details)
+	term := component.NewTerminal(pod.Namespace, "Terminal", pod.Name, containers, details)
 	return term, nil
 }
 

--- a/internal/modules/overview/terminalviewer/terminalviewer_test.go
+++ b/internal/modules/overview/terminalviewer/terminalviewer_test.go
@@ -29,7 +29,7 @@ func Test_ToComponent(t *testing.T) {
 		Command:   "/bin/sh",
 		Active:    true,
 	}
-	expected := component.NewTerminal("", "Terminal", "", details)
+	expected := component.NewTerminal("", "Terminal", "", []string{}, details)
 
 	assert.Equal(t, expected, got)
 }

--- a/pkg/view/component/terminal.go
+++ b/pkg/view/component/terminal.go
@@ -19,10 +19,11 @@ type TerminalDetails struct {
 
 // TerminalConfig holds a terminal config.
 type TerminalConfig struct {
-	Namespace string          `json:"namespace"`
-	Name      string          `json:"name"`
-	PodName   string          `json:"podName"`
-	Details   TerminalDetails `json:"terminal"`
+	Namespace  string          `json:"namespace"`
+	Name       string          `json:"name"`
+	PodName    string          `json:"podName"`
+	Containers []string        `json:"containers"`
+	Details    TerminalDetails `json:"terminal"`
 }
 
 type Terminal struct {
@@ -31,14 +32,15 @@ type Terminal struct {
 }
 
 // NewTerminal creates a terminal component.
-func NewTerminal(namespace, name string, podName string, details TerminalDetails) *Terminal {
+func NewTerminal(namespace, name string, podName string, containers []string, details TerminalDetails) *Terminal {
 	return &Terminal{
 		base: newBase(typeTerminal, TitleFromString(name)),
 		Config: TerminalConfig{
-			Namespace: namespace,
-			Name:      name,
-			PodName:   podName,
-			Details:   details,
+			Namespace:  namespace,
+			Name:       name,
+			PodName:    podName,
+			Containers: containers,
+			Details:    details,
 		},
 	}
 }

--- a/pkg/view/component/terminal_test.go
+++ b/pkg/view/component/terminal_test.go
@@ -20,7 +20,7 @@ func TestTerminal_Marshal(t *testing.T) {
 		Command:   "/bin/bash",
 		Active:    false,
 	}
-	input := NewTerminal("default", "term-test", "pod-name", details)
+	input := NewTerminal("default", "term-test", "pod-name", []string{"container-id", "sidecar-container"}, details)
 	actual, err := json.Marshal(input)
 	assert.NoError(t, err)
 

--- a/pkg/view/component/testdata/terminal.json
+++ b/pkg/view/component/testdata/terminal.json
@@ -12,6 +12,7 @@
     "name": "term-test",
     "podName": "pod-name",
     "namespace": "default",
+    "containers": ["container-id", "sidecar-container"],
     "terminal": {
       "active": false,
       "command": "/bin/bash",

--- a/web/src/app/modules/shared/components/smart/terminal/terminal.component.html
+++ b/web/src/app/modules/shared/components/smart/terminal/terminal.component.html
@@ -1,1 +1,7 @@
+<clr-select-container class="container-select">
+  <label>Container</label>
+  <select clrSelect name="options" [value]="selectedContainer" (change)="onContainerChange($event.target.value)">
+    <option *ngFor="let container of view?.config.containers; trackBy: trackByIdentity" value="{{ container }}">{{ container }}</option>
+  </select>
+</clr-select-container>
 <div class="app-terminal" #terminal></div>

--- a/web/src/app/modules/shared/models/content.ts
+++ b/web/src/app/modules/shared/models/content.ts
@@ -417,6 +417,7 @@ export interface TerminalView extends View {
     name: string;
     podName: string;
     terminal: TerminalDetail;
+    containers: string[];
   };
 }
 

--- a/web/src/app/modules/shared/terminals/terminals.service.ts
+++ b/web/src/app/modules/shared/terminals/terminals.service.ts
@@ -47,6 +47,10 @@ export class TerminalOutputStreamer {
   providedIn: 'root',
 })
 export class TerminalOutputService {
+  public selectedContainer: string;
+  public namespace: string;
+  public podName: string;
+
   constructor(private websocketService: WebsocketService) {}
 
   public createStream(namespace, pod, container): TerminalOutputStreamer {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support for command exec into multiple containers. It has the following properties in addition to those listed in https://github.com/vmware-tanzu/octant/issues/901#issuecomment-621832931:
 - containers in the terminated state will not be visible in the dropdown
 - a terminal opened in a new pod will default to the first container. If the user selects a different container, octant will remember that container until a terminal is opened for another pod.

**Which issue(s) this PR fixes**
- Fixes #901 

