### PR TITLE
Make graphviz component work again

### DIFF
--- a/changelogs/unreleased/948-mklanjsek
+++ b/changelogs/unreleased/948-mklanjsek
@@ -1,0 +1,1 @@
+Fixed problems with the graphviz component

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -2460,11 +2460,6 @@
         "@hapi/hoek": "^9.0.0"
       }
     },
-    "@hpcc-js/wasm": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/@hpcc-js/wasm/-/wasm-0.3.10.tgz",
-      "integrity": "sha512-srQsBfqkZ/FH/uTq55ZYBLBw28qP+5JW3GYetuVZUMnXZ3oDSpX5PxwkrUYpcbT/O5pxMEd59nxv7SHHJjQr5A=="
-    },
     "@icons/material": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@icons/material/-/material-0.2.4.tgz",
@@ -7566,33 +7561,19 @@
       }
     },
     "d3-graphviz": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/d3-graphviz/-/d3-graphviz-3.0.4.tgz",
-      "integrity": "sha512-PDT+W/k1OAygY5kZiQTQyHnsEHMCRRG0Mh3mZ1o8JVZeD/ekIOCrXeIHsx+UZOSC/2nr6j6+5Ut4OL47Y7TzuA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/d3-graphviz/-/d3-graphviz-2.6.1.tgz",
+      "integrity": "sha512-878AFSagQyr5tTOrM7YiVYeUC2/NoFcOB3/oew+LAML0xekyJSw9j3WOCUMBsc95KYe9XBYZ+SKKuObVya1tJQ==",
       "requires": {
-        "@hpcc-js/wasm": "^0.3.8",
-        "d3-dispatch": "^1.0.6",
-        "d3-format": "^1.4.3",
-        "d3-interpolate": "^1.4.0",
-        "d3-path": "^1.0.9",
-        "d3-selection": "^1.4.1",
-        "d3-timer": "^1.0.10",
-        "d3-transition": "^1.3.2",
-        "d3-zoom": "1.7.3"
-      },
-      "dependencies": {
-        "d3-zoom": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-1.7.3.tgz",
-          "integrity": "sha512-xEBSwFx5Z9T3/VrwDkMt+mr0HCzv7XjpGURJ8lWmIC8wxe32L39eWHIasEe/e7Ox8MPU4p1hvH8PKN2olLzIBg==",
-          "requires": {
-            "d3-dispatch": "1",
-            "d3-drag": "1",
-            "d3-interpolate": "1",
-            "d3-selection": "1",
-            "d3-transition": "1"
-          }
-        }
+        "d3-dispatch": "^1.0.3",
+        "d3-format": "^1.2.0",
+        "d3-interpolate": "^1.1.5",
+        "d3-path": "^1.0.5",
+        "d3-selection": "^1.1.0",
+        "d3-timer": "^1.0.6",
+        "d3-transition": "^1.1.1",
+        "d3-zoom": "^1.5.0",
+        "viz.js": "^1.8.2"
       }
     },
     "d3-hierarchy": {
@@ -19534,6 +19515,11 @@
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
       }
+    },
+    "viz.js": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/viz.js/-/viz.js-1.8.2.tgz",
+      "integrity": "sha512-W+1+N/hdzLpQZEcvz79n2IgUE9pfx6JLdHh3Kh8RGvLL8P1LdJVQmi2OsDcLdY4QVID4OUy+FPelyerX0nJxIQ=="
     },
     "vm-browserify": {
       "version": "1.1.2",

--- a/web/package.json
+++ b/web/package.json
@@ -49,7 +49,7 @@
     "cytoscape": "^3.14.1",
     "cytoscape-dagre": "^2.2.2",
     "cytoscape-node-html-label": "^1.2.0",
-    "d3-graphviz": "^3.0.4",
+    "d3-graphviz": "^2.6.1",
     "d3-selection": "^1.4.1",
     "d3-zoom": "^1.8.3",
     "dagre-d3": "^0.6.4",

--- a/web/src/app/modules/shared/components/presentation/graphviz/graphviz.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/graphviz/graphviz.component.spec.ts
@@ -5,24 +5,48 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { GraphvizComponent } from './graphviz.component';
+import { Component } from '@angular/core';
+import { GraphvizView } from '../../../models/content';
+
+@Component({
+  template: '<app-view-graphviz [view]="view"></app-view-graphviz>',
+})
+class TestWrapperComponent {
+  view: GraphvizView;
+}
 
 describe('GraphvizComponent', () => {
-  let component: GraphvizComponent;
-  let fixture: ComponentFixture<GraphvizComponent>;
+  let component: TestWrapperComponent;
+  let fixture: ComponentFixture<TestWrapperComponent>;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [GraphvizComponent],
+      declarations: [TestWrapperComponent, GraphvizComponent],
     }).compileComponents();
   }));
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(GraphvizComponent);
+    fixture = TestBed.createComponent(TestWrapperComponent);
     component = fixture.componentInstance;
+    component.view = {
+      config: { dot: 'digraph {a -> b}' },
+      metadata: { type: 'graphwiz' },
+    };
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should show graph', () => {
+    const element: HTMLDivElement = fixture.nativeElement;
+    fixture.detectChanges();
+
+    expect(element.querySelector('app-view-graphviz div')).not.toBeNull();
+    expect(element.querySelector('app-view-graphviz div svg g')).not.toBeNull();
+    expect(
+      element.querySelector('app-view-graphviz div svg g').children.length
+    ).toEqual(5);
   });
 });

--- a/web/src/app/modules/shared/components/presentation/summary/summary.component.html
+++ b/web/src/app/modules/shared/components/presentation/summary/summary.component.html
@@ -64,6 +64,9 @@
               <ng-container *ngSwitchCase="'error'">
                 <app-view-error [view]="item.content"></app-view-error>
               </ng-container>
+              <ng-container *ngSwitchCase="'graphviz'">
+                <app-view-graphviz [view]="item.content"></app-view-graphviz>
+              </ng-container>
               <div class="alert alert-danger static" *ngSwitchDefault>
                 <span class="alert-icon-wrapper">
                   <clr-icon

--- a/web/src/app/modules/shared/services/d3/d3graphviz.service.ts
+++ b/web/src/app/modules/shared/services/d3/d3graphviz.service.ts
@@ -13,6 +13,8 @@ export class D3GraphvizService {
 
   render(parentElement: ElementRef, g) {
     const viewer = parentElement.nativeElement;
-    graphviz(viewer).renderDot(g);
+    if (viewer) {
+      graphviz(viewer, { useWorker: false }).renderDot(g);
+    }
   }
 }


### PR DESCRIPTION
A couple of problems prevented this from working:
- The latest version of `d3-graphviz` requires addition of wasm implementation of `graphviz` library, but even after adding that, the component behavior was inconsistent and flaky. So, I went back to previous version and added unit test to detect any potential future problems,
- The graphviz component was not hooked up inside the summary component,

Signed-off-by: Milan Klanjsek <mklanjsek@pivotal.io>


**Which issue(s) this PR fixes**
- Fixes #948

**Special notes for your reviewer**:
Not easy to test since we don't use graphviz internally, to make sure it's tested I added a unit test that verifies the graphviz component renders properly. For manual testing I temporarily changed one of component.NewText() calls to  component.NewGraphviz("digraph {a -> b}") and verified the output.
