### PR TITLE
add filter for pods grid

### DIFF
--- a/internal/printer/pod.go
+++ b/internal/printer/pod.go
@@ -783,5 +783,8 @@ func podTableFilters() map[string]component.TableFilter {
 			Values:   []string{"Pending", "Running", "Succeeded", "Failed", "Unknown"},
 			Selected: []string{"Pending", "Running"},
 		},
+		"Name": {
+			IsTextFilter: true,
+		},
 	}
 }

--- a/pkg/view/component/table.go
+++ b/pkg/view/component/table.go
@@ -16,8 +16,9 @@ import (
 
 // TableFilter describer a text filter for a table.
 type TableFilter struct {
-	Values   []string `json:"values"`
-	Selected []string `json:"selected"`
+	Values       []string `json:"values"`
+	Selected     []string `json:"selected"`
+	IsTextFilter bool     `json:"isTextFilter"`
 }
 
 // TableConfig is the contents of a Table

--- a/web/src/app/modules/shared/components/presentation/content-text-filter/content-text-filter.component.html
+++ b/web/src/app/modules/shared/components/presentation/content-text-filter/content-text-filter.component.html
@@ -1,0 +1,4 @@
+<input
+  (ngModelChange)="onFilterChange($event)"
+  [(ngModel)]="text"
+/>

--- a/web/src/app/modules/shared/components/presentation/content-text-filter/content-text-filter.component.ts
+++ b/web/src/app/modules/shared/components/presentation/content-text-filter/content-text-filter.component.ts
@@ -1,0 +1,56 @@
+import { ChangeDetectorRef, Component, Input, OnInit } from '@angular/core';
+import { Subject } from 'rxjs';
+import { ClrDatagridFilter, ClrDatagridFilterInterface } from '@clr/angular';
+import { TableFilter, TableRow } from '../../../models/content';
+
+@Component({
+  selector: 'app-content-text-filter',
+  templateUrl: './content-text-filter.component.html',
+  styleUrls: ['./content-text-filter.component.scss'],
+})
+export class ContentTextFilterComponent
+  implements ClrDatagridFilterInterface<TableRow>, OnInit {
+  @Input() filter: TableFilter;
+  @Input() column: string;
+
+  changes = new Subject<any>();
+  text = '';
+
+  constructor(
+    private filterContainer: ClrDatagridFilter,
+    private cd: ChangeDetectorRef
+  ) {
+    filterContainer.setFilter(this);
+  }
+
+  ngOnInit(): void {
+    this.cd.detectChanges();
+  }
+
+  accepts(row: TableRow): boolean {
+    if (this.text.trim().length === 0) {
+      return true;
+    }
+
+    if (
+      !row.data[this.column] ||
+      !row.data[this.column].config ||
+      !row.data[this.column].config.value
+    ) {
+      return false;
+    }
+
+    return row.data[this.column].config.value
+      .toLowerCase()
+      .includes(this.text.toLowerCase());
+  }
+
+  isActive(): boolean {
+    return this.text.length > 0;
+  }
+
+  onFilterChange(text: string) {
+    this.text = text;
+    this.changes.next(true);
+  }
+}

--- a/web/src/app/modules/shared/components/presentation/datagrid/datagrid.component.html
+++ b/web/src/app/modules/shared/components/presentation/datagrid/datagrid.component.html
@@ -11,10 +11,14 @@
   <clr-dg-column *ngFor="let columnName of columns; trackBy: identifyColumn">
     {{ columnName }}
     <clr-dg-filter *ngIf="filters[columnName]">
-      <app-content-filter
+      <app-content-filter *ngIf="!filters[columnName].isTextFilter"
         [column]="columnName"
         [filter]="filters[columnName]"
       ></app-content-filter>
+      <app-content-text-filter *ngIf="filters[columnName].isTextFilter"
+                          [column]="columnName"
+                          [filter]="filters[columnName]"
+      ></app-content-text-filter>
     </clr-dg-filter>
   </clr-dg-column>
   <clr-dg-row

--- a/web/src/app/modules/shared/shared.module.ts
+++ b/web/src/app/modules/shared/shared.module.ts
@@ -69,6 +69,7 @@ import { OverflowSelectorsComponent } from './components/presentation/overflow-s
 import { PreferencesComponent } from './components/presentation/preferences/preferences.component';
 import { HelperComponent } from './components/smart/helper/helper.component';
 import { FilterDeletedDatagridRowPipe } from './pipes/filterDeletedDatagridRow/filter-deleted-datagrid-row.pipe';
+import { ContentTextFilterComponent } from './components/presentation/content-text-filter/content-text-filter.component';
 
 @NgModule({
   declarations: [
@@ -133,6 +134,7 @@ import { FilterDeletedDatagridRowPipe } from './pipes/filterDeletedDatagridRow/f
     OverflowSelectorsComponent,
     PreferencesComponent,
     HelperComponent,
+    ContentTextFilterComponent,
   ],
   imports: [
     ClarityModule,


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR allows to filter Pod on name. I't helpful if you have a few pages of Pods and you are trying to find the one you need.
**Which issue(s) this PR fixes**
No issue

**Special notes for your reviewer**:
-
**Release note**:
```
Add possibility to filter pods by name
```
