### PR TITLE
Vendor and tidy dependabot contributions

### DIFF
--- a/.github/workflows/dependabot-gomod.yaml
+++ b/.github/workflows/dependabot-gomod.yaml
@@ -1,0 +1,27 @@
+name: dependabot-gomod
+on:
+  push:
+    branches:
+    - dependabot/go_modules/**
+
+jobs:
+  go_mod_vendor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.14.x
+      - uses: actions/checkout@v2
+      - name: vendor
+        run: |
+          go mod vendor
+      - name: tidy
+        run: |
+          go mod tidy
+      - name: commit changes
+        uses: stefanzweifel/git-auto-commit-action@v4.3.0
+        with:
+          commit_message: Vendor and tidy go modules
+          commit_options: '--no-verify --signoff'
+          # use a personal access token so that the push will trigger new actions
+          token: ${{ secrets.PAT_TOKEN }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Dependabot will manage go dependencies via go.mod, but will not update
the vendor directory or tidy go.sum. This workflow runs on dependabot
go_module branches running `go mod vendor` and `go mod tidy` committing
the results if anything changed.

**Which issue(s) this PR fixes**

Continues #990

**Special notes for your reviewer**:

We will need a custom access token in order to trick GitHub into running workflows for the new pushed commit.

**Release note**:
```
n/a
```
