### PR TITLE
Remove duplicated titles and color from visited breadcrumb links

### DIFF
--- a/web/src/app/modules/shared/components/presentation/breadcrumb/breadcrumb.component.html
+++ b/web/src/app/modules/shared/components/presentation/breadcrumb/breadcrumb.component.html
@@ -1,22 +1,24 @@
 <div class="breadcrumb">
   <div class="breadcrumb-body">
-    <div *ngFor="let breadcrumb of path; trackBy: identifyPath"
+    <ng-container *ngIf="path?.length > 1">
+      <div *ngFor="let breadcrumb of path; trackBy: identifyPath"
         class="breadcrumb-item">
-      <ng-container
-        *ngIf="breadcrumb.url; then withLink; else withoutLink"
-      ></ng-container>
-      <ng-template #withLink>
-        <a [routerLink]="[breadcrumb.url]">
-        {{ breadcrumb.title }}
-        </a>
-        <clr-icon shape="angle" class="separator"></clr-icon>
-      </ng-template>
-      <ng-template #withoutLink>
-        <span class="breadcrumb-span">
-        {{ breadcrumb.title }}
-        </span>
-      </ng-template>
-    </div>
+        <ng-container
+          *ngIf="breadcrumb.url; then withLink; else withoutLink"
+        ></ng-container>
+        <ng-template #withLink>
+          <a [routerLink]="[breadcrumb.url]">
+          {{ breadcrumb.title }}
+          </a>
+          <clr-icon shape="angle" class="separator"></clr-icon>
+        </ng-template>
+        <ng-template #withoutLink>
+          <span class="breadcrumb-span">
+          {{ breadcrumb.title }}
+          </span>
+        </ng-template>
+      </div>
+    </ng-container>
   </div>
   <h2 class="breadcrumb-header">
     {{header}}

--- a/web/src/app/modules/shared/components/presentation/breadcrumb/breadcrumb.component.scss
+++ b/web/src/app/modules/shared/components/presentation/breadcrumb/breadcrumb.component.scss
@@ -21,4 +21,8 @@
     margin-right: 0.2rem;
     transform: rotate(90deg);
   }
+
+  a {
+    color: #0079b8;
+  }
 }

--- a/web/src/app/modules/shared/components/presentation/breadcrumb/breadcrumb.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/breadcrumb/breadcrumb.component.spec.ts
@@ -28,7 +28,7 @@ describe('BreadcrumbComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should create one path without link', () => {
+  it('should omit if single path', () => {
     component.path = [{ title: 'breadcrumb title', url: '' }];
     const breadcrumbElement: HTMLDivElement = fixture.debugElement.query(
       By.css('.breadcrumb')
@@ -41,11 +41,10 @@ describe('BreadcrumbComponent', () => {
     );
     const spans: DebugElement[] = fixture.debugElement.queryAll(By.css('span'));
     expect(links.length).toBe(0);
-    expect(icons.length).toBe(0);
-    expect(spans.length).toBe(1);
+    expect(spans.length).toBe(0);
 
     expect(breadcrumbElement.children.length).toEqual(2);
-    expect(breadcrumbElement.innerText).toBe('breadcrumb title');
+    expect(breadcrumbElement.innerText).toBe('');
   });
 
   it('should create two paths with single link', () => {
@@ -64,7 +63,6 @@ describe('BreadcrumbComponent', () => {
     );
     const spans: DebugElement[] = fixture.debugElement.queryAll(By.css('span'));
     expect(links.length).toBe(1);
-    expect(icons.length).toBe(1);
     expect(spans.length).toBe(1);
 
     expect(breadcrumbElement.children.length).toEqual(2);


### PR DESCRIPTION
**What this PR does / why we need it**:
This removes the extra title from overview pages. Also visited links in breadcrumbs should not need a color change.
