### PR TITLE
Add support for ALB ingress using annotations

### DIFF
--- a/changelogs/unreleased/988-GuessWhoSamFoo
+++ b/changelogs/unreleased/988-GuessWhoSamFoo
@@ -1,0 +1,1 @@
+Added support for an ingress to have `use-annotation` ServicePort

--- a/internal/printer/ingress.go
+++ b/internal/printer/ingress.go
@@ -97,6 +97,20 @@ func (i *IngressConfiguration) Create(options Options) (*component.Summary, erro
 		sections.AddText("Default Backend", "Default is not configured")
 	}
 
+	for _, rule := range ingress.Spec.Rules {
+		if rule.IngressRuleValue.HTTP == nil {
+			continue
+		}
+
+		for _, path := range rule.IngressRuleValue.HTTP.Paths {
+			if path.Backend.ServicePort.String() == "use-annotation" {
+				if action, ok := ingress.Annotations["alb.ingress.kubernetes.io/actions."+path.Backend.ServiceName]; ok {
+					sections.Add("Action: "+path.Backend.ServiceName, component.NewText(action))
+				}
+			}
+		}
+	}
+
 	summary := component.NewSummary("Configuration", sections...)
 
 	return summary, nil

--- a/internal/queryer/queryer.go
+++ b/internal/queryer/queryer.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/api/extensions/v1beta1"
 	extv1beta1 "k8s.io/api/extensions/v1beta1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	kLabels "k8s.io/apimachinery/pkg/labels"
@@ -611,7 +612,7 @@ func (osq *ObjectStoreQueryer) ServicesForIngress(ctx context.Context, ingress *
 			Name:       backend.ServiceName,
 		}
 		u, err := osq.objectStore.Get(ctx, key)
-		if err != nil {
+		if err != nil && !kerrors.IsNotFound(err) {
 			return nil, errors.Wrapf(err, "retrieving service backend: %v", backend)
 		}
 

--- a/pkg/store/get_as.go
+++ b/pkg/store/get_as.go
@@ -9,6 +9,7 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/vmware-tanzu/octant/internal/util/kubernetes"
@@ -18,12 +19,12 @@ import (
 // return false and a nil error.
 func GetAs(ctx context.Context, o Store, key Key, as runtime.Object) (bool, error) {
 	u, err := o.Get(ctx, key)
-	if err != nil {
-		return false, errors.Wrap(err, "get object from object store")
+	if kerrors.IsNotFound(err) || u == nil {
+		return false, nil
 	}
 
-	if u == nil {
-		return false, nil
+	if err != nil {
+		return false, errors.Wrap(err, "get object from object store")
 	}
 
 	if err := kubernetes.FromUnstructured(u, as); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
~AWS ALB Ingress controller have references to a service through annotations. Rather than writing ALB-specific logic in Octant, we can have the resource viewer and object status tell the user that the service cannot be found and offload more detailed views via plugins.~

This PR checks validates the action in the annotations if the service port is `use-annotation`.

**Which issue(s) this PR fixes**
- Fixes #987 

Signed-off-by: GuessWhoSamFoo <foos@vmware.com>
