### PR TITLE
Clean up cytoscape when destroyed

### DIFF
--- a/changelogs/unreleased/982-GuessWhoSamFoo
+++ b/changelogs/unreleased/982-GuessWhoSamFoo
@@ -1,0 +1,1 @@
+Fixed cytoscape component to clean up styles when destroyed


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently when navigating to the resource viewer, it will create a stylesheet for the graph which is not destroyed and continues to create new sheets each navigation to the resource viewer.