### PR TITLE
Switch Dependabot for npm to only manage the lock file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,7 @@ updates:
   open-pull-requests-limit: 10
 - package-ecosystem: npm
   directory: "/web"
+  versioning-strategy: lockfile-only
   schedule:
     interval: weekly
   open-pull-requests-limit: 10


### PR DESCRIPTION
**What this PR does / why we need it**:

This will preserve package.json and keep the lockfile in line with the
semver ranges defined by package.json. Dependabot will no longer suggest
version bumps that fall outside of the specified semver range.

**Special notes for your reviewer**:

https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#versioning-strategy

**Release note**:
```
none
```
