### PR TITLE
Use dependabot to manage dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10


### PR DESCRIPTION
**What this PR does / why we need it**:

Dependabot is now fully integrated into GitHub and will start sending
PRs for dependency updates of go modules and GitHub Actions. This
is particularly useful for quickly integrating upstream bug and security
patches.

**Which issue(s) this PR fixes**
none

**Special notes for your reviewer**:
https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/

**Release note**:
```
n/a
```
