### PR TITLE
Check replica spec for desired replica count

### DIFF
--- a/internal/objectstatus/replicaset.go
+++ b/internal/objectstatus/replicaset.go
@@ -32,9 +32,13 @@ func replicaSetAppsV1(_ context.Context, object runtime.Object, _ store.Store) (
 	}
 
 	status := replicaSet.Status
+	specReplicas := int32(0)
+	if r := replicaSet.Spec.Replicas; r != nil {
+		specReplicas = *r
+	}
 
 	switch {
-	case status.Replicas == 0:
+	case status.Replicas == 0 && specReplicas != 0:
 		return ObjectStatus{
 			nodeStatus: component.NodeStatusError,
 			Details:    []component.Component{component.NewText("Replica Set has no replicas available")},

--- a/internal/objectstatus/replicaset_test.go
+++ b/internal/objectstatus/replicaset_test.go
@@ -52,6 +52,18 @@ func Test_replicaSetAppsV1(t *testing.T) {
 			},
 		},
 		{
+			name: "zero replicas",
+			init: func(t *testing.T, o *storefake.MockStore) runtime.Object {
+				objectFile := "replicaset_zero_replicas.yaml"
+				return testutil.LoadObjectFromFile(t, objectFile)
+
+			},
+			expected: ObjectStatus{
+				nodeStatus: component.NodeStatusOK,
+				Details:    []component.Component{component.NewText("Replica Set is OK")},
+			},
+		},
+		{
 			name: "not available",
 			init: func(t *testing.T, o *storefake.MockStore) runtime.Object {
 				objectFile := "replicaset_not_available.yaml"

--- a/internal/objectstatus/testdata/replicaset_zero_replicas.yaml
+++ b/internal/objectstatus/testdata/replicaset_zero_replicas.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  annotations:
+    deployment.kubernetes.io/desired-replicas: "1"
+    deployment.kubernetes.io/max-replicas: "2"
+    deployment.kubernetes.io/revision: "1"
+  creationTimestamp: "2019-02-11T21:00:19Z"
+  generation: 1
+  labels:
+    app: hello-node
+    pod-template-hash: 64c578bdf8
+  name: hello-node-64c578bdf8
+  namespace: default
+  ownerReferences:
+  - apiVersion: apps/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Deployment
+    name: hello-node
+    uid: 0a64996f-2e40-11e9-b01e-025000000001
+  resourceVersion: "1489487"
+  selfLink: /apis/extensions/v1beta1/namespaces/default/replicasets/hello-node-64c578bdf8
+  uid: 0a65f564-2e40-11e9-b01e-025000000001
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      app: hello-node
+      pod-template-hash: 64c578bdf8
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: hello-node
+        pod-template-hash: 64c578bdf8
+    spec:
+      containers:
+      - image: gcr.io/hello-minikube-zero-install/hello-node
+        imagePullPolicy: Always
+        name: hello-node
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+status:
+  availableReplicas: 0
+  fullyLabeledReplicas: 0
+  observedGeneration: 0
+  readyReplicas: 0
+  replicas: 0


### PR DESCRIPTION
**What this PR does / why we need it**:

Check replica spec for desired replica counts. This fixes the issue where you have a replica set with 0 desired and Octant reporting it as an error.

**Which issue(s) this PR fixes**
- Fixes #960

**Release note**:
```
ReplicaSet with zero replicas should not always be an error.
```
