### PR TITLE
Handle multiple owner references in objects

### DIFF
--- a/internal/objectvisitor/object_test.go
+++ b/internal/objectvisitor/object_test.go
@@ -19,55 +19,114 @@ import (
 )
 
 func TestObject_Visit(t *testing.T) {
-	controller := gomock.NewController(t)
-	defer controller.Finish()
-
-	resourceList := &metav1.APIResourceList{}
-	resourceList.APIResources = []metav1.APIResource{
-		{
-			Kind:       "Deployment",
-			Namespaced: true,
-		},
-	}
-
-	dashConfig := configFake.NewMockDash(controller)
-
 	deployment := testutil.ToUnstructured(t, testutil.CreateDeployment("deployment"))
 	replicaSet := testutil.ToUnstructured(t, testutil.CreateAppReplicaSet("replica-set"))
 	pod := testutil.ToUnstructured(t, testutil.CreatePod("pod"))
 
-	q := queryerFake.NewMockQueryer(controller)
-	q.EXPECT().
-		OwnerReference(gomock.Any(), replicaSet).
-		Return(true, deployment, nil)
-	q.EXPECT().
-		Children(gomock.Any(), replicaSet).Return(testutil.ToUnstructuredList(t, pod), nil)
+	type ctorArgs struct {
+		dashConfig func(ctrl *gomock.Controller) *configFake.MockDash
+		queryer    func(ctrl *gomock.Controller) *queryerFake.MockQueryer
+	}
+	tests := []struct {
+		name        string
+		ctorArgs    ctorArgs
+		handler     func(ctrl *gomock.Controller) *fake.MockObjectHandler
+		expected    *unstructured.UnstructuredList
+		visitObject *unstructured.Unstructured
+	}{
+		{
+			name: "single owner reference",
+			ctorArgs: ctorArgs{
+				dashConfig: func(ctrl *gomock.Controller) *configFake.MockDash {
+					dashConfig := configFake.NewMockDash(ctrl)
+					return dashConfig
+				},
+				queryer: func(ctrl *gomock.Controller) *queryerFake.MockQueryer {
+					q := queryerFake.NewMockQueryer(ctrl)
+					q.EXPECT().
+						OwnerReference(gomock.Any(), replicaSet).
+						Return(true, []*unstructured.Unstructured{deployment}, nil)
+					q.EXPECT().
+						Children(gomock.Any(), replicaSet).Return(testutil.ToUnstructuredList(t, pod), nil)
+					return q
+				},
+			},
+			handler: func(ctrl *gomock.Controller) *fake.MockObjectHandler {
+				handler := fake.NewMockObjectHandler(ctrl)
+				handler.EXPECT().AddEdge(gomock.Any(), replicaSet, pod).Return(nil)
+				handler.EXPECT().AddEdge(gomock.Any(), replicaSet, deployment).Return(nil)
+				handler.EXPECT().Process(gomock.Any(), replicaSet).Return(nil)
+				return handler
+			},
+			visitObject: replicaSet,
+			expected:    testutil.ToUnstructuredList(t, deployment, pod),
+		},
+		{
+			name: "multiple owner reference",
+			ctorArgs: ctorArgs{
+				dashConfig: func(ctrl *gomock.Controller) *configFake.MockDash {
+					dashConfig := configFake.NewMockDash(ctrl)
+					return dashConfig
+				},
+				queryer: func(ctrl *gomock.Controller) *queryerFake.MockQueryer {
+					q := queryerFake.NewMockQueryer(ctrl)
+					q.EXPECT().
+						OwnerReference(gomock.Any(), pod).
+						Return(true, []*unstructured.Unstructured{deployment, replicaSet}, nil)
+					q.EXPECT().
+						Children(gomock.Any(), pod).Return(&unstructured.UnstructuredList{}, nil)
+					return q
+				},
+			},
+			visitObject: pod,
+			handler: func(ctrl *gomock.Controller) *fake.MockObjectHandler {
+				handler := fake.NewMockObjectHandler(ctrl)
+				handler.EXPECT().AddEdge(gomock.Any(), pod, replicaSet).Return(nil)
+				handler.EXPECT().AddEdge(gomock.Any(), pod, deployment).Return(nil)
+				handler.EXPECT().Process(gomock.Any(), pod).Return(nil)
+				return handler
+			},
+			expected: testutil.ToUnstructuredList(t, deployment, replicaSet),
+		},
+	}
 
-	handler := fake.NewMockObjectHandler(controller)
-	handler.EXPECT().AddEdge(gomock.Any(), replicaSet, pod).Return(nil)
-	handler.EXPECT().AddEdge(gomock.Any(), replicaSet, deployment).Return(nil)
-	handler.EXPECT().Process(gomock.Any(), replicaSet).Return(nil)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			controller := gomock.NewController(t)
+			defer controller.Finish()
 
-	var visited []unstructured.Unstructured
-	var mu sync.Mutex
-	visitor := fake.NewMockVisitor(controller)
-	visitor.EXPECT().
-		Visit(gomock.Any(), gomock.Any(), handler, gomock.Any()).
-		DoAndReturn(func(ctx context.Context, object *unstructured.Unstructured, handler objectvisitor.ObjectHandler, _ bool) error {
-			mu.Lock()
-			defer mu.Unlock()
-			visited = append(visited, *object)
-			return nil
-		}).
-		Times(2)
+			resourceList := &metav1.APIResourceList{}
+			resourceList.APIResources = []metav1.APIResource{
+				{
+					Kind:       "Deployment",
+					Namespaced: true,
+				},
+			}
 
-	object := objectvisitor.NewObject(dashConfig, q)
+			handler := tt.handler(controller)
 
-	ctx := context.Background()
-	err := object.Visit(ctx, replicaSet, handler, visitor, true)
-	require.NoError(t, err)
+			var visited []unstructured.Unstructured
+			var mu sync.Mutex
+			visitor := fake.NewMockVisitor(controller)
+			visitor.EXPECT().
+				Visit(gomock.Any(), gomock.Any(), handler, gomock.Any()).
+				DoAndReturn(func(ctx context.Context, object *unstructured.Unstructured, handler objectvisitor.ObjectHandler, _ bool) error {
+					mu.Lock()
+					defer mu.Unlock()
+					visited = append(visited, *object)
+					return nil
+				}).
+				Times(2)
 
-	sortObjectsByName(t, visited)
-	expected := testutil.ToUnstructuredList(t, deployment, pod)
-	assert.Equal(t, expected.Items, visited)
+			object := objectvisitor.NewObject(tt.ctorArgs.dashConfig(controller), tt.ctorArgs.queryer(controller))
+
+			ctx := context.Background()
+			err := object.Visit(ctx, tt.visitObject, handler, visitor, true)
+			require.NoError(t, err)
+
+			sortObjectsByName(t, visited)
+			assert.Equal(t, tt.expected.Items, visited)
+
+		})
+	}
 }

--- a/internal/queryer/fake/mock_queryer.go
+++ b/internal/queryer/fake/mock_queryer.go
@@ -99,11 +99,11 @@ func (mr *MockQueryerMockRecorder) IngressesForService(arg0, arg1 interface{}) *
 }
 
 // OwnerReference mocks base method
-func (m *MockQueryer) OwnerReference(arg0 context.Context, arg1 *unstructured.Unstructured) (bool, *unstructured.Unstructured, error) {
+func (m *MockQueryer) OwnerReference(arg0 context.Context, arg1 *unstructured.Unstructured) (bool, []*unstructured.Unstructured, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "OwnerReference", arg0, arg1)
 	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(*unstructured.Unstructured)
+	ret1, _ := ret[1].([]*unstructured.Unstructured)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -96,26 +96,30 @@ func LoadTypedObjectFromFile(t *testing.T, objectFile string, into runtime.Objec
 }
 
 // ToOwnerReferences converts an object to owner references.
-func ToOwnerReferences(t *testing.T, object runtime.Object) []metav1.OwnerReference {
-	objectKind := object.GetObjectKind()
-	apiVersion, kind := objectKind.GroupVersionKind().ToAPIVersionAndKind()
+func ToOwnerReferences(t *testing.T, objects ...runtime.Object) []metav1.OwnerReference {
+	var list []metav1.OwnerReference
 
-	accessor := meta.NewAccessor()
-	name, err := accessor.Name(object)
-	require.NoError(t, err)
+	for _, object := range objects {
+		objectKind := object.GetObjectKind()
+		apiVersion, kind := objectKind.GroupVersionKind().ToAPIVersionAndKind()
 
-	uid, err := accessor.UID(object)
-	require.NoError(t, err)
+		accessor := meta.NewAccessor()
+		name, err := accessor.Name(object)
+		require.NoError(t, err)
 
-	return []metav1.OwnerReference{
-		{
+		uid, err := accessor.UID(object)
+		require.NoError(t, err)
+
+		list = append(list, metav1.OwnerReference{
 			APIVersion: apiVersion,
 			Kind:       kind,
 			Name:       name,
 			UID:        uid,
 			Controller: pointer.BoolPtr(true),
-		},
+		})
 	}
+
+	return list
 }
 
 // Time generates a test time
@@ -131,4 +135,3 @@ func RequireErrorOrNot(t *testing.T, wantErr bool, err error) {
 	}
 	require.NoError(t, err)
 }
-


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds support for multiple owner references in objects.

**Which issue(s) this PR fixes**
- Fixes #541

**Release note**:
```
Octant can now build resource graphs for objects with multiple owner references.
```
