### PR TITLE
Add --namespace-list flag to accept a slice of namespaces

### DIFF
--- a/changelogs/unreleased/928-GuessWhoSamFoo
+++ b/changelogs/unreleased/928-GuessWhoSamFoo
@@ -1,1 +1,1 @@
-Added `--namespaces` flag to accept a slice of namespaces
+Added `--namespace-list` flag to accept a slice of namespaces

--- a/changelogs/unreleased/928-GuessWhoSamFoo
+++ b/changelogs/unreleased/928-GuessWhoSamFoo
@@ -1,0 +1,1 @@
+Added `--namespaces` flag to accept a slice of namespaces

--- a/internal/api/namespaces_manager.go
+++ b/internal/api/namespaces_manager.go
@@ -123,12 +123,26 @@ func NamespacesGenerator(_ context.Context, config NamespaceManagerConfig) ([]st
 		return nil, errors.Wrap(err, "retrieve namespaces client")
 	}
 
+	providedNamespaces := namespaceClient.ProvidedNamespaces()
+
 	names, err := namespaceClient.Names()
 	if err != nil {
 		initialNamespace := namespaceClient.InitialNamespace()
 		names = []string{initialNamespace}
 	}
 
+	for _, namespace := range providedNamespaces {
+		found := false
+		for _, foundNamespace := range names {
+			if namespace == foundNamespace {
+				found = true
+				break
+			}
+		}
+		if !found && namespaceClient.HasNamespace(namespace) {
+			names = append(names, namespace)
+		}
+	}
 	return names, nil
 }
 

--- a/internal/api/namespaces_manager_test.go
+++ b/internal/api/namespaces_manager_test.go
@@ -58,6 +58,7 @@ func TestNamespacesGenerator(t *testing.T) {
 
 				namespaceClient := clusterFake.NewMockNamespaceInterface(controller)
 				namespaceClient.EXPECT().Names().Return(namespaces, nil)
+				namespaceClient.EXPECT().ProvidedNamespaces().Return([]string{})
 
 				clusterClient := clusterFake.NewMockClientInterface(controller)
 				clusterClient.EXPECT().NamespaceClient().Return(namespaceClient, nil)

--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -17,6 +17,6 @@ func Test_FromKubeConfig(t *testing.T) {
 	kubeConfig := filepath.Join("testdata", "kubeconfig.yaml")
 	config := RESTConfigOptions{}
 
-	_, err := FromKubeConfig(context.TODO(), kubeConfig, "", "", config)
+	_, err := FromKubeConfig(context.TODO(), kubeConfig, "", "", []string{}, config)
 	require.NoError(t, err)
 }

--- a/internal/cluster/fake/mock_namespace_interface.go
+++ b/internal/cluster/fake/mock_namespace_interface.go
@@ -60,3 +60,31 @@ func (mr *MockNamespaceInterfaceMockRecorder) InitialNamespace() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitialNamespace", reflect.TypeOf((*MockNamespaceInterface)(nil).InitialNamespace))
 }
+
+// ProvidedNamespaces mocks base method
+func (m *MockNamespaceInterface) ProvidedNamespaces() []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ProvidedNamespaces")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// ProvidedNamespaces indicates an expected call of ProvidedNamespaces
+func (mr *MockNamespaceInterfaceMockRecorder) ProvidedNamespaces() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProvidedNamespaces", reflect.TypeOf((*MockNamespaceInterface)(nil).ProvidedNamespaces))
+}
+
+// HasNamespace mocks base method
+func (m *MockNamespaceInterface) HasNamespace(namespace string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasNamespace", namespace)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// HasNamespace indicates an expected call of HasNamespace
+func (mr *MockNamespaceInterfaceMockRecorder) HasNamespace(namespace interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasNamespace", reflect.TypeOf((*MockNamespaceInterface)(nil).HasNamespace), namespace)
+}

--- a/internal/cluster/namespace_test.go
+++ b/internal/cluster/namespace_test.go
@@ -25,7 +25,7 @@ func Test_namespaceClient_Names(t *testing.T) {
 		newUnstructured("v1", "Namespace", "", "app-1"),
 	)
 
-	nc := newNamespaceClient(dc, "default")
+	nc := newNamespaceClient(dc, nil, "default", []string{})
 
 	got, err := nc.Names()
 	require.NoError(t, err)
@@ -36,7 +36,7 @@ func Test_namespaceClient_Names(t *testing.T) {
 
 func Test_namespaceClient_InitialNamespace(t *testing.T) {
 	expected := "inital-namespace"
-	nc := newNamespaceClient(nil, expected)
+	nc := newNamespaceClient(nil, nil, expected, []string{})
 	assert.Equal(t, expected, nc.InitialNamespace())
 }
 

--- a/internal/commands/dash.go
+++ b/internal/commands/dash.go
@@ -76,6 +76,7 @@ func newOctantCmd(version string) *cobra.Command {
 					EnableOpenCensus:       viper.GetBool("enable-opencensus"),
 					KubeConfig:             viper.GetString("kubeconfig"),
 					Namespace:              viper.GetString("namespace"),
+					Namespaces:             viper.GetStringSlice("namespace-list"),
 					FrontendURL:            viper.GetString("ui-url"),
 					BrowserPath:            viper.GetString("browser-path"),
 					Context:                viper.GetString("context"),
@@ -136,6 +137,7 @@ func newOctantCmd(version string) *cobra.Command {
 	octantCmd.Flags().BoolP("enable-feature-applications", "", false, "enable applications feature")
 	octantCmd.Flags().String("kubeconfig", "", "absolute path to kubeConfig file")
 	octantCmd.Flags().StringP("namespace", "n", "", "initial namespace")
+	octantCmd.Flags().StringSlice("namespace-list", []string{}, "a slice of namespaces")
 	octantCmd.Flags().StringP("plugin-path", "", "", "plugin path")
 	octantCmd.Flags().BoolP("verbose", "v", false, "turn on debug logging")
 

--- a/internal/commands/dash.go
+++ b/internal/commands/dash.go
@@ -137,7 +137,7 @@ func newOctantCmd(version string) *cobra.Command {
 	octantCmd.Flags().BoolP("enable-feature-applications", "", false, "enable applications feature")
 	octantCmd.Flags().String("kubeconfig", "", "absolute path to kubeConfig file")
 	octantCmd.Flags().StringP("namespace", "n", "", "initial namespace")
-	octantCmd.Flags().StringSlice("namespace-list", []string{}, "a slice of namespaces")
+	octantCmd.Flags().StringSlice("namespace-list", []string{}, "a list of namespaces to use on start")
 	octantCmd.Flags().StringP("plugin-path", "", "", "plugin path")
 	octantCmd.Flags().BoolP("verbose", "v", false, "turn on debug logging")
 

--- a/internal/config/dash.go
+++ b/internal/config/dash.go
@@ -199,7 +199,7 @@ func (l *Live) PortForwarder() portforward.PortForwarder {
 // UseContext switches context name. This process should have synchronously.
 func (l *Live) UseContext(ctx context.Context, contextName string) error {
 	// TODO: (GuessWhoSamFoo) FromKubeConfig needs a refactor. Initial ns is not needed when changing contexts (GH#362)
-	client, err := cluster.FromKubeConfig(ctx, l.kubeConfigPath, contextName, "", l.restConfigOptions)
+	client, err := cluster.FromKubeConfig(ctx, l.kubeConfigPath, contextName, "", []string{}, l.restConfigOptions)
 	if err != nil {
 		return err
 	}

--- a/pkg/dash/dash.go
+++ b/pkg/dash/dash.go
@@ -49,6 +49,7 @@ type Options struct {
 	DisableClusterOverview bool
 	KubeConfig             string
 	Namespace              string
+	Namespaces             []string
 	FrontendURL            string
 	BrowserPath            string
 	Context                string
@@ -71,7 +72,7 @@ func Run(ctx context.Context, logger log.Logger, shutdownCh chan bool, options O
 		Burst:     options.ClientBurst,
 		UserAgent: options.UserAgent,
 	}
-	clusterClient, err := cluster.FromKubeConfig(ctx, options.KubeConfig, options.Context, options.Namespace, restConfigOptions)
+	clusterClient, err := cluster.FromKubeConfig(ctx, options.KubeConfig, options.Context, options.Namespace, options.Namespaces, restConfigOptions)
 	if err != nil {
 		return fmt.Errorf("failed to init cluster client: %w", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a `--namespace-list` flag which accepts a slice of namespaces in the form of `x,y,z` and validates each via `Get` rather than `List` for users who have restricted clusters.

**Which issue(s) this PR fixes**
- Fixes #911 
