### PR TITLE
fix: add CLI argument `browser-path`

### DIFF
--- a/internal/commands/dash.go
+++ b/internal/commands/dash.go
@@ -77,6 +77,7 @@ func newOctantCmd(version string) *cobra.Command {
 					KubeConfig:             viper.GetString("kubeconfig"),
 					Namespace:              viper.GetString("namespace"),
 					FrontendURL:            viper.GetString("ui-url"),
+					BrowserPath:            viper.GetString("browser-path"),
 					Context:                viper.GetString("context"),
 					ClientQPS:              float32(viper.GetFloat64("client-qps")),
 					ClientBurst:            viper.GetInt("client-burst"),
@@ -148,6 +149,7 @@ func newOctantCmd(version string) *cobra.Command {
 	octantCmd.Flags().StringP("local-content", "", "", "local content path [DEV]")
 	octantCmd.Flags().StringP("proxy-frontend", "", "", "url to send frontend request to [DEV]")
 	octantCmd.Flags().String("ui-url", "", "dashboard url [DEV]")
+	octantCmd.Flags().String("browser-path", "", "the browser path to open the browser on")
 
 	return octantCmd
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

adds a CLI argument:

* `browser-path` so you can specify the initial context path to open the browser as you start Octant.

**Release note**:
```

This release adds a new CLI argument:

* `browser-path` so you can specify the initial context path to open the browser as you start Octant

e.g. to open octant on the Deployments view:

    octant --browser-path "/#/overview/namespace/default/workloads/deployments"

```
