### PR TITLE
Fix dark mode colors for log viewer

### DIFF
--- a/web/src/app/modules/shared/components/smart/editor/editor.component.ts
+++ b/web/src/app/modules/shared/components/smart/editor/editor.component.ts
@@ -59,7 +59,6 @@ export class EditorComponent implements OnChanges {
   ngOnChanges(changes: SimpleChanges) {
     if (changes.view.currentValue) {
       const view = changes.view.currentValue as EditorView;
-      console.log(view);
 
       if (!this.isModified) {
         this.editorValue = view.config.value;

--- a/web/src/app/modules/shared/components/smart/logs/logs.component.scss
+++ b/web/src/app/modules/shared/components/smart/logs/logs.component.scss
@@ -70,8 +70,6 @@
     height: 100%;
     border: 1px solid #ccc;
     border-radius: 4px;
-    background-color: var(--clr-color-neutral-100);
-    color: var(--clr-color-on-neutral-100);
 
     .highlight {
       color: #0079b8;


### PR DESCRIPTION
Current log viewer colors are not showing up properly. Might be related to a Clarity version update.

Signed-off-by: GuessWhoSamFoo <foos@vmware.com>
