### PR TITLE
Pin node version to 10.x

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -26,6 +26,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-node@v2.0.0
+        with:
+          node-version: 10.x
       - uses: actions/checkout@v2
       - name: eslint
         run: |

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -8,6 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-node@v2.0.0
+        with:
+          node-version: 10.x
       - uses: actions/setup-go@v2
         with:
           go-version: '1.14'

--- a/.github/workflows/preflight-checks.yaml
+++ b/.github/workflows/preflight-checks.yaml
@@ -54,6 +54,8 @@ jobs:
     name: Karma tests on ${{ matrix.platform }}
     steps:
       - uses: actions/setup-node@v2.0.0
+        with:
+          node-version: 10.x
       - uses: actions/checkout@v2
       - name: run_karma
         run: |
@@ -72,6 +74,8 @@ jobs:
     name: Build on ${{ matrix.platform }}
     steps:
       - uses: actions/setup-node@v2.0.0
+        with:
+          node-version: 10.x
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go-version }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Use the version of Node we want, rather than whatever happens to be on the runner.

**Release note**:
```
none
```
