### PR TITLE
Add Dependabot for front-end deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,8 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+- package-ecosystem: npm
+  directory: "/web"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds front-end npm dependencies defined in `./web/package.json` under Dependabot management. PRs will be created when there is a new release published for each dependency.

**Which issue(s) this PR fixes**
Continues #990 

**Special notes for your reviewer**:
Based on the current output from `npm outdated` merging this PR will generate a lot of PRs to update individual npm dependencies.

**Release note**:
```
n/a
```
