### PR TITLE
Allow octant to start without a kubeconfig

### DIFF
--- a/changelogs/unreleased/991-GuessWhoSamFoo
+++ b/changelogs/unreleased/991-GuessWhoSamFoo
@@ -1,0 +1,1 @@
+Refactored internals to allow Octant to start without a kubeconfig

--- a/cmd/octant-electron/main.go
+++ b/cmd/octant-electron/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/vmware-tanzu/octant/internal/api"
+	ocontext "github.com/vmware-tanzu/octant/internal/context"
 	"github.com/vmware-tanzu/octant/internal/electron"
 	"github.com/vmware-tanzu/octant/internal/log"
 	"github.com/vmware-tanzu/octant/pkg/dash"
@@ -87,14 +88,15 @@ func run(ctx context.Context) error {
 	runCh := make(chan bool, 1)
 
 	ctx, cancel := context.WithCancel(ctx)
+	ctxKubeConfig := ocontext.WithKubeConfigCh(ctx)
 
-	runner, err := dash.NewRunner(ctx, logger, dashOptions)
+	runner, err := dash.NewRunner(ctxKubeConfig, logger, dashOptions)
 	if err != nil {
 		return fmt.Errorf("create octant runner: %w", err)
 	}
 
 	go func() {
-		runner.Start(ctx, logger, dashOptions, startupCh, shutdownCh)
+		runner.Start(ctxKubeConfig, logger, dashOptions, startupCh, shutdownCh)
 		runCh <- true
 	}()
 

--- a/cmd/octant-electron/main.go
+++ b/cmd/octant-electron/main.go
@@ -12,7 +12,6 @@ import (
 	"os"
 
 	"github.com/spf13/viper"
-	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/vmware-tanzu/octant/internal/api"
 	"github.com/vmware-tanzu/octant/internal/electron"
@@ -81,7 +80,6 @@ func run(ctx context.Context) error {
 	dashOptions := dash.Options{
 		DisableClusterOverview: false,
 		EnableOpenCensus:       false,
-		KubeConfig:             clientcmd.NewDefaultClientConfigLoadingRules().GetDefaultFilename(),
 		UserAgent:              fmt.Sprintf("octant-electron"), // TODO: create proper user agent
 	}
 	shutdownCh := make(chan bool, 1)
@@ -96,7 +94,7 @@ func run(ctx context.Context) error {
 	}
 
 	go func() {
-		runner.Start(ctx, startupCh, shutdownCh)
+		runner.Start(ctx, logger, dashOptions, startupCh, shutdownCh)
 		runCh <- true
 	}()
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -17,7 +17,6 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/vmware-tanzu/octant/internal/config"
-	"github.com/vmware-tanzu/octant/internal/kubeconfig"
 	"github.com/vmware-tanzu/octant/internal/mime"
 	"github.com/vmware-tanzu/octant/internal/module"
 	"github.com/vmware-tanzu/octant/pkg/log"
@@ -165,7 +164,6 @@ type LoadingAPI struct {
 	actionDispatcher ActionDispatcher
 	prefix           string
 	logger           log.Logger
-	KubeConfig       kubeconfig.TemporaryKubeConfig
 	wsClientManager  *WebsocketClientManager
 
 	modulePaths   map[string]module.Module
@@ -176,7 +174,7 @@ type LoadingAPI struct {
 var _ Service = (*LoadingAPI)(nil)
 
 // NewLoadingAPI creates an instance of LoadingAPI
-func NewLoadingAPI(ctx context.Context, prefix string, actionDispatcher ActionDispatcher, websocketClientManager *WebsocketClientManager, logger log.Logger, temporaryKubeConfig kubeconfig.TemporaryKubeConfig) *LoadingAPI {
+func NewLoadingAPI(ctx context.Context, prefix string, actionDispatcher ActionDispatcher, websocketClientManager *WebsocketClientManager, logger log.Logger) *LoadingAPI {
 	logger = logger.With("component", "loading api")
 	return &LoadingAPI{
 		ctx:              ctx,
@@ -185,7 +183,6 @@ func NewLoadingAPI(ctx context.Context, prefix string, actionDispatcher ActionDi
 		modulePaths:      make(map[string]module.Module),
 		logger:           logger,
 		forceUpdateCh:    make(chan bool, 1),
-		KubeConfig:       temporaryKubeConfig,
 		wsClientManager:  websocketClientManager,
 	}
 }
@@ -202,7 +199,7 @@ func (l *LoadingAPI) Handler(ctx context.Context) (http.Handler, error) {
 
 	s := router.PathPrefix(l.prefix).Subrouter()
 
-	s.Handle("/stream", loadingWebsocketService(l.wsClientManager, l.KubeConfig))
+	s.Handle("/stream", loadingWebsocketService(l.wsClientManager))
 
 	return router, nil
 }

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -17,6 +17,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/vmware-tanzu/octant/internal/config"
+	"github.com/vmware-tanzu/octant/internal/kubeconfig"
 	"github.com/vmware-tanzu/octant/internal/mime"
 	"github.com/vmware-tanzu/octant/internal/module"
 	"github.com/vmware-tanzu/octant/pkg/log"
@@ -108,6 +109,7 @@ type API struct {
 	prefix           string
 	dashConfig       config.Dash
 	logger           log.Logger
+	wsClientManager  *WebsocketClientManager
 
 	modulePaths   map[string]module.Module
 	modules       []module.Module
@@ -117,7 +119,7 @@ type API struct {
 var _ Service = (*API)(nil)
 
 // New creates an instance of API.
-func New(ctx context.Context, prefix string, actionDispatcher ActionDispatcher, dashConfig config.Dash) *API {
+func New(ctx context.Context, prefix string, actionDispatcher ActionDispatcher, websocketClientManager *WebsocketClientManager, dashConfig config.Dash) *API {
 	logger := dashConfig.Logger().With("component", "api")
 	return &API{
 		ctx:              ctx,
@@ -127,6 +129,7 @@ func New(ctx context.Context, prefix string, actionDispatcher ActionDispatcher, 
 		dashConfig:       dashConfig,
 		logger:           logger,
 		forceUpdateCh:    make(chan bool, 1),
+		wsClientManager:  websocketClientManager,
 	}
 }
 
@@ -137,20 +140,69 @@ func (a *API) ForceUpdate() error {
 
 // Handler returns a HTTP handler for the service.
 func (a *API) Handler(ctx context.Context) (http.Handler, error) {
+	if a.dashConfig == nil {
+		return nil, fmt.Errorf("missing dashConfig")
+	}
 	router := mux.NewRouter()
 	router.Use(rebindHandler(ctx, acceptedHosts()))
 
 	s := router.PathPrefix(a.prefix).Subrouter()
 
-	manager := NewWebsocketClientManager(ctx, a.actionDispatcher)
-	go manager.Run(ctx)
-
-	s.Handle("/stream", websocketService(manager, a.dashConfig))
+	s.Handle("/stream", websocketService(a.wsClientManager, a.dashConfig))
 
 	s.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		a.logger.Errorf("api handler not found: %s", r.URL.String())
 		RespondWithError(w, http.StatusNotFound, "not found", a.logger)
 	})
+
+	return router, nil
+}
+
+// LoadingAPI is an API for startup modules to run
+type LoadingAPI struct {
+	ctx              context.Context
+	moduleManager    module.ManagerInterface
+	actionDispatcher ActionDispatcher
+	prefix           string
+	logger           log.Logger
+	KubeConfig       kubeconfig.TemporaryKubeConfig
+	wsClientManager  *WebsocketClientManager
+
+	modulePaths   map[string]module.Module
+	modules       []module.Module
+	forceUpdateCh chan bool
+}
+
+var _ Service = (*LoadingAPI)(nil)
+
+// NewLoadingAPI creates an instance of LoadingAPI
+func NewLoadingAPI(ctx context.Context, prefix string, actionDispatcher ActionDispatcher, websocketClientManager *WebsocketClientManager, logger log.Logger, temporaryKubeConfig kubeconfig.TemporaryKubeConfig) *LoadingAPI {
+	logger = logger.With("component", "loading api")
+	return &LoadingAPI{
+		ctx:              ctx,
+		prefix:           prefix,
+		actionDispatcher: actionDispatcher,
+		modulePaths:      make(map[string]module.Module),
+		logger:           logger,
+		forceUpdateCh:    make(chan bool, 1),
+		KubeConfig:       temporaryKubeConfig,
+		wsClientManager:  websocketClientManager,
+	}
+}
+
+func (l *LoadingAPI) ForceUpdate() error {
+	l.forceUpdateCh <- true
+	return nil
+}
+
+// Handler contains a list of handlers
+func (l *LoadingAPI) Handler(ctx context.Context) (http.Handler, error) {
+	router := mux.NewRouter()
+	router.Use(rebindHandler(ctx, acceptedHosts()))
+
+	s := router.PathPrefix(l.prefix).Subrouter()
+
+	s.Handle("/stream", loadingWebsocketService(l.wsClientManager, l.KubeConfig))
 
 	return router, nil
 }

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -97,7 +97,9 @@ func TestAPI_routes(t *testing.T) {
 			actionDispatcher := apiFake.NewMockActionDispatcher(controller)
 
 			ctx := context.Background()
-			srv := api.New(ctx, "/", actionDispatcher, dashConfig)
+			wsClientManager := api.NewWebsocketClientManager(ctx, actionDispatcher)
+
+			srv := api.New(ctx, "/", actionDispatcher, wsClientManager, dashConfig)
 
 			handler, err := srv.Handler(ctx)
 			require.NoError(t, err)

--- a/internal/api/fake/mock_client_manager.go
+++ b/internal/api/fake/mock_client_manager.go
@@ -9,7 +9,6 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	api "github.com/vmware-tanzu/octant/internal/api"
 	config "github.com/vmware-tanzu/octant/internal/config"
-	kubeconfig "github.com/vmware-tanzu/octant/internal/kubeconfig"
 	http "net/http"
 	reflect "reflect"
 )
@@ -79,16 +78,16 @@ func (mr *MockClientManagerMockRecorder) Run(arg0 interface{}) *gomock.Call {
 }
 
 // TemporaryClientFromLoadingRequest mocks base method
-func (m *MockClientManager) TemporaryClientFromLoadingRequest(arg0 kubeconfig.TemporaryKubeConfig, arg1 http.ResponseWriter, arg2 *http.Request) (*api.WebsocketClient, error) {
+func (m *MockClientManager) TemporaryClientFromLoadingRequest(arg0 http.ResponseWriter, arg1 *http.Request) (*api.WebsocketClient, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TemporaryClientFromLoadingRequest", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "TemporaryClientFromLoadingRequest", arg0, arg1)
 	ret0, _ := ret[0].(*api.WebsocketClient)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // TemporaryClientFromLoadingRequest indicates an expected call of TemporaryClientFromLoadingRequest
-func (mr *MockClientManagerMockRecorder) TemporaryClientFromLoadingRequest(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockClientManagerMockRecorder) TemporaryClientFromLoadingRequest(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TemporaryClientFromLoadingRequest", reflect.TypeOf((*MockClientManager)(nil).TemporaryClientFromLoadingRequest), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TemporaryClientFromLoadingRequest", reflect.TypeOf((*MockClientManager)(nil).TemporaryClientFromLoadingRequest), arg0, arg1)
 }

--- a/internal/api/fake/mock_client_manager.go
+++ b/internal/api/fake/mock_client_manager.go
@@ -9,6 +9,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	api "github.com/vmware-tanzu/octant/internal/api"
 	config "github.com/vmware-tanzu/octant/internal/config"
+	kubeconfig "github.com/vmware-tanzu/octant/internal/kubeconfig"
 	http "net/http"
 	reflect "reflect"
 )
@@ -75,4 +76,19 @@ func (m *MockClientManager) Run(arg0 context.Context) {
 func (mr *MockClientManagerMockRecorder) Run(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Run", reflect.TypeOf((*MockClientManager)(nil).Run), arg0)
+}
+
+// TemporaryClientFromLoadingRequest mocks base method
+func (m *MockClientManager) TemporaryClientFromLoadingRequest(arg0 kubeconfig.TemporaryKubeConfig, arg1 http.ResponseWriter, arg2 *http.Request) (*api.WebsocketClient, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TemporaryClientFromLoadingRequest", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*api.WebsocketClient)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// TemporaryClientFromLoadingRequest indicates an expected call of TemporaryClientFromLoadingRequest
+func (mr *MockClientManagerMockRecorder) TemporaryClientFromLoadingRequest(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TemporaryClientFromLoadingRequest", reflect.TypeOf((*MockClientManager)(nil).TemporaryClientFromLoadingRequest), arg0, arg1, arg2)
 }

--- a/internal/api/loading_state.go
+++ b/internal/api/loading_state.go
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2020 the Octant contributors. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/vmware-tanzu/octant/internal/event"
+	"github.com/vmware-tanzu/octant/internal/kubeconfig"
+	"github.com/vmware-tanzu/octant/internal/log"
+	"github.com/vmware-tanzu/octant/internal/octant"
+	"github.com/vmware-tanzu/octant/pkg/action"
+)
+
+const (
+	UploadKubeConfig = "action.octant.dev/uploadKubeConfig"
+)
+
+type LoadingManager struct {
+	client     OctantClient
+	kubeConfig kubeconfig.TemporaryKubeConfig
+	ctx        context.Context
+	poller     Poller
+}
+
+var _ StateManager = (*LoadingManager)(nil)
+
+func NewLoadingManager(temporaryKubeConfig kubeconfig.TemporaryKubeConfig) *LoadingManager {
+	lm := &LoadingManager{
+		kubeConfig: temporaryKubeConfig,
+		poller:     NewInterruptiblePoller("loading"),
+	}
+
+	return lm
+}
+
+func (l *LoadingManager) Handlers() []octant.ClientRequestHandler {
+	return []octant.ClientRequestHandler{
+		{
+			RequestType: UploadKubeConfig,
+			Handler:     l.UploadKubeConfig,
+		},
+	}
+}
+
+func (l *LoadingManager) Start(ctx context.Context, state octant.State, client OctantClient) {
+	l.client = client
+	l.ctx = ctx
+
+	l.poller.Run(ctx, nil, l.runUpdate(state, client), event.DefaultScheduleDelay)
+}
+
+func (l *LoadingManager) runUpdate(state octant.State, client OctantClient) PollerFunc {
+	var previous []byte
+	return func(ctx context.Context) bool {
+		logger := log.From(ctx)
+
+		if ctx.Err() == nil {
+			event := octant.Event{
+				Type: octant.EventTypeLoading,
+			}
+
+			cur, err := json.Marshal(event)
+			if err != nil {
+				logger.WithErr(err).Errorf("unable to marshal loading")
+				return false
+			}
+
+			if bytes.Compare(previous, cur) != 0 {
+				previous = cur
+				client.Send(event)
+			}
+		}
+		return false
+	}
+}
+
+func (l *LoadingManager) UploadKubeConfig(state octant.State, payload action.Payload) error {
+	kubeConfig64, err := payload.String("kubeConfig")
+	if err != nil {
+		return fmt.Errorf("getting kubeConfig from payload: %w", err)
+	}
+
+	kubeConfig, err := base64.StdEncoding.DecodeString(kubeConfig64)
+	if err != nil {
+		return fmt.Errorf("decode base64 kubeconfig: %w", err)
+	}
+
+	// Check if kube config can be converted to config object
+	// TODO: Show error elsewhere instead of notifier
+	if _, err := clientcmd.Load(kubeConfig); err != nil {
+		message := fmt.Sprintf("Error parsing KubeConfig: %v", err)
+		alert := action.CreateAlert(action.AlertTypeError, message, action.DefaultAlertExpiration)
+		state.SendAlert(alert)
+		return err
+	}
+
+	l.kubeConfig.KubeConfig <- string(kubeConfig)
+
+	tempFile, err := ioutil.TempFile(os.TempDir(), "kubeconfig")
+	if err != nil {
+		return err
+	}
+
+	if _, err := tempFile.Write(kubeConfig); err != nil {
+		return err
+	}
+
+	if err := tempFile.Close(); err != nil {
+		return err
+	}
+
+	l.client.Send(octant.Event{
+		Type: octant.EventTypeRefresh,
+	})
+
+	l.kubeConfig.Path <- tempFile.Name()
+	return nil
+}

--- a/internal/api/loading_state_test.go
+++ b/internal/api/loading_state_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/vmware-tanzu/octant/internal/api"
 	"github.com/vmware-tanzu/octant/internal/api/fake"
-	"github.com/vmware-tanzu/octant/internal/kubeconfig"
 	"github.com/vmware-tanzu/octant/internal/octant"
 
 	"k8s.io/client-go/tools/clientcmd"
@@ -34,15 +33,13 @@ func Test_watchConfig(t *testing.T) {
 	config := clientcmd.NewDefaultClientConfigLoadingRules().GetDefaultFilename()
 	afero.WriteFile(fs, config, []byte(""), 0755)
 
-	tkc := kubeconfig.TemporaryKubeConfig{
-		Path: make(chan string, 1),
-	}
+	kubeConfigPath := make(chan string, 1)
 
-	manager := api.NewLoadingManager(tkc)
-	manager.WatchConfig(tkc.Path, octantClient, fs)
+	manager := api.NewLoadingManager()
+	manager.WatchConfig(kubeConfigPath, octantClient, fs)
 
 	select {
-	case path := <-tkc.Path:
+	case path := <-kubeConfigPath:
 		assert.Equal(t, path, config)
 	case <-time.After(3 * time.Second):
 		t.FailNow()

--- a/internal/api/loading_state_test.go
+++ b/internal/api/loading_state_test.go
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2020 the Octant contributors. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package api_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/vmware-tanzu/octant/internal/api"
+	"github.com/vmware-tanzu/octant/internal/api/fake"
+	"github.com/vmware-tanzu/octant/internal/kubeconfig"
+	"github.com/vmware-tanzu/octant/internal/octant"
+
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+func Test_watchConfig(t *testing.T) {
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	octantClient := fake.NewMockOctantClient(controller)
+
+	octantClient.EXPECT().Send(octant.Event{
+		Type: octant.EventTypeRefresh,
+	})
+
+	fs := afero.NewMemMapFs()
+	config := clientcmd.NewDefaultClientConfigLoadingRules().GetDefaultFilename()
+	afero.WriteFile(fs, config, []byte(""), 0755)
+
+	tkc := kubeconfig.TemporaryKubeConfig{
+		Path: make(chan string, 1),
+	}
+
+	manager := api.NewLoadingManager(tkc)
+	manager.WatchConfig(tkc.Path, octantClient, fs)
+
+	select {
+	case path := <-tkc.Path:
+		assert.Equal(t, path, config)
+	case <-time.After(3 * time.Second):
+		t.FailNow()
+	}
+}

--- a/internal/api/websocket_client.go
+++ b/internal/api/websocket_client.go
@@ -16,7 +16,6 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/vmware-tanzu/octant/internal/config"
-	"github.com/vmware-tanzu/octant/internal/kubeconfig"
 	internalLog "github.com/vmware-tanzu/octant/internal/log"
 	"github.com/vmware-tanzu/octant/internal/octant"
 	"github.com/vmware-tanzu/octant/pkg/action"
@@ -93,7 +92,7 @@ func NewWebsocketClient(ctx context.Context, conn *websocket.Conn, manager *Webs
 }
 
 // NewTemporaryWebsocketClient creates an instance of WebsocketClient
-func NewTemporaryWebsocketClient(ctx context.Context, conn *websocket.Conn, manager *WebsocketClientManager, temporaryKubeConfig kubeconfig.TemporaryKubeConfig, actionDispatcher ActionDispatcher, id uuid.UUID) *WebsocketClient {
+func NewTemporaryWebsocketClient(ctx context.Context, conn *websocket.Conn, manager *WebsocketClientManager, actionDispatcher ActionDispatcher, id uuid.UUID) *WebsocketClient {
 	ctx, cancel := context.WithCancel(ctx)
 	logger := internalLog.From(ctx)
 
@@ -108,7 +107,7 @@ func NewTemporaryWebsocketClient(ctx context.Context, conn *websocket.Conn, mana
 		handlers: make(map[string][]octant.ClientRequestHandler),
 	}
 
-	state := NewTemporaryWebsocketState(temporaryKubeConfig, actionDispatcher, client)
+	state := NewTemporaryWebsocketState(actionDispatcher, client)
 	go state.Start(ctx)
 
 	client.state = state

--- a/internal/api/websocket_service.go
+++ b/internal/api/websocket_service.go
@@ -13,7 +13,6 @@ import (
 	"github.com/gorilla/websocket"
 
 	"github.com/vmware-tanzu/octant/internal/config"
-	"github.com/vmware-tanzu/octant/internal/kubeconfig"
 )
 
 var (
@@ -50,14 +49,14 @@ func serveWebsocket(manager ClientManager, dashConfig config.Dash, w http.Respon
 }
 
 // Create dummy websocketService and serveWebsocket
-func loadingWebsocketService(manager ClientManager, temporaryKubeConfig kubeconfig.TemporaryKubeConfig) http.HandlerFunc {
+func loadingWebsocketService(manager ClientManager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		serveLoadingWebsocket(manager, temporaryKubeConfig, w, r)
+		serveLoadingWebsocket(manager, w, r)
 	}
 }
 
-func serveLoadingWebsocket(manager ClientManager, temporaryKubeConfig kubeconfig.TemporaryKubeConfig, w http.ResponseWriter, r *http.Request) {
-	client, err := manager.TemporaryClientFromLoadingRequest(temporaryKubeConfig, w, r)
+func serveLoadingWebsocket(manager ClientManager, w http.ResponseWriter, r *http.Request) {
+	client, err := manager.TemporaryClientFromLoadingRequest(w, r)
 	if err != nil {
 		fmt.Println("create loading websocket client")
 	}

--- a/internal/api/websocket_state.go
+++ b/internal/api/websocket_state.go
@@ -17,7 +17,6 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/vmware-tanzu/octant/internal/config"
-	"github.com/vmware-tanzu/octant/internal/kubeconfig"
 	"github.com/vmware-tanzu/octant/internal/octant"
 	"github.com/vmware-tanzu/octant/pkg/action"
 )
@@ -139,7 +138,7 @@ func NewWebsocketState(dashConfig config.Dash, actionDispatcher ActionDispatcher
 	return w
 }
 
-func NewTemporaryWebsocketState(temporaryKubeConfig kubeconfig.TemporaryKubeConfig, actionDispatcher ActionDispatcher, wsClient OctantClient, options ...WebsocketStateOption) *WebsocketState {
+func NewTemporaryWebsocketState(actionDispatcher ActionDispatcher, wsClient OctantClient, options ...WebsocketStateOption) *WebsocketState {
 	w := &WebsocketState{
 		wsClient:           wsClient,
 		contentPathUpdates: make(map[string]octant.ContentPathUpdateFunc),
@@ -153,7 +152,7 @@ func NewTemporaryWebsocketState(temporaryKubeConfig kubeconfig.TemporaryKubeConf
 
 	if len(w.managers) < 1 {
 		w.managers = []StateManager{
-			NewLoadingManager(temporaryKubeConfig),
+			NewLoadingManager(),
 		}
 	}
 

--- a/internal/commands/dash.go
+++ b/internal/commands/dash.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/klog"
 
 	"github.com/vmware-tanzu/octant/internal/config"
+	ocontext "github.com/vmware-tanzu/octant/internal/context"
 	"github.com/vmware-tanzu/octant/internal/log"
 	"github.com/vmware-tanzu/octant/pkg/dash"
 )
@@ -116,13 +117,14 @@ func newOctantCmd(version string, gitCommit string, buildTime string) *cobra.Com
 
 				_ = klogFlagSet.Parse(klogOpts)
 
-				runner, err := dash.NewRunner(ctx, logger, options)
+				ctxKubeConfig := ocontext.WithKubeConfigCh(ctx)
+				runner, err := dash.NewRunner(ctxKubeConfig, logger, options)
 				if err != nil {
 					golog.Printf("unable to start runner: %v", err)
 					os.Exit(1)
 				}
 
-				runner.Start(ctx, logger, options, nil, shutdownCh)
+				runner.Start(ctxKubeConfig, logger, options, nil, shutdownCh)
 
 				runCh <- true
 			}()

--- a/internal/commands/dash.go
+++ b/internal/commands/dash.go
@@ -122,7 +122,7 @@ func newOctantCmd(version string, gitCommit string, buildTime string) *cobra.Com
 					os.Exit(1)
 				}
 
-				runner.Start(ctx, nil, shutdownCh)
+				runner.Start(ctx, logger, options, nil, shutdownCh)
 
 				runCh <- true
 			}()

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2020 the Octant contributors. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package context
+
+import "context"
+
+type OctantContextKey string
+
+const KubeConfigKey = OctantContextKey("kubeConfigPath")
+
+func KubeConfigChFrom(ctx context.Context) chan string {
+	return ctx.Value(KubeConfigKey).(chan string)
+}
+
+func WithKubeConfigCh(ctx context.Context) context.Context {
+	return context.WithValue(ctx, KubeConfigKey, make(chan string))
+}

--- a/internal/kubeconfig/kubeconfig.go
+++ b/internal/kubeconfig/kubeconfig.go
@@ -22,12 +22,6 @@ type KubeConfig struct {
 	CurrentContext string
 }
 
-// TemporaryKubeConfig describes an uploaded kube config
-type TemporaryKubeConfig struct {
-	KubeConfig chan string
-	Path       chan string
-}
-
 // Context describes a kube config context.
 type Context struct {
 	Name string `json:"name"`

--- a/internal/kubeconfig/kubeconfig.go
+++ b/internal/kubeconfig/kubeconfig.go
@@ -22,6 +22,12 @@ type KubeConfig struct {
 	CurrentContext string
 }
 
+// TemporaryKubeConfig describes an uploaded kube config
+type TemporaryKubeConfig struct {
+	KubeConfig chan string
+	Path       chan string
+}
+
 // Context describes a kube config context.
 type Context struct {
 	Name string `json:"name"`

--- a/internal/octant/event.go
+++ b/internal/octant/event.go
@@ -49,6 +49,12 @@ const (
 	// EventTypeAlert is an alert event.
 	EventTypeAlert EventType = "event.octant.dev/alert"
 
+	// EventTypeRefresh is a refresh event.
+	EventTypeRefresh EventType = "event.octant.dev/refresh"
+
+	// EventTypeLoading is a loading event.
+	EventTypeLoading EventType = "event.octant.dev/loading"
+
 	// EventTypeTerminalFormat is a string with format specifiers to assist in generating
 	// a terminal event type.
 	EventTypeTerminalFormat string = "event.octant.dev/terminals/namespace/%s/pod/%s/container/%s"

--- a/pkg/dash/dash.go
+++ b/pkg/dash/dash.go
@@ -19,12 +19,14 @@ import (
 	"github.com/skratchdot/open-golang/open"
 	"github.com/spf13/viper"
 	"go.opencensus.io/trace"
+	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/vmware-tanzu/octant/internal/api"
 	"github.com/vmware-tanzu/octant/internal/cluster"
 	"github.com/vmware-tanzu/octant/internal/config"
 	"github.com/vmware-tanzu/octant/internal/describer"
 	oerrors "github.com/vmware-tanzu/octant/internal/errors"
+	"github.com/vmware-tanzu/octant/internal/kubeconfig"
 	internalLog "github.com/vmware-tanzu/octant/internal/log"
 	"github.com/vmware-tanzu/octant/internal/module"
 	"github.com/vmware-tanzu/octant/internal/modules/applications"
@@ -60,21 +62,125 @@ type Options struct {
 }
 
 type Runner struct {
-	dash          *dash
-	pluginManager *plugin.Manager
-	moduleManager *module.Manager
+	dash                   *dash
+	pluginManager          *plugin.Manager
+	moduleManager          *module.Manager
+	actionManager          *action.Manager
+	websocketClientManager *api.WebsocketClientManager
+	loadingComplete        chan bool
 }
 
 func NewRunner(ctx context.Context, logger log.Logger, options Options) (*Runner, error) {
 	ctx = internalLog.WithLoggerContext(ctx, logger)
 
-	r := Runner{}
+	r := Runner{
+		loadingComplete: make(chan bool, 1),
+	}
 
 	if options.Context != "" {
 		logger.With("initial-context", options.Context).Infof("Setting initial context from user flags")
 	}
 
-	logger.Debugf("Loading configuration: %v", options.KubeConfig)
+	actionManger := action.NewManager(logger)
+	r.actionManager = actionManger
+
+	websocketClientManager := api.NewWebsocketClientManager(ctx, r.actionManager)
+	r.websocketClientManager = websocketClientManager
+	go websocketClientManager.Run(ctx)
+
+	listener, err := buildListener()
+	if err != nil {
+		err = fmt.Errorf("failed to create net listener: %w", err)
+		return nil, fmt.Errorf("use OCTANT_LISTENER_ADDR to set host:port: %w", err)
+	}
+
+	// Initialize the API
+	apiService, err := r.initLoadingAPI(ctx, logger, options)
+	if err != nil {
+		return nil, fmt.Errorf("failed to start loading api: %w", err)
+	}
+
+	d, err := newDash(listener, options.Namespace, options.FrontendURL, options.BrowserPath, apiService, logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create dash instance: %w", err)
+	}
+
+	if viper.GetBool("disable-open-browser") {
+		d.willOpenBrowser = false
+	}
+
+	d.kubeconfig = apiService.KubeConfig
+	r.dash = d
+
+	return &r, nil
+}
+
+func (r *Runner) Start(ctx context.Context, logger log.Logger, options Options, startupCh, shutdownCh chan bool) error {
+	go func() {
+		if err := r.dash.Run(ctx, startupCh); err != nil {
+			logger.Debugf("running dashboard service: %v", err)
+		}
+		return
+	}()
+
+	go func() {
+		if r.dash != nil {
+			select {
+			case options.KubeConfig = <-findKubeConfig(r.dash.kubeconfig):
+				if options.KubeConfig != "" {
+					logger.Debugf("Loading configuration: %v", options.KubeConfig)
+					r.loadingComplete <- true
+					return
+				}
+			}
+		}
+	}()
+
+	go func() {
+		<-r.loadingComplete
+		apiService, err := r.initAPI(ctx, logger, options)
+		if err != nil {
+			logger.Errorf("cannot create api: %v", err)
+		}
+		r.dash.apiHandler = apiService
+
+		hf := octant.NewHandlerFactory(
+			octant.BackendHandler(r.dash.apiHandler.Handler),
+			octant.FrontendURL(viper.GetString("proxy-frontend")))
+
+		r.dash.server.Handler, err = hf.Handler(ctx)
+		if err != nil {
+			logger.Errorf("cannot create handler: %v", err)
+		}
+
+		logger.Infof("using api service")
+		return
+	}()
+
+	<-ctx.Done()
+
+	shutdownCtx := internalLog.WithLoggerContext(context.Background(), logger)
+
+	r.moduleManager.Unload()
+	r.pluginManager.Stop(shutdownCtx)
+
+	shutdownCh <- true
+	return nil
+}
+
+func (r *Runner) initLoadingAPI(ctx context.Context, logger log.Logger, option Options) (*api.LoadingAPI, error) {
+	temporaryKubeConfig := kubeconfig.TemporaryKubeConfig{
+		KubeConfig: make(chan string, 1),
+		Path:       make(chan string, 1),
+	}
+	apiService := api.NewLoadingAPI(ctx, api.PathPrefix, r.actionManager, r.websocketClientManager, logger, temporaryKubeConfig)
+
+	return apiService, nil
+}
+
+func (r *Runner) initAPI(ctx context.Context, logger log.Logger, options Options) (*api.API, error) {
+	frontendProxy := pluginAPI.FrontendProxy{}
+
 	restConfigOptions := cluster.RESTConfigOptions{
 		QPS:       options.ClientQPS,
 		Burst:     options.ClientBurst,
@@ -131,13 +237,11 @@ func NewRunner(ctx context.Context, logger log.Logger, options Options) (*Runner
 		return nil, fmt.Errorf("initializing port forwarder: %w", err)
 	}
 
-	actionManger := action.NewManager(logger)
-
 	mo := &moduleOptions{
 		clusterClient: clusterClient,
 		namespace:     options.Namespace,
 		logger:        logger,
-		actionManager: actionManger,
+		actionManager: r.actionManager,
 	}
 	moduleManager, err := initModuleManager(mo)
 	if err != nil {
@@ -146,8 +250,6 @@ func NewRunner(ctx context.Context, logger log.Logger, options Options) (*Runner
 
 	r.moduleManager = moduleManager
 
-	frontendProxy := pluginAPI.FrontendProxy{}
-
 	pluginDashboardService := &pluginAPI.GRPCService{
 		ObjectStore:        appObjectStore,
 		PortForwarder:      portForwarder,
@@ -155,7 +257,7 @@ func NewRunner(ctx context.Context, logger log.Logger, options Options) (*Runner
 		FrontendProxy:      frontendProxy,
 	}
 
-	pluginManager, err := initPlugin(moduleManager, actionManger, pluginDashboardService)
+	pluginManager, err := initPlugin(moduleManager, r.actionManager, pluginDashboardService)
 	if err != nil {
 		return nil, fmt.Errorf("initializing plugin manager: %w", err)
 	}
@@ -201,52 +303,17 @@ func NewRunner(ctx context.Context, logger log.Logger, options Options) (*Runner
 		return nil, fmt.Errorf("start plugin manager: %w", err)
 	}
 
-	listener, err := buildListener()
-	if err != nil {
-		err = fmt.Errorf("failed to create net listener: %w", err)
-		return nil, fmt.Errorf("use OCTANT_LISTENER_ADDR to set host:port: %w", err)
-	}
-
-	// Initialize the API
-	apiService := api.New(ctx, api.PathPrefix, actionManger, dashConfig)
-	frontendProxy.FrontendUpdateController = apiService
-
 	// Watch for CRDs after modules initialized
 	if err := crdWatcher.Watch(ctx); err != nil {
 		return nil, fmt.Errorf("unable to start CRD watcher: %w", err)
 	}
 
-	d, err := newDash(listener, options.Namespace, options.FrontendURL, options.BrowserPath, apiService, logger)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create dash instance: %w", err)
-	}
+	apiService := api.New(ctx, api.PathPrefix, r.actionManager, r.websocketClientManager, dashConfig)
+	frontendProxy.FrontendUpdateController = apiService
 
-	if viper.GetBool("disable-open-browser") {
-		d.willOpenBrowser = false
-	}
+	r.dash.apiHandler = apiService
 
-	r.dash = d
-
-	return &r, nil
-}
-
-func (r *Runner) Start(ctx context.Context, startupCh, shutdownCh chan bool) {
-	logger := internalLog.From(ctx)
-
-	go func() {
-		if err := r.dash.Run(ctx, startupCh); err != nil {
-			logger.Debugf("running dashboard service: %v", err)
-		}
-	}()
-
-	<-ctx.Done()
-
-	shutdownCtx := internalLog.WithLoggerContext(context.Background(), logger)
-
-	r.moduleManager.Unload()
-	r.pluginManager.Stop(shutdownCtx)
-
-	shutdownCh <- true
+	return apiService, nil
 }
 
 // initObjectStore initializes the cluster object store interface
@@ -371,6 +438,8 @@ type dash struct {
 	willOpenBrowser bool
 	logger          log.Logger
 	handlerFactory  *octant.HandlerFactory
+	kubeconfig      kubeconfig.TemporaryKubeConfig
+	server          http.Server
 }
 
 func newDash(listener net.Listener, namespace, uiURL string, browserPath string, apiHandler api.Service, logger log.Logger) (*dash, error) {
@@ -401,10 +470,10 @@ func (d *dash) Run(ctx context.Context, startupCh chan bool) error {
 		return err
 	}
 
-	server := http.Server{Handler: handler}
+	d.server = http.Server{Handler: handler}
 
 	go func() {
-		if err = server.Serve(d.listener); err != nil && err != http.ErrServerClosed {
+		if err = d.server.Serve(d.listener); err != nil && err != http.ErrServerClosed {
 			d.logger.Errorf("http server: %v", err)
 			os.Exit(1) // TODO graceful shutdown for other goroutines (GH#494)
 		}
@@ -436,7 +505,7 @@ func (d *dash) Run(ctx context.Context, startupCh chan bool) error {
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer shutdownCancel()
 
-	return server.Shutdown(shutdownCtx)
+	return d.server.Shutdown(shutdownCtx)
 }
 
 func enableOpenCensus() error {
@@ -457,4 +526,25 @@ func enableOpenCensus() error {
 	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
 
 	return nil
+}
+
+// findKubeConfig looks for kube config from .kube or provided by user
+func findKubeConfig(temporaryKubeConfig kubeconfig.TemporaryKubeConfig) <-chan string {
+	r := make(chan string)
+	go func() {
+		kubeconfig := clientcmd.NewDefaultClientConfigLoadingRules().GetDefaultFilename()
+		if _, err := os.Stat(kubeconfig); err == nil {
+			r <- kubeconfig
+			return
+		}
+
+		defer close(r)
+		select {
+		case path, ok := <-temporaryKubeConfig.Path:
+			if ok {
+				r <- path
+			}
+		}
+	}()
+	return r
 }

--- a/vendor/github.com/hashicorp/go-plugin/go.mod
+++ b/vendor/github.com/hashicorp/go-plugin/go.mod
@@ -1,5 +1,7 @@
 module github.com/hashicorp/go-plugin
 
+go 1.14
+
 require (
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
 	github.com/golang/protobuf v1.2.0

--- a/web/src/app/modules/sugarloaf/components/smart/container/container.component.html
+++ b/web/src/app/modules/sugarloaf/components/smart/container/container.component.html
@@ -2,6 +2,9 @@
   <div class="notifier">
     <app-notifier></app-notifier>
   </div>
+  <div class="uploader">
+    <app-uploader></app-uploader>
+  </div>
   <header class="header header-6">
     <div class="branding">
       <a [routerLink]="['/']">

--- a/web/src/app/modules/sugarloaf/components/smart/container/container.component.spec.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/container/container.component.spec.ts
@@ -7,11 +7,14 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, inject, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
-import { ClarityModule } from '@clr/angular';
-import { FormsModule } from '@angular/forms';
+import { ClarityModule, ClrPopoverToggleService } from '@clr/angular';
+import { BrowserModule } from '@angular/platform-browser';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { ContainerComponent } from './container.component';
 import { NamespaceComponent } from '../namespace/namespace.component';
 import { PageNotFoundComponent } from '../page-not-found/page-not-found.component';
+import { PreferencesComponent } from '../../../../shared/components/presentation/preferences/preferences.component';
+import { HelperComponent } from '../../../../shared/components/smart/helper/helper.component';
 import { InputFilterComponent } from '../input-filter/input-filter.component';
 import { NotifierComponent } from '../notifier/notifier.component';
 import { NavigationComponent } from '../navigation/navigation.component';
@@ -25,6 +28,7 @@ import { ClarityIcons } from '@clr/icons';
 import { ThemeSwitchButtonComponent } from '../theme-switch/theme-switch-button.component';
 import { QuickSwitcherComponent } from '../quick-switcher/quick-switcher.component';
 import { MonacoEditorConfig, MonacoProviderService } from 'ng-monaco-editor';
+import { UploaderComponent } from '../uploader/uploader.component';
 
 describe('AppComponent', () => {
   beforeEach(async(() => {
@@ -32,20 +36,25 @@ describe('AppComponent', () => {
       providers: [
         { provide: WebsocketService, useClass: WebsocketServiceMock },
         { provide: window, useValue: ClarityIcons },
+        ClrPopoverToggleService,
         MonacoProviderService,
         MonacoEditorConfig,
       ],
       imports: [
+        BrowserModule,
         RouterTestingModule,
         ClarityModule,
         HttpClientTestingModule,
         FormsModule,
         NgSelectModule,
+        ReactiveFormsModule,
       ],
       declarations: [
         ContainerComponent,
         NamespaceComponent,
         PageNotFoundComponent,
+        HelperComponent,
+        PreferencesComponent,
         InputFilterComponent,
         NotifierComponent,
         NavigationComponent,
@@ -54,6 +63,7 @@ describe('AppComponent', () => {
         FilterTextPipe,
         ThemeSwitchButtonComponent,
         QuickSwitcherComponent,
+        UploaderComponent,
       ],
     }).compileComponents();
   }));

--- a/web/src/app/modules/sugarloaf/components/smart/uploader/uploader.component.html
+++ b/web/src/app/modules/sugarloaf/components/smart/uploader/uploader.component.html
@@ -1,0 +1,25 @@
+<div *ngIf="showModal" class="modal">
+    <div class="modal-dialog modal-xl" role="dialog" aria-hidden="true">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h3 class="modal-title">Add a new kubeconfig</h3>
+            </div>
+            <div class="modal-body">
+                <form class="clr-form">
+                    <label for="config" class="clr-control-label">Upload a kubeconfig</label>
+                    <div class="clr-control-container" [ngClass]="{'clr-error': inputValue === ''}">
+                        <div class="clr-textarea-wrapper">
+                            <textarea id="config" name="config" [(ngModel)]="inputValue" placeholder="Enter value here" class="clr-textarea"></textarea>
+                            <clr-icon class="clr-validate-icon" shape="exclamation-circle"></clr-icon>
+                        </div>
+                        <span class="clr-subtext">This can't be empty</span>
+                    </div>
+                  </form>
+            </div>
+            <div class="modal-footer">
+                <button (click)="upload()" class="btn btn-primary" type="button">Upload</button>
+            </div>
+        </div>
+    </div>
+</div>
+<div *ngIf="showModal" class="modal-backdrop" aria-hidden="true"></div>

--- a/web/src/app/modules/sugarloaf/components/smart/uploader/uploader.component.html
+++ b/web/src/app/modules/sugarloaf/components/smart/uploader/uploader.component.html
@@ -9,7 +9,7 @@
                     <label for="config" class="clr-control-label">Upload a kubeconfig</label>
                     <div class="clr-control-container" [ngClass]="{'clr-error': inputValue === ''}">
                         <div class="clr-textarea-wrapper">
-                            <textarea id="config" name="config" [(ngModel)]="inputValue" placeholder="Enter value here" class="clr-textarea"></textarea>
+                            <textarea id="config" name="config" [(ngModel)]="inputValue" (ngModelChange)="updateInput($event)" placeholder="Enter value here" class="clr-textarea"></textarea>
                             <clr-icon class="clr-validate-icon" shape="exclamation-circle"></clr-icon>
                         </div>
                         <span class="clr-subtext">This can't be empty</span>
@@ -17,7 +17,7 @@
                   </form>
             </div>
             <div class="modal-footer">
-                <button (click)="upload()" class="btn btn-primary" type="button">Upload</button>
+                <button (click)="upload()" class="btn btn-primary" type="button" [disabled]="hasInput()">Upload</button>
             </div>
         </div>
     </div>

--- a/web/src/app/modules/sugarloaf/components/smart/uploader/uploader.component.html
+++ b/web/src/app/modules/sugarloaf/components/smart/uploader/uploader.component.html
@@ -12,7 +12,7 @@
                             <textarea id="config" name="config" [(ngModel)]="inputValue" (ngModelChange)="updateInput($event)" placeholder="Enter value here" class="clr-textarea"></textarea>
                             <clr-icon class="clr-validate-icon" shape="exclamation-circle"></clr-icon>
                         </div>
-                        <span class="clr-subtext">This can't be empty</span>
+                        <span *ngIf="inputValue === ''" class="clr-subtext">This can't be empty</span>
                     </div>
                   </form>
             </div>

--- a/web/src/app/modules/sugarloaf/components/smart/uploader/uploader.component.scss
+++ b/web/src/app/modules/sugarloaf/components/smart/uploader/uploader.component.scss
@@ -1,0 +1,13 @@
+.clr-control-container {
+    width: 100%;
+    min-height: 400px;
+}
+
+.clr-textarea-wrapper {
+    min-height: inherit;
+}
+
+.clr-textarea {
+    width: 100%;
+    min-height: inherit;
+}

--- a/web/src/app/modules/sugarloaf/components/smart/uploader/uploader.component.spec.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/uploader/uploader.component.spec.ts
@@ -1,0 +1,27 @@
+// Copyright (c) 2020 the Octant contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { UploaderComponent } from './uploader.component';
+
+describe('UploaderComponent', () => {
+  let component: UploaderComponent;
+  let fixture: ComponentFixture<UploaderComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [UploaderComponent],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(UploaderComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/web/src/app/modules/sugarloaf/components/smart/uploader/uploader.component.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/uploader/uploader.component.ts
@@ -5,8 +5,6 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { WebsocketService } from '../../../../shared/services/websocket/websocket.service';
 import { Subscription } from 'rxjs';
-import { KubeContextService } from '../../../../shared/services/kube-context/kube-context.service';
-import { has } from 'lodash';
 
 @Component({
   selector: 'app-uploader',
@@ -14,9 +12,10 @@ import { has } from 'lodash';
   styleUrls: ['./uploader.component.scss'],
 })
 export class UploaderComponent implements OnInit, OnDestroy {
-  private kubeContextSubscription: Subscription;
   inputValue: string;
   showModal: boolean;
+
+  private contentSubscription: Subscription;
 
   constructor(private websocketService: WebsocketService) {}
 
@@ -27,13 +26,27 @@ export class UploaderComponent implements OnInit, OnDestroy {
     this.websocketService.registerHandler('event.octant.dev/refresh', () => {
       setTimeout(window.location.reload.bind(window.location), 1000);
     });
+
+    this.websocketService.sendMessage('action.octant.dev/loading', {
+      loading: true,
+    });
   }
 
-  ngOnDestroy(): void {}
+  ngOnDestroy(): void {
+    this.contentSubscription.unsubscribe();
+  }
 
   upload() {
     this.websocketService.sendMessage('action.octant.dev/uploadKubeConfig', {
       kubeConfig: window.btoa(this.inputValue),
     });
+  }
+
+  updateInput(event: HTMLInputElement) {
+    this.inputValue = String(event);
+  }
+
+  hasInput(): boolean {
+    return !this.inputValue || this.inputValue.length === 0;
   }
 }

--- a/web/src/app/modules/sugarloaf/components/smart/uploader/uploader.component.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/uploader/uploader.component.ts
@@ -33,7 +33,9 @@ export class UploaderComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.contentSubscription.unsubscribe();
+    if (this.contentSubscription) {
+      this.contentSubscription.unsubscribe();
+    }
   }
 
   upload() {

--- a/web/src/app/modules/sugarloaf/components/smart/uploader/uploader.component.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/uploader/uploader.component.ts
@@ -1,0 +1,39 @@
+// Copyright (c) 2020 the Octant contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { WebsocketService } from '../../../../shared/services/websocket/websocket.service';
+import { Subscription } from 'rxjs';
+import { KubeContextService } from '../../../../shared/services/kube-context/kube-context.service';
+import { has } from 'lodash';
+
+@Component({
+  selector: 'app-uploader',
+  templateUrl: './uploader.component.html',
+  styleUrls: ['./uploader.component.scss'],
+})
+export class UploaderComponent implements OnInit, OnDestroy {
+  private kubeContextSubscription: Subscription;
+  inputValue: string;
+  showModal: boolean;
+
+  constructor(private websocketService: WebsocketService) {}
+
+  ngOnInit(): void {
+    this.websocketService.registerHandler('event.octant.dev/loading', () => {
+      this.showModal = true;
+    });
+    this.websocketService.registerHandler('event.octant.dev/refresh', () => {
+      setTimeout(window.location.reload.bind(window.location), 1000);
+    });
+  }
+
+  ngOnDestroy(): void {}
+
+  upload() {
+    this.websocketService.sendMessage('action.octant.dev/uploadKubeConfig', {
+      kubeConfig: window.btoa(this.inputValue),
+    });
+  }
+}

--- a/web/src/app/modules/sugarloaf/sugarloaf.module.ts
+++ b/web/src/app/modules/sugarloaf/sugarloaf.module.ts
@@ -8,6 +8,7 @@ import { NotifierComponent } from './components/smart/notifier/notifier.componen
 import { NavigationComponent } from './components/smart/navigation/navigation.component';
 import { QuickSwitcherComponent } from './components/smart/quick-switcher/quick-switcher.component';
 import { ThemeSwitchButtonComponent } from './components/smart/theme-switch/theme-switch-button.component';
+import { UploaderComponent } from './components/smart/uploader/uploader.component';
 import { ClarityModule } from '@clr/angular';
 import { HttpClientModule } from '@angular/common/http';
 import { RouterModule, Routes } from '@angular/router';
@@ -44,6 +45,7 @@ export class UnstripTrailingSlashLocation extends Location {
     ContentComponent,
     QuickSwitcherComponent,
     ThemeSwitchButtonComponent,
+    UploaderComponent,
     FilterTextPipe,
   ],
   imports: [


### PR DESCRIPTION
**What this PR does / why we need it**:
- [x] Fix modal flicker
- [x] ~Add file browser~ To do in a future PR
- [x] ~Handle case where CRD watcher fails to start (valid kubeconfig, but connection refused)~ To do in a future PR

closes #750 

**Which issue(s) this PR fixes**
- Fixes #362

Signed-off-by: GuessWhoSamFoo <foos@vmware.com>
