### PR TITLE
show custom resources in overview

### DIFF
--- a/internal/describer/crd_list.go
+++ b/internal/describer/crd_list.go
@@ -8,33 +8,25 @@ package describer
 import (
 	"context"
 
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-
-	"github.com/vmware-tanzu/octant/internal/link"
-	"github.com/vmware-tanzu/octant/internal/modules/overview/yamlviewer"
 	"github.com/vmware-tanzu/octant/internal/printer"
 	"github.com/vmware-tanzu/octant/pkg/view/component"
 )
-
-type crdListPrinter func(crdObject *unstructured.Unstructured, resources *unstructured.UnstructuredList, version string, linkGenerator link.Interface) (component.Component, error)
 
 type crdListDescriptionOption func(*crdList)
 
 type crdList struct {
 	base
 
-	name    string
-	path    string
-	printer crdListPrinter
+	name string
+	path string
 }
 
 var _ Describer = (*crdList)(nil)
 
 func newCRDList(name, path string, options ...crdListDescriptionOption) *crdList {
 	d := &crdList{
-		name:    name,
-		path:    path,
-		printer: printer.CustomResourceListHandler,
+		name: name,
+		path: path,
 	}
 
 	for _, option := range options {
@@ -57,31 +49,19 @@ func (cld *crdList) Describe(ctx context.Context, namespace string, options Opti
 		Link:       options.Link,
 	}
 
+	title := getCrdTitle(namespace, crd, "")
+	contentResponse := component.NewContentResponse(title)
+
 	view, err := printer.CustomResourceDefinitionHandler(ctx, crd, namespace, printOptions)
 	if err != nil {
 		return component.EmptyContentResponse, err
 	}
-	view.SetAccessor("summary")
 
-	title := getCrdTitle(namespace, crd, "")
+	m := view.GetMetadata()
+	m.Title = getCrdTitle(namespace, crd, "")
+	view.SetMetadata(m)
 
-	contentResponse := component.NewContentResponse(title)
 	contentResponse.Add(view)
-
-	metadata, err := printer.MetadataHandler(crd, options.Link)
-	if err != nil {
-		return component.EmptyContentResponse, err
-	}
-	metadata.SetAccessor("metadata")
-	contentResponse.Add(metadata)
-
-	yamlView, err := yamlviewer.ToComponent(crd)
-	if err != nil {
-		return component.EmptyContentResponse, err
-	}
-	yamlView.SetAccessor("yaml")
-
-	contentResponse.Add(yamlView)
 
 	return *contentResponse, nil
 }

--- a/internal/describer/describer_test.go
+++ b/internal/describer/describer_test.go
@@ -23,6 +23,9 @@ func (c *emptyComponent) GetMetadata() component.Metadata {
 	}
 }
 
+func (c *emptyComponent) SetMetadata(_ component.Metadata) {
+}
+
 func (c *emptyComponent) SetAccessor(string) {
 	// no-op
 }

--- a/internal/describer/resource.go
+++ b/internal/describer/resource.go
@@ -7,10 +7,11 @@ package describer
 
 import (
 	"context"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"path"
 	"reflect"
 	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/vmware-tanzu/octant/pkg/store"
 	"github.com/vmware-tanzu/octant/pkg/view/component"
@@ -87,7 +88,7 @@ func (r *Resource) Object() *Object {
 			ObjectType: func() interface{} {
 				return reflect.New(reflect.ValueOf(r.ObjectType).Elem().Type()).Interface()
 			},
-			RootPath:   r.RootPath,
+			RootPath: r.RootPath,
 		},
 	)
 }
@@ -114,10 +115,11 @@ func getBreadcrumb(rootPath ResourceLink, objectTitle string, objectUrl string, 
 	return title
 }
 
+//
 func getCrdTitle(namespace string, crd *unstructured.Unstructured, objectName string) []component.TitleComponent {
 	var title []component.TitleComponent
 	if namespace == "" {
-		title= component.Title(component.NewLink("", "Cluster Overview", "/cluster-overview"),
+		title = component.Title(component.NewLink("", "Cluster Overview", "/cluster-overview"),
 			component.NewLink("", "Custom Resources", "/cluster-overview/custom-resources"))
 	} else {
 		title = component.Title(component.NewLink("", "Overview", "/overview/namespace/"+namespace),
@@ -125,10 +127,10 @@ func getCrdTitle(namespace string, crd *unstructured.Unstructured, objectName st
 	}
 
 	if objectName == "" {
-		title= append(title, component.NewText(crd.GetName()))
+		title = append(title, component.NewText(crd.GetName()))
 	} else {
-		title= append(title, component.NewLink("", crd.GetName(), getCrdUrl(namespace, crd)))
-		title= append(title, component.NewText(objectName))
+		title = append(title, component.NewLink("", crd.GetName(), getCrdUrl(namespace, crd)))
+		title = append(title, component.NewText(objectName))
 	}
 	return title
 }

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -110,6 +110,9 @@ func (c *emptyComponent) GetMetadata() component.Metadata {
 	}
 }
 
+func (c *emptyComponent) SetMetadata(_ component.Metadata) {
+}
+
 func (c *emptyComponent) SetAccessor(string) {
 	// no-op
 }

--- a/internal/octant/workload.go
+++ b/internal/octant/workload.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -375,6 +376,9 @@ func (wl *ClusterWorkloadLoader) Load(ctx context.Context, namespace string) ([]
 
 		owner, err := objectOwner(ctx, wl.ObjectStore, object)
 		if err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
 			return nil, fmt.Errorf("find owner for pod '%s': %w", object.GetName(), err)
 		}
 

--- a/internal/printer/customresource.go
+++ b/internal/printer/customresource.go
@@ -20,7 +20,7 @@ import (
 	"github.com/vmware-tanzu/octant/pkg/view/component"
 )
 
-// CustomResourceListHandler prints a list of custom resources with
+// CustomResourceListHandler prints a list of custom resources as a table with
 // optional custom columns.
 func CustomResourceListHandler(crdObject *unstructured.Unstructured, resources *unstructured.UnstructuredList, version string, linkGenerator link.Interface) (component.Component, error) {
 	if crdObject == nil {

--- a/internal/printer/customresourcedefinition.go
+++ b/internal/printer/customresourcedefinition.go
@@ -7,7 +7,6 @@ package printer
 
 import (
 	"context"
-	"fmt"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
@@ -18,15 +17,6 @@ import (
 )
 
 func CustomResourceDefinitionHandler(ctx context.Context, crd *unstructured.Unstructured, namespace string, options Options) (component.Component, error) {
-	object := NewObject(crd)
-	object.EnableEvents()
-
-	config, err := printCustomResourceDefinitionConfig(crd)
-	if err != nil {
-		return nil, err
-	}
-	object.RegisterConfig(config)
-
 	octantCRD, err := octant.NewCustomResourceDefinition(crd)
 	if err != nil {
 		return nil, err
@@ -39,81 +29,31 @@ func CustomResourceDefinitionHandler(ctx context.Context, crd *unstructured.Unst
 		return nil, err
 	}
 
+	list := component.NewList(nil, nil)
+
 	for i := range versions {
 		version := versions[i]
 
-		object.RegisterItems(ItemDescriptor{
-			Func: func() (component.Component, error) {
-				crGVK, err := gvk.CustomResource(crd, version)
-				if err != nil {
-					return nil, err
-				}
+		crGVK, err := gvk.CustomResource(crd, version)
+		if err != nil {
+			return nil, err
+		}
 
-				key := store.KeyFromGroupVersionKind(crGVK)
-				key.Namespace = namespace
+		key := store.KeyFromGroupVersionKind(crGVK)
+		key.Namespace = namespace
 
-				customResources, _, err := objectStore.List(ctx, key)
-				if err != nil {
-					return nil, err
-				}
+		customResources, _, err := objectStore.List(ctx, key)
+		if err != nil {
+			return nil, err
+		}
 
-				view, err := CustomResourceListHandler(crd, customResources, version, options.Link)
-				if err != nil {
-					return nil, err
-				}
+		view, err := CustomResourceListHandler(crd, customResources, version, options.Link)
+		if err != nil {
+			return nil, err
+		}
 
-				if view.IsEmpty() {
-					// if view is empty, return nil so the object printer will skip it.
-					return nil, nil
-				}
-
-				return view, nil
-			},
-			Width: component.WidthFull,
-		})
-
+		list.Add(view)
 	}
 
-	view, err := object.ToComponent(ctx, options)
-	if err != nil {
-		return nil, fmt.Errorf("print custom resource definition: %w", err)
-	}
-
-	return view, nil
-}
-
-func printCustomResourceDefinitionConfig(crd *unstructured.Unstructured) (*component.Summary, error) {
-	if crd == nil {
-		return nil, fmt.Errorf("custom resource definition is nil")
-	}
-
-	summary := component.NewSummary("Config")
-
-	group, err := nestedString(crd, "spec", "group")
-	if err != nil {
-		return nil, err
-	}
-
-	kind, err := nestedString(crd, "spec", "names", "kind")
-	if err != nil {
-		return nil, err
-	}
-
-	summary.AddSection("Group", component.NewText(group))
-	summary.AddSection("Kind", component.NewText(kind))
-
-	return summary, nil
-}
-
-func nestedString(object *unstructured.Unstructured, fields ...string) (string, error) {
-	s, found, err := unstructured.NestedString(object.Object, fields...)
-	if err != nil {
-		return "", err
-	}
-
-	if !found {
-		return "", nil
-	}
-
-	return s, nil
+	return list, nil
 }

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -178,6 +178,9 @@ func (v *stubComponent) GetMetadata() component.Metadata {
 	}
 }
 
+func (v *stubComponent) SetMetadata(_ component.Metadata) {
+}
+
 func (v *stubComponent) IsEmpty() bool {
 	return false
 }

--- a/pkg/view/component/base.go
+++ b/pkg/view/component/base.go
@@ -6,42 +6,40 @@ SPDX-License-Identifier: Apache-2.0
 package component
 
 const (
-	typeAnnotations         = "annotations"
-	typeButtonGroup         = "buttonGroup"
-	typeCard                = "card"
-	typeCardList            = "cardList"
-	typeCodeBlock           = "codeBlock"
-	typeContainers          = "containers"
-	typeDonutChart          = "donutChart"
-	typeEditor              = "editor"
-	typeError               = "error"
-	typeExtension           = "extension"
-	typeExpressionSelector  = "expressionSelector"
-	typeFlexLayout          = "flexlayout"
-	typeGraphviz            = "graphviz"
-	typeGridActions         = "gridActions"
-	typeIFrame              = "iframe"
-	typeLabels              = "labels"
-	typeLabelSelector       = "labelSelector"
-	typeLink                = "link"
-	typeList                = "list"
-	typeLoading             = "loading"
-	typeLogs                = "logs"
-	typePodStatus           = "podStatus"
-	typePort                = "port"
-	typePorts               = "ports"
-	typePortForward         = "portforward"
-	typeQuadrant            = "quadrant"
-	typeResourceViewer      = "resourceViewer"
-	typeSelectors           = "selectors"
-	typeSingleStat          = "singleStat"
-	typeSummary             = "summary"
-	typeTable               = "table"
-	typeTerminal            = "terminal"
-	typeText                = "text"
-	typeTimestamp           = "timestamp"
-	typeVerticalBulletChart = "verticalBulletChart"
-	typeYAML                = "yaml"
+	typeAnnotations        = "annotations"
+	typeButtonGroup        = "buttonGroup"
+	typeCard               = "card"
+	typeCardList           = "cardList"
+	typeCodeBlock          = "codeBlock"
+	typeContainers         = "containers"
+	typeDonutChart         = "donutChart"
+	typeEditor             = "editor"
+	typeError              = "error"
+	typeExtension          = "extension"
+	typeExpressionSelector = "expressionSelector"
+	typeFlexLayout         = "flexlayout"
+	typeGraphviz           = "graphviz"
+	typeGridActions        = "gridActions"
+	typeIFrame             = "iframe"
+	typeLabels             = "labels"
+	typeLabelSelector      = "labelSelector"
+	typeLink               = "link"
+	typeList               = "list"
+	typeLoading            = "loading"
+	typeLogs               = "logs"
+	typePodStatus          = "podStatus"
+	typePort               = "port"
+	typePorts              = "ports"
+	typeQuadrant           = "quadrant"
+	typeResourceViewer     = "resourceViewer"
+	typeSelectors          = "selectors"
+	typeSingleStat         = "singleStat"
+	typeSummary            = "summary"
+	typeTable              = "table"
+	typeTerminal           = "terminal"
+	typeText               = "text"
+	typeTimestamp          = "timestamp"
+	typeYAML               = "yaml"
 )
 
 // base is a base component.
@@ -63,6 +61,10 @@ func (b *base) GetMetadata() Metadata {
 	return b.Metadata
 }
 
+func (b *base) SetMetadata(metadata Metadata) {
+	b.Metadata = metadata
+}
+
 // SetAccessor sets the accessor for the object.
 func (b *base) SetAccessor(accessor string) {
 	b.Metadata.Accessor = accessor
@@ -81,6 +83,6 @@ func (b *base) String() string {
 }
 
 // LessThan returns false.
-func (b *base) LessThan(i interface{}) bool {
+func (b *base) LessThan(_ interface{}) bool {
 	return false
 }

--- a/pkg/view/component/component.go
+++ b/pkg/view/component/component.go
@@ -175,8 +175,10 @@ type Component interface {
 
 	// GetMetadata returns metadata for the component.
 	GetMetadata() Metadata
+	// GetMetadata sets the metadata for the component.
+	SetMetadata(metadata Metadata)
 	// SetAccessor sets the accessor for the component.
-	SetAccessor(string)
+	SetAccessor(accessor string)
 	// IsEmpty returns true if the component is "empty".
 	IsEmpty() bool
 	// String returns a string representation of the component.

--- a/pkg/view/component/table.go
+++ b/pkg/view/component/table.go
@@ -116,7 +116,7 @@ func NewTableCols(keys ...string) []TableCol {
 
 // IsEmpty returns true if there is one or more rows.
 func (t *Table) IsEmpty() bool {
-	return len(t.Config.Rows) < 1
+	return len(t.Config.Rows) == 0
 }
 
 func (t *Table) SetPlaceholder(placeholder string) {

--- a/web/src/app/modules/shared/components/presentation/datagrid/datagrid.component.ts
+++ b/web/src/app/modules/shared/components/presentation/datagrid/datagrid.component.ts
@@ -117,7 +117,7 @@ export class DatagridComponent implements OnChanges {
 
   showTitle() {
     if (this.view) {
-      return this.view.totalItems === undefined || this.view.totalItems > 1;
+      return this.view.totalItems === undefined || this.view.totalItems > 0;
     }
     return true;
   }


### PR DESCRIPTION
**What this PR does / why we need it**:

Show lists of custom resources rather lists of custom resource definitions

<img width="1497" alt="Screen Shot 2020-05-31 at 6 49 41 PM" src="https://user-images.githubusercontent.com/240/83364478-8d90dd00-a36f-11ea-9782-dbeafd9d1640.png">

**Which issue(s) this PR fixes**
- Fixes #509

**Release note**:
```
Show lists of custom resources rather lists of custom resource definitions
```
