### PR TITLE
Fixed Terminal window resizing issues

### DIFF
--- a/changelogs/unreleased/935-mklanjsek
+++ b/changelogs/unreleased/935-mklanjsek
@@ -1,0 +1,1 @@
+Fixed Terminal window resizing issues

--- a/web/src/app/modules/shared/components/smart/terminal/terminal.component.html
+++ b/web/src/app/modules/shared/components/smart/terminal/terminal.component.html
@@ -1,19 +1,21 @@
-<clr-select-container class="container-select">
-  <label>Container</label>
-  <select
-    clrSelect
-    name="options"
-    [value]="selectedContainer"
-    (change)="onContainerChange($event.target.value)"
-  >
-    <option
-      *ngFor="
-        let container of view?.config.containers;
-        trackBy: trackByIdentity
-      "
-      value="{{ container }}"
-      >{{ container }}</option
+<div class="terminal-container" (window:resize)="onResize()">
+  <clr-select-container class="container-select">
+    <label>Container</label>
+    <select
+      clrSelect
+      name="options"
+      [value]="selectedContainer"
+      (change)="onContainerChange($event.target.value)"
     >
-  </select>
-</clr-select-container>
-<div class="app-terminal" #terminal></div>
+      <option
+        *ngFor="
+          let container of view?.config.containers;
+          trackBy: trackByIdentity
+        "
+        value="{{ container }}"
+        >{{ container }}</option
+      >
+    </select>
+  </clr-select-container>
+  <div class="app-terminal" #terminal></div>
+</div>

--- a/web/src/app/modules/shared/components/smart/terminal/terminal.component.scss
+++ b/web/src/app/modules/shared/components/smart/terminal/terminal.component.scss
@@ -1,8 +1,10 @@
 @import 'xterm/css/xterm.css';
-
+.terminal-container {
+  height: calc(90% - 72px);
+}
 .app-terminal {
   height: 100%;
-  min-height: 20vh;
+  min-height: 10vh;
 
   border: 0.05rem solid #ccc;
   border-radius: 0.15rem;

--- a/web/src/app/modules/shared/components/smart/terminal/terminal.component.ts
+++ b/web/src/app/modules/shared/components/smart/terminal/terminal.component.ts
@@ -20,7 +20,6 @@ import {
 import trackByIdentity from 'src/app/util/trackBy/trackByIdentity';
 import { TerminalView } from 'src/app/modules/shared/models/content';
 import { WebsocketService } from '../../../services/websocket/websocket.service';
-import { ActionService } from '../../../services/action/action.service';
 
 @Component({
   encapsulation: ViewEncapsulation.None,
@@ -58,8 +57,8 @@ export class TerminalComponent implements OnDestroy, AfterViewInit {
   ngAfterViewInit() {
     if (this.view) {
       const logLevel = 'info';
-      const { podName, namespace, terminal, containers } = this.view.config;
-      const { active, command, container } = terminal;
+      const { terminal } = this.view.config;
+      const { active } = terminal;
       const disableStdin = !active;
       this.term = new Terminal({
         logLevel,
@@ -81,20 +80,13 @@ export class TerminalComponent implements OnDestroy, AfterViewInit {
       this.term.open(this.terminalDiv.nativeElement);
       this.term.focus();
       this.fitAddon.fit();
-      this.updateTerminalHeight();
     }
-  }
-
-  private updateTerminalHeight() {
-    const roundedModulo = this.terminalDiv.nativeElement.clientHeight % 17;
-    this.terminalDiv.nativeElement.style.height = `calc(100% - ${roundedModulo}px)`;
   }
 
   enableResize() {
     let timeOut = null;
     const resizeDebounce = (e: { cols: number; rows: number }) => {
       const resize = () => {
-        const { active } = this.view.config.terminal;
         this.wss.sendMessage('action.octant.dev/sendTerminalResize', {
           rows: e.rows,
           cols: e.cols,
@@ -119,7 +111,7 @@ export class TerminalComponent implements OnDestroy, AfterViewInit {
 
   initStream() {
     const { namespace, podName, terminal } = this.view.config;
-    const { active, container } = terminal;
+    const { container } = terminal;
     if (this.terminalService.selectedContainer) {
       this.selectedContainer = this.terminalService.selectedContainer;
     }
@@ -161,5 +153,9 @@ export class TerminalComponent implements OnDestroy, AfterViewInit {
       this.terminalService.namespace = namespace;
       this.terminalService.podName = podName;
     }
+  }
+
+  onResize() {
+    this.fitAddon.fit();
   }
 }


### PR DESCRIPTION
Signed-off-by: Milan Klanjsek <mklanjsek@pivotal.io>
Terminal fitting is now happening on window resize, making it adjust height better.  Also removed old rounding logic that's not necessary now and tweaked default heights.  

**Which issue(s) this PR fixes**
- Fixes #935

**Special notes for your reviewer**:
Note that terminal view has lower limit to hight, that used to be 20vh but I reduced it to 10vh - that will affect scrolling for very small window sizes.
