### PR TITLE
Re-add HPA printer

### DIFF
--- a/internal/describer/objects.go
+++ b/internal/describer/objects.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -16,7 +17,6 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 
-	"github.com/vmware-tanzu/octant/pkg/icon"
 	"github.com/vmware-tanzu/octant/pkg/store"
 )
 
@@ -60,7 +60,6 @@ func initNamespacedOverview() *Section {
 		ListType:       &batchv1beta1.CronJobList{},
 		ObjectType:     &batchv1beta1.CronJob{},
 		Titles:         ResourceTitle{List: "Cron Jobs", Object: "Cron Jobs"},
-		IconName:       icon.OverviewCronJob,
 		RootPath:       ResourceLink{Title: "Workloads", Url: "/overview/namespace/($NAMESPACE)/workloads"},
 	})
 
@@ -70,7 +69,6 @@ func initNamespacedOverview() *Section {
 		ListType:       &appsv1.DaemonSetList{},
 		ObjectType:     &appsv1.DaemonSet{},
 		Titles:         ResourceTitle{List: "Daemon Sets", Object: "Daemon Sets"},
-		IconName:       icon.OverviewDaemonSet,
 		RootPath:       ResourceLink{Title: "Workloads", Url: "/overview/namespace/($NAMESPACE)/workloads"},
 	})
 
@@ -80,7 +78,6 @@ func initNamespacedOverview() *Section {
 		ListType:       &appsv1.DeploymentList{},
 		ObjectType:     &appsv1.Deployment{},
 		Titles:         ResourceTitle{List: "Deployments", Object: "Deployments"},
-		IconName:       icon.OverviewDeployment,
 		RootPath:       ResourceLink{Title: "Workloads", Url: "/overview/namespace/($NAMESPACE)/workloads"},
 	})
 
@@ -90,7 +87,6 @@ func initNamespacedOverview() *Section {
 		ListType:       &batchv1.JobList{},
 		ObjectType:     &batchv1.Job{},
 		Titles:         ResourceTitle{List: "Jobs", Object: "Jobs"},
-		IconName:       icon.OverviewJob,
 		RootPath:       ResourceLink{Title: "Workloads", Url: "/overview/namespace/($NAMESPACE)/workloads"},
 	})
 
@@ -100,7 +96,6 @@ func initNamespacedOverview() *Section {
 		ListType:       &corev1.PodList{},
 		ObjectType:     &corev1.Pod{},
 		Titles:         ResourceTitle{List: "Pods", Object: "Pods"},
-		IconName:       icon.OverviewPod,
 		RootPath:       ResourceLink{Title: "Workloads", Url: "/overview/namespace/($NAMESPACE)/workloads"},
 	})
 
@@ -110,7 +105,6 @@ func initNamespacedOverview() *Section {
 		ListType:       &appsv1.ReplicaSetList{},
 		ObjectType:     &appsv1.ReplicaSet{},
 		Titles:         ResourceTitle{List: "Replica Sets", Object: "Replica Sets"},
-		IconName:       icon.OverviewReplicaSet,
 		RootPath:       ResourceLink{Title: "Workloads", Url: "/overview/namespace/($NAMESPACE)/workloads"},
 	})
 
@@ -120,7 +114,6 @@ func initNamespacedOverview() *Section {
 		ListType:       &corev1.ReplicationControllerList{},
 		ObjectType:     &corev1.ReplicationController{},
 		Titles:         ResourceTitle{List: "Replication Controllers", Object: "Replication Controllers"},
-		IconName:       icon.OverviewReplicationController,
 		RootPath:       ResourceLink{Title: "Workloads", Url: "/overview/namespace/($NAMESPACE)/workloads"},
 	})
 	workloadsStatefulSets := NewResource(ResourceOptions{
@@ -129,7 +122,6 @@ func initNamespacedOverview() *Section {
 		ListType:       &appsv1.StatefulSetList{},
 		ObjectType:     &appsv1.StatefulSet{},
 		Titles:         ResourceTitle{List: "Stateful Sets", Object: "Stateful Sets"},
-		IconName:       icon.OverviewStatefulSet,
 		RootPath:       ResourceLink{Title: "Workloads", Url: "/overview/namespace/($NAMESPACE)/workloads"},
 	})
 
@@ -146,13 +138,21 @@ func initNamespacedOverview() *Section {
 		workloadsStatefulSets,
 	)
 
+	dlbHorizontalPodAutoscalers := NewResource(ResourceOptions{
+		Path:           "/discovery-and-load-balancing/horizontal-pod-autoscalers",
+		ObjectStoreKey: store.Key{APIVersion: "autoscaling/v1", Kind: "HorizontalPodAutoscaler"},
+		ListType:       &autoscalingv1.HorizontalPodAutoscalerList{},
+		ObjectType:     &autoscalingv1.HorizontalPodAutoscaler{},
+		Titles:         ResourceTitle{List: "Horizontal Pod Autoscalers", Object: "Horizontal Pod Autoscalers"},
+		RootPath:       ResourceLink{Title: "Discovery and Load Balancing", Url: "/overview/namespace/($NAMESPACE)/discovery-and-load-balancing"},
+	})
+
 	dlbIngresses := NewResource(ResourceOptions{
 		Path:           "/discovery-and-load-balancing/ingresses",
 		ObjectStoreKey: store.Key{APIVersion: "extensions/v1beta1", Kind: "Ingress"},
 		ListType:       &v1beta1.IngressList{},
 		ObjectType:     &v1beta1.Ingress{},
 		Titles:         ResourceTitle{List: "Ingresses", Object: "Ingresses"},
-		IconName:       icon.OverviewIngress,
 		RootPath:       ResourceLink{Title: "Discovery and Load Balancing", Url: "/overview/namespace/($NAMESPACE)/discovery-and-load-balancing"},
 	})
 
@@ -162,7 +162,6 @@ func initNamespacedOverview() *Section {
 		ListType:       &corev1.ServiceList{},
 		ObjectType:     &corev1.Service{},
 		Titles:         ResourceTitle{List: " Services", Object: "Services"},
-		IconName:       icon.OverviewService,
 		RootPath:       ResourceLink{Title: "Discovery and Load Balancing", Url: "/overview/namespace/($NAMESPACE)/discovery-and-load-balancing"},
 	})
 
@@ -173,12 +172,12 @@ func initNamespacedOverview() *Section {
 		ObjectType:     &networkingv1.NetworkPolicy{},
 		Titles:         ResourceTitle{List: "Network Policies", Object: "Network Policy"},
 		RootPath:       ResourceLink{Title: "Discovery and Load Balancing", Url: "/overview/namespace/($NAMESPACE)/discovery-and-load-balancing"},
-		IconName:       icon.OverviewNetworkPolicy,
 	})
 
 	discoveryAndLoadBalancingDescriber := NewSection(
 		"/discovery-and-load-balancing",
 		"Discovery and Load Balancing",
+		dlbHorizontalPodAutoscalers,
 		dlbIngresses,
 		dlbServices,
 		dlbNetworkPolicies,
@@ -190,7 +189,6 @@ func initNamespacedOverview() *Section {
 		ListType:       &corev1.ConfigMapList{},
 		ObjectType:     &corev1.ConfigMap{},
 		Titles:         ResourceTitle{List: "Config Maps", Object: "Config Maps"},
-		IconName:       icon.OverviewConfigMap,
 		RootPath:       ResourceLink{Title: "Config and Storage", Url: "/overview/namespace/($NAMESPACE)/config-and-storage"},
 	})
 
@@ -200,7 +198,6 @@ func initNamespacedOverview() *Section {
 		ListType:       &corev1.PersistentVolumeClaimList{},
 		ObjectType:     &corev1.PersistentVolumeClaim{},
 		Titles:         ResourceTitle{List: "Persistent Volume Claims", Object: "Persistent Volume Claims"},
-		IconName:       icon.OverviewPersistentVolumeClaim,
 		RootPath:       ResourceLink{Title: "Config and Storage", Url: "/overview/namespace/($NAMESPACE)/config-and-storage"},
 	})
 
@@ -210,7 +207,6 @@ func initNamespacedOverview() *Section {
 		ListType:       &corev1.SecretList{},
 		ObjectType:     &corev1.Secret{},
 		Titles:         ResourceTitle{List: "Secrets", Object: "Secrets"},
-		IconName:       icon.OverviewSecret,
 		RootPath:       ResourceLink{Title: "Config and Storage", Url: "/overview/namespace/($NAMESPACE)/config-and-storage"},
 	})
 
@@ -220,7 +216,6 @@ func initNamespacedOverview() *Section {
 		ListType:       &corev1.ServiceAccountList{},
 		ObjectType:     &corev1.ServiceAccount{},
 		Titles:         ResourceTitle{List: "Service Accounts", Object: "Service Accounts"},
-		IconName:       icon.OverviewServiceAccount,
 		RootPath:       ResourceLink{Title: "Config and Storage", Url: "/overview/namespace/($NAMESPACE)/config-and-storage"},
 	})
 
@@ -239,7 +234,6 @@ func initNamespacedOverview() *Section {
 		ListType:       &rbacv1.RoleList{},
 		ObjectType:     &rbacv1.Role{},
 		Titles:         ResourceTitle{List: "Roles", Object: "Roles"},
-		IconName:       icon.OverviewRole,
 		RootPath:       ResourceLink{Title: "RBAC", Url: "/overview/namespace/($NAMESPACE)/rbac"},
 	})
 
@@ -249,7 +243,6 @@ func initNamespacedOverview() *Section {
 		ListType:       &rbacv1.RoleBindingList{},
 		ObjectType:     &rbacv1.RoleBinding{},
 		Titles:         ResourceTitle{List: "Role Bindings", Object: "Role Bindings"},
-		IconName:       icon.OverviewRoleBinding,
 		RootPath:       ResourceLink{Title: "RBAC", Url: "/overview/namespace/($NAMESPACE)/rbac"},
 	})
 

--- a/internal/printer/handler.go
+++ b/internal/printer/handler.go
@@ -27,6 +27,8 @@ func AddHandlers(p Handler) error {
 		DaemonSetHandler,
 		DeploymentHandler,
 		DeploymentListHandler,
+		HorizontalPodAutoscalerHandler,
+		HorizontalPodAutoscalerListHandler,
 		IngressListHandler,
 		IngressHandler,
 		JobListHandler,

--- a/internal/printer/horizontalpodautoscaler.go
+++ b/internal/printer/horizontalpodautoscaler.go
@@ -1,0 +1,607 @@
+/*
+Copyright (c) 2020 the Octant contributors. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package printer
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/pkg/errors"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/vmware-tanzu/octant/pkg/store"
+	"github.com/vmware-tanzu/octant/pkg/view/component"
+)
+
+// HorizontalPodAutoscalerListHandler is a printFunc that lists horizontal pod autoscalers
+func HorizontalPodAutoscalerListHandler(ctx context.Context, list *autoscalingv1.HorizontalPodAutoscalerList, options Options) (component.Component, error) {
+	if list == nil {
+		return nil, errors.New("horizontalpod handler list is nil")
+	}
+
+	cols := component.NewTableCols("Name", "Labels", "Targets", "Minimum Pods", "Maximum Pods", "Replicas", "Age")
+	ot := NewObjectTable("Horizontal Pod Autoscalers",
+		"We couldn't find any horizontal pod autoscalers", cols, options.DashConfig.ObjectStore())
+
+	for _, horizontalPodAutoscaler := range list.Items {
+		row := component.TableRow{}
+		nameLink, err := options.Link.ForObject(&horizontalPodAutoscaler, horizontalPodAutoscaler.Name)
+		if err != nil {
+			return nil, err
+		}
+
+		horizontalPodAutoscalerMetrics, horizontalPodAutoscalerCurrentMetrics, err := parseAnnotations(horizontalPodAutoscaler)
+		if err != nil {
+			return nil, errors.Wrap(err, "can't parse annotations")
+		}
+
+		aggregatedMetricTargets, err := getCombinedMetrics(horizontalPodAutoscaler, horizontalPodAutoscalerMetrics, horizontalPodAutoscalerCurrentMetrics)
+		if err != nil {
+			return nil, errors.Wrap(err, "can't combine metrics")
+		}
+
+		row["Name"] = nameLink
+		row["Labels"] = component.NewLabels(horizontalPodAutoscaler.Labels)
+		row["Targets"] = component.NewText(aggregatedMetricTargets)
+		row["Minimum Pods"] = component.NewText(fmt.Sprintf("%d", *horizontalPodAutoscaler.Spec.MinReplicas))
+		row["Maximum Pods"] = component.NewText(fmt.Sprintf("%d", horizontalPodAutoscaler.Spec.MaxReplicas))
+		row["Replicas"] = component.NewText(fmt.Sprintf("%d", horizontalPodAutoscaler.Status.CurrentReplicas))
+		row["Age"] = component.NewTimestamp(horizontalPodAutoscaler.CreationTimestamp.Time)
+
+		if err := ot.AddRowForObject(ctx, &horizontalPodAutoscaler, row); err != nil {
+			return nil, fmt.Errorf("add row for object: %w", err)
+		}
+	}
+
+	return ot.ToComponent()
+}
+
+// HorizontalPodAutoscalerHandler is a printFunc that prints a HorizontalPodAutoscaler
+func HorizontalPodAutoscalerHandler(ctx context.Context, horizontalPodAutoscaler *autoscalingv1.HorizontalPodAutoscaler, options Options) (component.Component, error) {
+	o := NewObject(horizontalPodAutoscaler)
+	o.EnableEvents()
+
+	hh, err := newHorizontalPodAutoscalerHandler(horizontalPodAutoscaler, o)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := hh.Config(ctx, options); err != nil {
+		return nil, errors.Wrap(err, "print horizontalpodautoscaler configuration")
+	}
+
+	if err := hh.Status(); err != nil {
+		return nil, errors.Wrap(err, "print horizontalpodautoscaler status")
+	}
+
+	if err := hh.Metrics(ctx, options); err != nil {
+		return nil, errors.Wrap(err, "print horizontalpodautoscaler metrics")
+	}
+
+	if err := hh.Conditions(); err != nil {
+		return nil, errors.Wrap(err, "print horizontalpodautoscaler conditions")
+	}
+
+	return o.ToComponent(ctx, options)
+}
+
+func createHorizontalPodAutoscalerSummaryStatus(horizontalPodAutoscaler *autoscalingv1.HorizontalPodAutoscaler) (*component.Summary, error) {
+	if horizontalPodAutoscaler == nil {
+		return nil, errors.New("unable to generate status for a nil horizontalpodautoscaler")
+	}
+
+	horizontalPodAutoscalerMetrics, horizontalPodAutoscalerCurrentMetrics, err := parseAnnotations(*horizontalPodAutoscaler)
+	if err != nil {
+		return nil, errors.Wrap(err, "can't parse annotations")
+	}
+
+	aggregatedMetricTargets, err := getCombinedMetrics(*horizontalPodAutoscaler, horizontalPodAutoscalerMetrics, horizontalPodAutoscalerCurrentMetrics)
+	if err != nil {
+		return nil, errors.Wrap(err, "can't combine metrics")
+	}
+
+	status := horizontalPodAutoscaler.Status
+
+	summary := component.NewSummary("Status")
+
+	sections := component.SummarySections{}
+
+	sections.AddText("Targets", aggregatedMetricTargets)
+
+	if status.ObservedGeneration != nil {
+		sections = append(sections, component.SummarySection{
+			Header:  "Observed Generation",
+			Content: component.NewText(fmt.Sprintf("%d", *status.ObservedGeneration)),
+		})
+	}
+
+	if status.LastScaleTime != nil {
+		sections = append(sections, component.SummarySection{
+			Header:  "Last Scale Time",
+			Content: component.NewTimestamp(status.LastScaleTime.Time),
+		})
+	}
+
+	sections.AddText("Current Replicas", fmt.Sprintf("%d", status.CurrentReplicas))
+	sections.AddText("Desired Replicas", fmt.Sprintf("%d", status.DesiredReplicas))
+
+	if status.CurrentCPUUtilizationPercentage != nil {
+		sections = append(sections, component.SummarySection{
+			Header:  "Current CPU Utilization Percentage",
+			Content: component.NewText(fmt.Sprintf("%d", *status.CurrentCPUUtilizationPercentage)),
+		})
+	}
+
+	summary.Add(sections...)
+
+	return summary, nil
+}
+
+func createHorizontalPodAutoscalerMetricsStatusView(metricStatus *autoscalingv1.MetricStatus, options Options) (*component.Summary, error) {
+	if metricStatus == nil {
+		return nil, errors.New("unable to generate metrics from a nil metric status")
+	}
+
+	sections := component.SummarySections{}
+	summary := component.NewSummary(fmt.Sprintf("Metric"))
+
+	sections.AddText("Type", fmt.Sprintf("%s", metricStatus.Type))
+
+	if metricStatus.Object != nil {
+		sections = append(sections, component.SummarySection{
+			Header:  "Name",
+			Content: component.NewText(metricStatus.Object.MetricName),
+		})
+
+		if metricStatus.Object.Target.Name != "" {
+			sections = append(sections, component.SummarySection{
+				Header:  "Described Object Name",
+				Content: component.NewText(metricStatus.Object.Target.Name),
+			})
+			sections = append(sections, component.SummarySection{
+				Header:  "Described Object API Version",
+				Content: component.NewText(metricStatus.Object.Target.APIVersion),
+			})
+			sections = append(sections, component.SummarySection{
+				Header:  "Described Object Kind",
+				Content: component.NewText(metricStatus.Object.Target.Kind),
+			})
+		}
+	}
+
+	if metricStatus.Pods != nil {
+		sections = append(sections, component.SummarySection{
+			Header:  "Name",
+			Content: component.NewText(metricStatus.Pods.MetricName),
+		})
+		sections = append(sections, component.SummarySection{
+			Header:  "Average Utilization",
+			Content: component.NewText(fmt.Sprint(&metricStatus.Pods.CurrentAverageValue)),
+		})
+	}
+
+	if metricStatus.Resource != nil {
+		sections = append(sections, component.SummarySection{
+			Header:  "Name",
+			Content: component.NewText(string(metricStatus.Resource.Name)),
+		})
+		if metricStatus.Resource.CurrentAverageUtilization != nil {
+			sections = append(sections, component.SummarySection{
+				Header:  "Average Utilization",
+				Content: component.NewText(fmt.Sprint(*metricStatus.Resource.CurrentAverageUtilization)),
+			})
+		}
+		sections = append(sections, component.SummarySection{
+			Header:  "Average Value",
+			Content: component.NewText(metricStatus.Resource.CurrentAverageValue.String()),
+		})
+	}
+
+	summary.Add(sections...)
+
+	return summary, nil
+}
+
+func createHorizontalPodAutoscalerConditionsView(horizontalPodAutoscaler *autoscalingv1.HorizontalPodAutoscaler) (*component.Table, error) {
+	if horizontalPodAutoscaler == nil {
+		return nil, errors.New("unable to generate conditions from a nil horizontalpodautoscaler")
+	}
+
+	cols := component.NewTableCols("Type", "Reason", "Status", "Message", "Last Transition")
+	table := component.NewTable("Conditions", "There are no horizontalpodautoscaler conditions!", cols)
+
+	horizontalPodAutoscalerConditions := make([]autoscalingv2beta2.HorizontalPodAutoscalerCondition, 0)
+
+	if conditions, ok := horizontalPodAutoscaler.Annotations["autoscaling.alpha.kubernetes.io/conditions"]; ok {
+		err := json.Unmarshal([]byte(conditions), &horizontalPodAutoscalerConditions)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	for _, condition := range horizontalPodAutoscalerConditions {
+		row := component.TableRow{
+			"Type":            component.NewText(string(condition.Type)),
+			"Reason":          component.NewText(condition.Reason),
+			"Status":          component.NewText(string(condition.Status)),
+			"Message":         component.NewText(condition.Message),
+			"Last Transition": component.NewTimestamp(condition.LastTransitionTime.Time),
+		}
+
+		table.Add(row)
+	}
+
+	table.Sort("Type", false)
+
+	return table, nil
+}
+
+// HorizontalPodAutoscalerConfiguration generates a horizontalpodautoscaler configuration
+type HorizontalPodAutoscalerConfiguration struct {
+	horizontalPodAutoscaler *autoscalingv1.HorizontalPodAutoscaler
+}
+
+// NewHorizontalPodAutoscalerConfiguration creates an instance of HorizontalPodAutoscalerConfiguration
+func NewHorizontalPodAutoscalerConfiguration(hpa *autoscalingv1.HorizontalPodAutoscaler) *HorizontalPodAutoscalerConfiguration {
+	return &HorizontalPodAutoscalerConfiguration{
+		horizontalPodAutoscaler: hpa,
+	}
+}
+
+type horizontalPodAutoscalerObject interface {
+	Config(ctx context.Context, options Options) error
+	Status() error
+	Metrics(ctx context.Context, options Options) error
+	Conditions() error
+}
+
+type horizontalPodAutoscalerHandler struct {
+	horizontalPodAutoScaler *autoscalingv1.HorizontalPodAutoscaler
+	configFunc              func(context.Context, *autoscalingv1.HorizontalPodAutoscaler, Options) (*component.Summary, error)
+	statusFunc              func(*autoscalingv1.HorizontalPodAutoscaler) (*component.Summary, error)
+	metricsFunc             func(context.Context, *autoscalingv1.MetricStatus, Options) (*component.Summary, error)
+	conditionsFunc          func(*autoscalingv1.HorizontalPodAutoscaler) (*component.Table, error)
+	object                  *Object
+}
+
+// Create creates a horizontalpodautoscaler configuration sumamry
+func (hc *HorizontalPodAutoscalerConfiguration) Create(ctx context.Context, options Options) (*component.Summary, error) {
+	if hc.horizontalPodAutoscaler == nil {
+		return nil, errors.New("horizontalpodautoscaler is nil")
+	}
+
+	hpa := hc.horizontalPodAutoscaler
+
+	sections := component.SummarySections{}
+
+	scaleTarget, err := forScaleTarget(ctx, hpa, &hpa.Spec.ScaleTargetRef, options)
+	if err != nil {
+		return nil, err
+	}
+
+	sections = append(sections, component.SummarySection{
+		Header:  "Scale target",
+		Content: scaleTarget,
+	})
+
+	minReplicas := fmt.Sprintf("%d", *hpa.Spec.MinReplicas)
+	maxReplicas := fmt.Sprintf("%d", hpa.Spec.MaxReplicas)
+	sections.AddText("Min Replicas", minReplicas)
+	sections.AddText("Max Replicas", maxReplicas)
+
+	b := autoscalingv2beta2.HorizontalPodAutoscalerBehavior{}
+
+	if behavior, ok := hpa.Annotations["autoscaling.alpha.kubernetes.io/behavior"]; ok {
+		err := json.Unmarshal([]byte(behavior), &b)
+		if err != nil {
+			return nil, err
+		}
+
+		var upPolicies, downPolicies []string
+		for _, policy := range b.ScaleUp.Policies {
+			p := fmt.Sprintf("%d %s / %d seconds", policy.Value, policy.Type, policy.PeriodSeconds)
+			upPolicies = append(upPolicies, p)
+		}
+
+		for _, policy := range b.ScaleDown.Policies {
+			p := fmt.Sprintf("%d %s / %d seconds", policy.Value, policy.Type, policy.PeriodSeconds)
+			downPolicies = append(downPolicies, p)
+		}
+
+		cols := component.NewTableCols("Stabilization Window", "Select Policies", "Policies")
+		scaleUpTbl := component.NewTableWithRows("", "There are no scale up policies!", cols,
+			[]component.TableRow{
+				{
+					"Stabilization Window": component.NewText(fmt.Sprint(*b.ScaleUp.StabilizationWindowSeconds) + " seconds"),
+					"Select Policies":      component.NewText(fmt.Sprint(*b.ScaleUp.SelectPolicy)),
+					"Policies":             component.NewText(strings.Join(upPolicies, ", ")),
+				},
+			})
+		sections.Add("Scale Up", scaleUpTbl)
+
+		scaleDownTbl := component.NewTableWithRows("", "There are no scale down policies!", cols,
+			[]component.TableRow{
+				{
+					"Stabilization Window": component.NewText(fmt.Sprint(*b.ScaleDown.StabilizationWindowSeconds) + " seconds"),
+					"Select Policies":      component.NewText(fmt.Sprint(*b.ScaleDown.SelectPolicy)),
+					"Policies":             component.NewText(strings.Join(downPolicies, ", ")),
+				},
+			})
+		sections.Add("Scale Down", scaleDownTbl)
+	}
+
+	summary := component.NewSummary("Configuration", sections...)
+	return summary, nil
+}
+
+var _ horizontalPodAutoscalerObject = (*horizontalPodAutoscalerHandler)(nil)
+
+func newHorizontalPodAutoscalerHandler(horizontalPodAutoscaler *autoscalingv1.HorizontalPodAutoscaler, object *Object) (*horizontalPodAutoscalerHandler, error) {
+	if horizontalPodAutoscaler == nil {
+		return nil, errors.New("can't print a nil horizontalpodautoscaler")
+	}
+
+	if object == nil {
+		return nil, errors.New("can't print horizontalpodautoscaler using a nil object printer")
+	}
+
+	hh := &horizontalPodAutoscalerHandler{
+		horizontalPodAutoScaler: horizontalPodAutoscaler,
+		configFunc:              defaultHorizontalPodAutoscalerConfig,
+		statusFunc:              defaultHorizontalPodAutoscalerStatus,
+		metricsFunc:             defaultHorizontalPodAutoscalerMetrics,
+		conditionsFunc:          defaultHorizontalPodAutoscalerConditions,
+		object:                  object,
+	}
+
+	return hh, nil
+}
+
+func (h *horizontalPodAutoscalerHandler) Config(ctx context.Context, options Options) error {
+	out, err := h.configFunc(ctx, h.horizontalPodAutoScaler, options)
+	if err != nil {
+		return err
+	}
+
+	h.object.RegisterConfig(out)
+	return nil
+}
+
+func defaultHorizontalPodAutoscalerConfig(ctx context.Context, horizontalPodAutoscaler *autoscalingv1.HorizontalPodAutoscaler, options Options) (*component.Summary, error) {
+	return NewHorizontalPodAutoscalerConfiguration(horizontalPodAutoscaler).Create(ctx, options)
+}
+
+func (h *horizontalPodAutoscalerHandler) Status() error {
+	out, err := h.statusFunc(h.horizontalPodAutoScaler)
+	if err != nil {
+		return err
+	}
+
+	h.object.RegisterSummary(out)
+	return nil
+}
+
+func defaultHorizontalPodAutoscalerStatus(horizontalPodAutoscaler *autoscalingv1.HorizontalPodAutoscaler) (*component.Summary, error) {
+	return createHorizontalPodAutoscalerSummaryStatus(horizontalPodAutoscaler)
+}
+
+func (h *horizontalPodAutoscalerHandler) metrics(ctx context.Context, currentMetrics []autoscalingv1.MetricStatus, options Options) error {
+	if h == nil || h.horizontalPodAutoScaler == nil {
+		return errors.New("can't display metrics for nil horizontalpodautoscaler")
+	}
+
+	for i := range currentMetrics {
+		metric := currentMetrics[i]
+
+		if metric.Type == "" {
+			continue
+		}
+
+		h.object.RegisterItems(ItemDescriptor{
+			Width: component.WidthFull,
+			Func: func() (component.Component, error) {
+				return h.metricsFunc(ctx, &metric, options)
+			},
+		})
+	}
+
+	return nil
+}
+
+func (h *horizontalPodAutoscalerHandler) Metrics(ctx context.Context, options Options) error {
+	if h.horizontalPodAutoScaler == nil {
+		return errors.New("can't display metrics for nil horizontalpodautoscaler")
+	}
+
+	_, metricStatus, err := parseAnnotations(*h.horizontalPodAutoScaler)
+	if err != nil {
+		return errors.New("can't parse annotations for metrics")
+	}
+
+	return h.metrics(ctx, metricStatus, options)
+}
+
+func defaultHorizontalPodAutoscalerMetrics(ctx context.Context, metricStatus *autoscalingv1.MetricStatus, options Options) (*component.Summary, error) {
+	return createHorizontalPodAutoscalerMetricsStatusView(metricStatus, options)
+}
+
+func (h *horizontalPodAutoscalerHandler) Conditions() error {
+	if h.horizontalPodAutoScaler == nil {
+		return errors.New("can't display conditions for nil horizontalpodautoscaler")
+	}
+
+	h.object.RegisterItems(ItemDescriptor{
+		Width: component.WidthFull,
+		Func: func() (component.Component, error) {
+			return h.conditionsFunc(h.horizontalPodAutoScaler)
+		},
+	})
+
+	return nil
+}
+
+func defaultHorizontalPodAutoscalerConditions(horizontalPodAutoscaler *autoscalingv1.HorizontalPodAutoscaler) (*component.Table, error) {
+	return createHorizontalPodAutoscalerConditionsView(horizontalPodAutoscaler)
+}
+
+// forScaleTarget returns a scale target for a cross version object reference
+func forScaleTarget(ctx context.Context, object runtime.Object, scaleTarget *autoscalingv1.CrossVersionObjectReference, options Options) (*component.Link, error) {
+	if scaleTarget == nil || object == nil {
+		return component.NewLink("", "none", ""), nil
+	}
+
+	accessor := meta.NewAccessor()
+	ns, err := accessor.Namespace(object)
+	if err != nil {
+		return component.NewLink("", "none", ""), nil
+	}
+
+	key := store.Key{
+		Namespace:  ns,
+		APIVersion: scaleTarget.APIVersion,
+		Kind:       scaleTarget.Kind,
+		Name:       scaleTarget.Name,
+	}
+
+	objectStore := options.DashConfig.ObjectStore()
+	u, err := objectStore.Get(ctx, key)
+	if err != nil || u == nil {
+		return component.NewLink("", "none", ""), nil
+	}
+
+	return options.Link.ForGVK(
+		ns,
+		scaleTarget.APIVersion,
+		scaleTarget.Kind,
+		scaleTarget.Name,
+		scaleTarget.Name,
+	)
+}
+
+func getCombinedMetrics(horizontalPodAutoscaler autoscalingv1.HorizontalPodAutoscaler, metricSpec []autoscalingv1.MetricSpec, metricStatus []autoscalingv1.MetricStatus) (string, error) {
+	var targets = make(map[string]string)
+	var currents = make(map[string]string)
+
+	for _, m := range metricSpec {
+		switch m.Type {
+		case autoscalingv1.ObjectMetricSourceType:
+			if m.Object != nil {
+				if m.Object.MetricName != "" {
+					targets[m.Object.MetricName] = m.Object.TargetValue.String()
+				}
+			}
+		case autoscalingv1.PodsMetricSourceType:
+			if m.Pods != nil {
+				if m.Pods.MetricName != "" {
+					target := m.Pods.TargetAverageValue.String()
+					targets[m.Pods.MetricName] = target
+				}
+			}
+
+		case autoscalingv1.ResourceMetricSourceType:
+			if m.Resource != nil {
+				if m.Resource.Name != "" {
+					targets[string(m.Resource.Name)] = m.Resource.TargetAverageValue.String()
+				}
+			}
+		}
+	}
+
+	for _, m := range metricStatus {
+		current, err := getMetricStatusValue(&m)
+		if err != nil {
+			return "", err
+		}
+
+		switch m.Type {
+		case autoscalingv1.ObjectMetricSourceType:
+			if m.Object != nil {
+				if m.Object.MetricName != "" {
+					currents[m.Object.MetricName] = current
+				}
+			}
+		case autoscalingv1.PodsMetricSourceType:
+			if m.Pods != nil {
+				if m.Pods.MetricName != "" {
+					currents[m.Pods.MetricName] = current
+				}
+			}
+		case autoscalingv1.ResourceMetricSourceType:
+			if m.Resource != nil {
+				if m.Resource.Name != "" {
+					currents[string(m.Resource.Name)] = current
+				}
+			}
+		}
+	}
+
+	var result []string
+	keys := make([]string, 0, len(targets))
+	for k := range targets {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		if currents[k] == "" {
+			currents[k] = "<unknown>"
+		}
+		result = append(result, currents[k]+"/"+targets[k])
+	}
+
+	if horizontalPodAutoscaler.Spec.TargetCPUUtilizationPercentage != nil && horizontalPodAutoscaler.Status.CurrentCPUUtilizationPercentage != nil {
+		cpu := fmt.Sprintf("%d/%d", *horizontalPodAutoscaler.Status.CurrentCPUUtilizationPercentage, *horizontalPodAutoscaler.Spec.TargetCPUUtilizationPercentage) + "%"
+		result = append(result, cpu)
+	}
+
+	return strings.Join(result, ", "), nil
+}
+
+func getMetricStatusValue(metricStatus *autoscalingv1.MetricStatus) (string, error) {
+	var value string
+	if metricStatus == nil {
+		return "", errors.New("nil metric status")
+	}
+
+	switch metricStatus.Type {
+	case autoscalingv1.ObjectMetricSourceType:
+		value = metricStatus.Object.CurrentValue.String()
+	case autoscalingv1.PodsMetricSourceType:
+		value = metricStatus.Pods.CurrentAverageValue.String()
+	case autoscalingv1.ResourceMetricSourceType:
+		value = metricStatus.Resource.CurrentAverageValue.String()
+	case autoscalingv1.ExternalMetricSourceType:
+		value = metricStatus.External.CurrentAverageValue.String()
+	}
+
+	return value, nil
+}
+
+func parseAnnotations(horizontalPodAutoscaler autoscalingv1.HorizontalPodAutoscaler) ([]autoscalingv1.MetricSpec, []autoscalingv1.MetricStatus, error) {
+	horizontalPodAutoscalerMetrics := make([]autoscalingv1.MetricSpec, 0)
+	horizontalPodAutoscalerCurrentMetrics := make([]autoscalingv1.MetricStatus, 0)
+
+	if metrics, ok := horizontalPodAutoscaler.Annotations["autoscaling.alpha.kubernetes.io/metrics"]; ok {
+		err := json.Unmarshal([]byte(metrics), &horizontalPodAutoscalerMetrics)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+	if currentMetrics, ok := horizontalPodAutoscaler.Annotations["autoscaling.alpha.kubernetes.io/current-metrics"]; ok {
+		err := json.Unmarshal([]byte(currentMetrics), &horizontalPodAutoscalerCurrentMetrics)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	return horizontalPodAutoscalerMetrics, horizontalPodAutoscalerCurrentMetrics, nil
+}

--- a/internal/printer/horizontalpodautoscaler_test.go
+++ b/internal/printer/horizontalpodautoscaler_test.go
@@ -1,0 +1,363 @@
+/*
+Copyright (c) 2019 the Octant contributors. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package printer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+	"github.com/vmware-tanzu/octant/internal/testutil"
+	"github.com/vmware-tanzu/octant/pkg/store"
+	"github.com/vmware-tanzu/octant/pkg/view/component"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_HorizontalPodAutoscalerListHandler(t *testing.T) {
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	tpo := newTestPrinterOptions(controller)
+	printOptions := tpo.ToOptions()
+
+	objectLabels := map[string]string{
+		"foo": "bar",
+	}
+
+	now := testutil.Time()
+	var minReplicas int32 = 1
+	var currentPercentCPU int32 = 5
+	var targetPercentCPU int32 = 50
+
+	object := &autoscalingv1.HorizontalPodAutoscaler{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "autoscaling/v1",
+			Kind:       "HorizontalPodAutoscaler",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "horizontalpodautoscaler",
+			Namespace: "default",
+			CreationTimestamp: metav1.Time{
+				Time: now,
+			},
+			Labels: objectLabels,
+		},
+		Spec: autoscalingv1.HorizontalPodAutoscalerSpec{
+			MinReplicas:                    &minReplicas,
+			MaxReplicas:                    10,
+			TargetCPUUtilizationPercentage: &targetPercentCPU,
+		},
+		Status: autoscalingv1.HorizontalPodAutoscalerStatus{
+			CurrentReplicas:                 2,
+			CurrentCPUUtilizationPercentage: &currentPercentCPU,
+		},
+	}
+
+	tpo.PathForObject(object, object.Name, "/path")
+
+	list := &autoscalingv1.HorizontalPodAutoscalerList{
+		Items: []autoscalingv1.HorizontalPodAutoscaler{*object},
+	}
+
+	ctx := context.Background()
+	got, err := HorizontalPodAutoscalerListHandler(ctx, list, printOptions)
+	require.NoError(t, err)
+
+	cols := component.NewTableCols("Name", "Labels", "Targets", "Minimum Pods", "Maximum Pods", "Replicas", "Age")
+	expected := component.NewTable("Horizontal Pod Autoscalers", "We couldn't find any horizontal pod autoscalers", cols)
+	expected.Add(component.TableRow{
+		"Name": component.NewLink("", "horizontalpodautoscaler", "/path",
+			genObjectStatus(component.TextStatusOK, []string{"autoscaling/v1 HorizontalPodAutoscaler is OK"})),
+		"Labels":       component.NewLabels(objectLabels),
+		"Targets":      component.NewText("5/50%"),
+		"Minimum Pods": component.NewText("1"),
+		"Maximum Pods": component.NewText("10"),
+		"Replicas":     component.NewText("2"),
+		"Age":          component.NewTimestamp(now),
+		component.GridActionKey: gridActionsFactory([]component.GridAction{
+			buildObjectDeleteAction(t, object),
+		}),
+	})
+
+	component.AssertEqual(t, expected, got)
+}
+
+func Test_HorizontalPodAutoscalerConfiguration(t *testing.T) {
+	var replicas int32 = 1
+	hpa := testutil.CreateHorizontalPodAutoscaler("hpa")
+	hpa.Spec.MinReplicas = &replicas
+	hpa.Spec.MaxReplicas = 10
+
+	deployment := testutil.CreateDeployment("deployment")
+	hpa.Spec.ScaleTargetRef = autoscalingv1.CrossVersionObjectReference{
+		Kind:       deployment.Kind,
+		APIVersion: deployment.APIVersion,
+		Name:       deployment.Name,
+	}
+
+	cases := []struct {
+		name                    string
+		horizontalPodAutoscaler *autoscalingv1.HorizontalPodAutoscaler
+		expected                component.Component
+		isErr                   bool
+	}{
+		{
+			name:                    "general",
+			horizontalPodAutoscaler: hpa,
+			expected: component.NewSummary("Configuration", []component.SummarySection{
+				{
+					Header:  "Scale target",
+					Content: component.NewLink("", "deployment", "/deployment"),
+				},
+				{
+					Header:  "Min Replicas",
+					Content: component.NewText("1"),
+				},
+				{
+					Header:  "Max Replicas",
+					Content: component.NewText("10"),
+				},
+			}...),
+		},
+		{
+			name:                    "nil horizontalpodautoscaler",
+			horizontalPodAutoscaler: nil,
+			isErr:                   true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			controller := gomock.NewController(t)
+			defer controller.Finish()
+
+			ctx := context.Background()
+
+			tpo := newTestPrinterOptions(controller)
+			printOptions := tpo.ToOptions()
+
+			hc := NewHorizontalPodAutoscalerConfiguration(tc.horizontalPodAutoscaler)
+
+			scaleTarget := component.NewLink("", "deployment", "/deployment")
+			tpo.link.EXPECT().
+				ForGVK("namespace", "apps/v1", "Deployment", "deployment", "deployment").
+				Return(scaleTarget, nil).
+				AnyTimes()
+
+			if tc.horizontalPodAutoscaler != nil {
+				key := store.Key{
+					APIVersion: deployment.APIVersion,
+					Kind:       deployment.Kind,
+					Name:       deployment.Name,
+					Namespace:  deployment.Namespace,
+				}
+				tpo.objectStore.EXPECT().Get(ctx, gomock.Eq(key)).Return(testutil.ToUnstructured(t, deployment), nil)
+			}
+
+			summary, err := hc.Create(ctx, printOptions)
+			if tc.isErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			component.AssertEqual(t, tc.expected, summary)
+		})
+	}
+}
+
+func Test_createHorizontalPodAutoscalerSummaryStatus(t *testing.T) {
+	var observedGeneration int64 = 1
+	var currentCPU int32 = 3
+	var targetCPUPercent int32 = 80
+	now := testutil.Time()
+
+	hpa := testutil.CreateHorizontalPodAutoscaler("hpa")
+	hpa.Status.ObservedGeneration = &observedGeneration
+	hpa.Status.LastScaleTime = &metav1.Time{Time: now}
+	hpa.Status.CurrentReplicas = 2
+	hpa.Status.DesiredReplicas = 7
+	hpa.Status.CurrentCPUUtilizationPercentage = &currentCPU
+	hpa.Spec.TargetCPUUtilizationPercentage = &targetCPUPercent
+
+	cases := []struct {
+		name                    string
+		horizontalPodAutoscaler *autoscalingv1.HorizontalPodAutoscaler
+		expected                *component.Summary
+		isErr                   bool
+	}{
+		{
+			name:                    "in general",
+			horizontalPodAutoscaler: hpa,
+			expected: component.NewSummary("Status", []component.SummarySection{
+				{
+					Header:  "Targets",
+					Content: component.NewText("3/80%"),
+				},
+				{
+					Header:  "Observed Generation",
+					Content: component.NewText("1"),
+				},
+				{
+					Header:  "Last Scale Time",
+					Content: component.NewTimestamp(now),
+				},
+				{
+					Header:  "Current Replicas",
+					Content: component.NewText("2"),
+				},
+				{
+					Header:  "Desired Replicas",
+					Content: component.NewText("7"),
+				},
+				{
+					Header:  "Current CPU Utilization Percentage",
+					Content: component.NewText("3"),
+				},
+			}...),
+		},
+		{
+			name:                    "nil horizontalpodautoscaler",
+			horizontalPodAutoscaler: nil,
+			isErr:                   true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			summary, err := createHorizontalPodAutoscalerSummaryStatus(tc.horizontalPodAutoscaler)
+			if tc.isErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			component.AssertEqual(t, tc.expected, summary)
+		})
+	}
+}
+
+func Test_HorizontalPodAutoscalerMetrics(t *testing.T) {
+	var averageUtilization int32 = 20
+	metricResource := autoscalingv1.MetricStatus{
+		Type: autoscalingv1.ResourceMetricSourceType,
+		Resource: &autoscalingv1.ResourceMetricStatus{
+			Name:                      "cpu",
+			CurrentAverageUtilization: &averageUtilization,
+		},
+	}
+
+	metricPods := autoscalingv1.MetricStatus{
+		Type: autoscalingv1.PodsMetricSourceType,
+		Pods: &autoscalingv1.PodsMetricStatus{
+			MetricName:          "packets-per-second",
+			CurrentAverageValue: *resource.NewMilliQuantity(1000, resource.DecimalSI),
+		},
+	}
+
+	cases := []struct {
+		name         string
+		metricStatus *autoscalingv1.MetricStatus
+		expected     *component.Summary
+		isErr        bool
+	}{
+		{
+			name:         "resource type",
+			metricStatus: &metricResource,
+			expected: component.NewSummary("Metric", []component.SummarySection{
+				{
+					Header:  "Type",
+					Content: component.NewText("Resource"),
+				},
+				{
+					Header:  "Name",
+					Content: component.NewText("cpu"),
+				},
+				{
+					Header:  "Average Utilization",
+					Content: component.NewText("20"),
+				},
+				{
+					Header:  "Average Value",
+					Content: component.NewText("0"),
+				},
+			}...),
+		},
+		{
+			name:         "pods type",
+			metricStatus: &metricPods,
+			expected: component.NewSummary("Metric", []component.SummarySection{
+				{
+					Header:  "Type",
+					Content: component.NewText("Pods"),
+				},
+				{
+					Header:  "Name",
+					Content: component.NewText("packets-per-second"),
+				},
+				{
+					Header:  "Average Utilization",
+					Content: component.NewText("1"),
+				},
+			}...),
+		},
+		{
+			name:         "nil metric",
+			metricStatus: nil,
+			isErr:        true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			controller := gomock.NewController(t)
+			defer controller.Finish()
+
+			tpo := newTestPrinterOptions(controller)
+			printOptions := tpo.ToOptions()
+
+			summary, err := createHorizontalPodAutoscalerMetricsStatusView(tc.metricStatus, printOptions)
+			if tc.isErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			component.AssertEqual(t, tc.expected, summary)
+		})
+	}
+}
+
+func Test_createHorizontalPodAutoscalerConditionsView(t *testing.T) {
+	now := metav1.Time{Time: testutil.Time()}
+
+	condition := `[{"type":"AbleToScale","status":"True","reason":"reason","message":"message","lastTransitionTime":"2019-01-11T12:57:10Z"}]`
+
+	horizontalPodAutoscaler := testutil.CreateHorizontalPodAutoscaler("hpa")
+	horizontalPodAutoscaler.Annotations = map[string]string{
+		"autoscaling.alpha.kubernetes.io/conditions": condition,
+	}
+
+	got, err := createHorizontalPodAutoscalerConditionsView(horizontalPodAutoscaler)
+	require.NoError(t, err)
+
+	cols := component.NewTableCols("Type", "Reason", "Status", "Message", "Last Transition")
+	expected := component.NewTable("Conditions", "There are no horizontalpodautoscaler conditions!", cols)
+	expected.Add([]component.TableRow{
+		{
+			"Type":            component.NewText("AbleToScale"),
+			"Reason":          component.NewText("reason"),
+			"Status":          component.NewText("True"),
+			"Message":         component.NewText("message"),
+			"Last Transition": component.NewTimestamp(now.Time),
+		},
+	}...)
+
+	component.AssertEqual(t, expected, got)
+}

--- a/pkg/icon/icon.go
+++ b/pkg/icon/icon.go
@@ -5,7 +5,6 @@ SPDX-License-Identifier: Apache-2.0
 
 package icon
 
-
 const (
 	// Names of Clarity icons
 	Applications              = "application"
@@ -32,23 +31,4 @@ const (
 	ConfigurationPlugin = "plugin"
 
 	CustomResourceDefinition = "crd"
-
-	OverviewConfigMap               = "cm"
-	OverviewCronJob                 = "cronjob"
-	OverviewDaemonSet               = "ds"
-	OverviewDeployment              = "deploy"
-	OverviewHorizontalPodAutoscaler = "hpa"
-	OverviewIngress                 = "ing"
-	OverviewJob                     = "job"
-	OverviewNetworkPolicy           = "netpol"
-	OverviewPersistentVolumeClaim   = "pvc"
-	OverviewPod                     = "pod"
-	OverviewReplicaSet              = "rs"
-	OverviewReplicationController   = "deploy"
-	OverviewRole                    = "role"
-	OverviewRoleBinding             = "rb"
-	OverviewSecret                  = "secret"
-	OverviewService                 = "svc"
-	OverviewServiceAccount          = "sa"
-	OverviewStatefulSet             = "sts"
 )


### PR DESCRIPTION
Uses a workaround to optimistically parse data not found in v1 via annotations

**Which issue(s) this PR fixes**
- Fixes #930

**Special notes for your reviewer**:
Also adds support for https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-configurable-scaling-behavior for 1.18+