### PR TITLE
fix: add a couple of CLI arguments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+
+
+all: web-build update
+
+build:
+	go run build.go build
+	cp build/octant /Users/jstrachan/bin/octant
+
+update:
+	go generate ./web
+	go run build.go build
+	cp build/octant /Users/jstrachan/bin/octant
+
+web-build:
+	cd web && npm run build
+	go generate ./web

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -26,8 +26,14 @@ import (
 
 const (
 	// ListenerAddrKey is the environment variable for the Octant listener address.
-	ListenerAddrKey  = "listener-addr"
+	ListenerAddrKey = "listener-addr"
+
+	// AcceptedHostsKey the list of accepted hosts to be allowed to connect over web sockets
 	AcceptedHostsKey = "accepted-hosts"
+
+	// AcceptLocalIPKey if no accepted hosts are specified this flag will add all the local IP addresses
+	//starting with `192.168.1.` to the accepted hosts
+	AcceptLocalIPKey = "accept-local-ip"
 	// PathPrefix is a string for the api path prefix.
 	PathPrefix          = "/api/v1"
 	defaultListenerAddr = "127.0.0.1:7777"
@@ -38,9 +44,16 @@ func acceptedHosts() []string {
 		"localhost",
 		"127.0.0.1",
 	}
-	if customHosts := viper.GetString(AcceptedHostsKey); customHosts != "" {
+	customHosts := viper.GetString(AcceptedHostsKey)
+	if customHosts != "" {
 		allowedHosts := strings.Split(customHosts, ",")
 		hosts = append(hosts, allowedHosts...)
+	} else {
+		if viper.GetBool(AcceptLocalIPKey) {
+			for i := 0; i < 256; i++ {
+				hosts = append(hosts, fmt.Sprintf("192.168.1.%d", i))
+			}
+		}
 	}
 
 	listenerAddr := ListenerAddr()

--- a/internal/commands/dash.go
+++ b/internal/commands/dash.go
@@ -77,6 +77,7 @@ func newOctantCmd(version string) *cobra.Command {
 					KubeConfig:             viper.GetString("kubeconfig"),
 					Namespace:              viper.GetString("namespace"),
 					FrontendURL:            viper.GetString("ui-url"),
+					BrowserPath:            viper.GetString("browser-path"),
 					Context:                viper.GetString("context"),
 					ClientQPS:              float32(viper.GetFloat64("client-qps")),
 					ClientBurst:            viper.GetInt("client-burst"),
@@ -142,12 +143,14 @@ func newOctantCmd(version string) *cobra.Command {
 	octantCmd.Flags().Float32P("client-qps", "", 200, "maximum QPS for client [DEV]")
 	octantCmd.Flags().IntP("client-burst", "", 400, "maximum burst for client throttle [DEV]")
 	octantCmd.Flags().BoolP("disable-open-browser", "", false, "disable automatic launching of the browser [DEV]")
+	octantCmd.Flags().BoolP("accept-local-ip", "", false, "allows local IP addresses starting with 192.168.1.")
 	octantCmd.Flags().BoolP("enable-opencensus", "c", false, "enable open census [DEV]")
 	octantCmd.Flags().IntP("klog-verbosity", "", 0, "klog verbosity level [DEV]")
 	octantCmd.Flags().StringP("listener-addr", "", "", "listener address for the octant frontend [DEV]")
 	octantCmd.Flags().StringP("local-content", "", "", "local content path [DEV]")
 	octantCmd.Flags().StringP("proxy-frontend", "", "", "url to send frontend request to [DEV]")
 	octantCmd.Flags().String("ui-url", "", "dashboard url [DEV]")
+	octantCmd.Flags().String("browser-path", "", "the browser path to open the browser on")
 
 	return octantCmd
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

adds a few helper CLI arguments:

* `browser-path` so you can specify the initial context path to open the browser as you start Octant.

* `accept-local-ip` so that we can pre-populate the accepted hosts with all the local IP addresses on your local network so you can use another local device to access octant. I've found this particularly useful so I can keep an eye on octant running on my laptop while I'm around the house on my iPhone ;)


**Release note**:
```

This release adds 2 new CLI arguments:

* `browser-path` so you can specify the initial context path to open the browser as you start Octant

e.g. to open octant on the Deployments view:

    octant --browser-path "/#/overview/namespace/default/workloads/deployments"

* `accept-local-ip` so that we can pre-populate the accepted hosts with all the local IP addresses on your local network so you can use another local device to access octant. 

e.g. if you start octant via:

    octant --listener-addr=0.0.0.0:7777 --accept-local-ip

You will be able to connect to http://your-laptop-ip-address:7777 from your phone/tablet on your local LAN.

```
