### PR TITLE
Add delete action for namespace list

### DIFF
--- a/changelogs/unreleased/1026-GuessWhoSamFoo
+++ b/changelogs/unreleased/1026-GuessWhoSamFoo
@@ -1,0 +1,1 @@
+Added delete object to namespace list

--- a/internal/printer/namespace_test.go
+++ b/internal/printer/namespace_test.go
@@ -44,14 +44,17 @@ func Test_NamespaceListHandler(t *testing.T) {
 
 	expected := component.NewTableWithRows("Namespaces", "We couldn't find any namespaces!", namespaceListCols, []component.TableRow{
 		{
-			"Name":   component.NewLink("", "ns-test-1", "/cluster-overview/namespaces/ns-test-1"),
+			"Name":   component.NewLink("", "ns-test-1", "/cluster-overview/namespaces/ns-test-1", genObjectStatus(component.TextStatusOK, []string{"v1 Namespace is OK"})),
 			"Labels": component.NewLabels(make(map[string]string)),
 			"Status": component.NewText("Active"),
 			"Age":    component.NewTimestamp(namespace.CreationTimestamp.Time),
+			component.GridActionKey: gridActionsFactory([]component.GridAction{
+				buildObjectDeleteAction(t, namespace),
+			}),
 		},
 	})
 
-	component.AssertEqual(t, expected, got)
+	testutil.AssertJSONEqual(t, expected, got)
 }
 
 func Test_printNamespaceResourceQuotas(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Change namespaces to use object tables so they have a delete action that does not require clicking into the object view

**Which issue(s) this PR fixes**
- Fixes #985 

Signed-off-by: GuessWhoSamFoo <foos@vmware.com>
