### PR TITLE
Add port-forward button on Service summary page

### DIFF
--- a/internal/octant/port_forward.go
+++ b/internal/octant/port_forward.go
@@ -49,7 +49,10 @@ func (p *PortForward) Handle(ctx context.Context, alerter action.Alerter, payloa
 	}
 	p.logger.Debugf("%s", request)
 
-	p.portForwarder.Create(ctx, request.gvk(), request.Name, request.Namespace, request.Port)
+	_, err = p.portForwarder.Create(ctx, request.gvk(), request.Name, request.Namespace, request.Port)
+	if err != nil {
+		return errors.Wrap(err, "create port forwarder")
+	}
 	return nil
 }
 

--- a/internal/portforward/fake/mock_interface.go
+++ b/internal/portforward/fake/mock_interface.go
@@ -79,19 +79,34 @@ func (mr *MockPortForwarderMockRecorder) Create(ctx, gvk, name, namespace, remot
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockPortForwarder)(nil).Create), ctx, gvk, name, namespace, remotePort)
 }
 
-// Find mocks base method
-func (m *MockPortForwarder) Find(namespace string, gvk schema.GroupVersionKind, name string) ([]portforward.State, error) {
+// FindTarget mocks base method
+func (m *MockPortForwarder) FindTarget(namespace string, gvk schema.GroupVersionKind, name string) ([]portforward.State, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Find", namespace, gvk, name)
+	ret := m.ctrl.Call(m, "FindTarget", namespace, gvk, name)
 	ret0, _ := ret[0].([]portforward.State)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// Find indicates an expected call of Find
-func (mr *MockPortForwarderMockRecorder) Find(namespace, gvk, name interface{}) *gomock.Call {
+// FindTarget indicates an expected call of FindTarget
+func (mr *MockPortForwarderMockRecorder) FindTarget(namespace, gvk, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Find", reflect.TypeOf((*MockPortForwarder)(nil).Find), namespace, gvk, name)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindTarget", reflect.TypeOf((*MockPortForwarder)(nil).FindTarget), namespace, gvk, name)
+}
+
+// FindPod mocks base method
+func (m *MockPortForwarder) FindPod(namespace string, gvk schema.GroupVersionKind, name string) ([]portforward.State, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindPod", namespace, gvk, name)
+	ret0, _ := ret[0].([]portforward.State)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindPod indicates an expected call of FindPod
+func (mr *MockPortForwarderMockRecorder) FindPod(namespace, gvk, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindPod", reflect.TypeOf((*MockPortForwarder)(nil).FindPod), namespace, gvk, name)
 }
 
 // Stop mocks base method

--- a/internal/portforward/service.go
+++ b/internal/portforward/service.go
@@ -132,6 +132,9 @@ type Service struct {
 	state    States
 }
 
+// Check that struct satisfies interface
+var _ PortForwarder = (*Service)(nil)
+
 // New creates an instance of Service.
 func New(ctx context.Context, opts ServiceOptions) *Service {
 	ctx, cancel := context.WithCancel(ctx)
@@ -174,15 +177,6 @@ func (s *Service) validateCreateRequest(r CreateRequest) error {
 	}
 
 	return nil
-}
-
-func (s *Service) FindPodSpecForService(ctx context.Context, apiVersion, kind, namespace, name string) (*corev1.PodSpec, error) {
-	pod, err := s.findPodForService(ctx, apiVersion, kind, namespace, name)
-	if err != nil {
-		return nil, err
-	}
-
-	return &pod.Spec, nil
 }
 
 // resolvePod attempts to resolve a port forward request into an active pod we can
@@ -242,7 +236,7 @@ func (s *Service) findPodForService(ctx context.Context, apiVersion, kind, names
 		APIVersion: apiVersion,
 		Kind:       "Pod",
 		Namespace:  namespace,
-		Selector: &lbls,
+		Selector:   &lbls,
 	}
 	list, _, err := o.List(ctx, key)
 	if err != nil {
@@ -299,7 +293,7 @@ func (s *Service) verifyPod(ctx context.Context, namespace, name string) (bool, 
 // createForwarder creates a port forwarder, forwards traffic, and blocks until
 // port state information is populated.
 // Returns forwarder id.
-func (s *Service) createForwarder(targetRequest CreateRequest, podRequest CreateRequest) (string, error) {
+func (s *Service) createForwarder(targetRequest, podRequest CreateRequest) (string, error) {
 	logger := s.logger.With("context", "PortForwardService.createForwarder")
 
 	if s.opts.PortForwarder == nil {
@@ -569,6 +563,9 @@ func (s *Service) StopForwarder(id string) {
 }
 
 type notFound struct{}
+
+// Check that struct satisfies interface
+var _ error = (*notFound)(nil)
 
 func (e *notFound) Error() string {
 	return "port forward not found"

--- a/internal/printer/container.go
+++ b/internal/printer/container.go
@@ -265,7 +265,7 @@ func describeContainerPorts(
 		}
 	}
 
-	states, err := portForwardService.Find(namespace, gvk, name)
+	states, err := portForwardService.FindPod(namespace, gvk, name)
 	if err != nil {
 		if _, ok := err.(notFound); !ok {
 			return nil, errors.Wrap(err, "query port forward service for pod")

--- a/internal/printer/container_test.go
+++ b/internal/printer/container_test.go
@@ -315,7 +315,8 @@ func Test_ContainerConfiguration(t *testing.T) {
 
 			state := createPortForwardState("stateid", "namespace", "pod", gvk)
 
-			pf.EXPECT().Find("namespace", gomock.Eq(gvk), "pod").Return(states, nil).AnyTimes()
+			pf.EXPECT().FindPod("namespace", gomock.Eq(gvk), "pod").Return(states, nil).AnyTimes()
+			pf.EXPECT().FindTarget("namespace", gomock.Eq(gvk), "pod").Return(states, nil).AnyTimes()
 			pf.EXPECT().Get(gomock.Any()).Return(state, true).AnyTimes()
 
 			tpo.PathForGVK("namespace", "v1", "Secret", "mysecret", "mysecret:somesecretkey", "/secret")

--- a/internal/printer/helpers_test.go
+++ b/internal/printer/helpers_test.go
@@ -31,6 +31,7 @@ type testPrinterOptions struct {
 
 	objectStore   *objectStoreFake.MockStore
 	pluginManager *pluginFake.MockManagerInterface
+	portForwarder *portForwardFake.MockPortForwarder
 }
 
 func newTestPrinterOptions(controller *gomock.Controller) *testPrinterOptions {
@@ -50,6 +51,7 @@ func newTestPrinterOptions(controller *gomock.Controller) *testPrinterOptions {
 		link:          linkFake.NewMockInterface(controller),
 		objectStore:   objectStore,
 		pluginManager: pluginManager,
+		portForwarder: portForwarder,
 	}
 
 	tpo.dashConfig.EXPECT().Validate().Return(nil).AnyTimes()

--- a/pkg/view/component/port.go
+++ b/pkg/view/component/port.go
@@ -26,10 +26,12 @@ type Port struct {
 
 // PortConfig is the contents of Port
 type PortConfig struct {
-	Port     int              `json:"port,omitempty"`
-	Protocol string           `json:"protocol,omitempty"`
-	State    PortForwardState `json:"state,omitempty"`
-	Button   *ButtonGroup     `json:"buttonGroup,omitempty"`
+	Port       int              `json:"port,omitempty"`
+	Protocol   string           `json:"protocol,omitempty"`
+	TargetPort int              `json:"targetPort,omitempty"`
+	TargetPortName string              `json:"targetPortName,omitempty"`
+	State      PortForwardState `json:"state,omitempty"`
+	Button     *ButtonGroup     `json:"buttonGroup,omitempty"`
 }
 
 // NewPort creates a port component
@@ -41,6 +43,21 @@ func NewPort(namespace, apiVersion, kind, name string, port int, protocol string
 			Protocol: protocol,
 			State:    pfs,
 			Button:   describeButton(namespace, apiVersion, kind, name, port, pfs),
+		},
+	}
+}
+
+// NewPort creates a port component
+func NewServicePort(namespace, apiVersion, kind, name string, port int, protocol string, targetPort int, targetPortName string, pfs PortForwardState) *Port {
+	return &Port{
+		base: newBase(typePort, nil),
+		Config: PortConfig{
+			Port:       port,
+			Protocol:   protocol,
+			TargetPort: targetPort,
+			TargetPortName: targetPortName,
+			State:      pfs,
+			Button:     describeButton(namespace, apiVersion, kind, name, targetPort, pfs),
 		},
 	}
 }

--- a/pkg/view/component/port.go
+++ b/pkg/view/component/port.go
@@ -26,12 +26,12 @@ type Port struct {
 
 // PortConfig is the contents of Port
 type PortConfig struct {
-	Port       int              `json:"port,omitempty"`
-	Protocol   string           `json:"protocol,omitempty"`
-	TargetPort int              `json:"targetPort,omitempty"`
-	TargetPortName string              `json:"targetPortName,omitempty"`
-	State      PortForwardState `json:"state,omitempty"`
-	Button     *ButtonGroup     `json:"buttonGroup,omitempty"`
+	Port           int              `json:"port,omitempty"`
+	Protocol       string           `json:"protocol,omitempty"`
+	TargetPort     int              `json:"targetPort,omitempty"`
+	TargetPortName string           `json:"targetPortName,omitempty"`
+	State          PortForwardState `json:"state,omitempty"`
+	Button         *ButtonGroup     `json:"buttonGroup,omitempty"`
 }
 
 // NewPort creates a port component
@@ -52,12 +52,12 @@ func NewServicePort(namespace, apiVersion, kind, name string, port int, protocol
 	return &Port{
 		base: newBase(typePort, nil),
 		Config: PortConfig{
-			Port:       port,
-			Protocol:   protocol,
-			TargetPort: targetPort,
+			Port:           port,
+			Protocol:       protocol,
+			TargetPort:     targetPort,
 			TargetPortName: targetPortName,
-			State:      pfs,
-			Button:     describeButton(namespace, apiVersion, kind, name, targetPort, pfs),
+			State:          pfs,
+			Button:         describeButton(namespace, apiVersion, kind, name, targetPort, pfs),
 		},
 	}
 }

--- a/web/src/app/modules/shared/components/presentation/ports/ports.component.html
+++ b/web/src/app/modules/shared/components/presentation/ports/ports.component.html
@@ -1,7 +1,9 @@
 <div class="ports">
   <div class="port" *ngFor="let port of v?.config.ports; trackBy: trackByFn">
     <div class="port-text">
-      {{ port.config.port }}/{{ port.config.protocol }}
+      <span>{{ port.config.port }}/{{ port.config.protocol }}</span>
+      <span *ngIf="port.config.targetPort > 0 && !port.config.targetPortName"> ⟹ {{port.config.targetPort}}</span>
+      <span *ngIf="port.config.targetPort > 0 && port.config.targetPortName"> ⟹ {{port.config.targetPortName}} ({{port.config.targetPort}})</span>
     </div>
     <div class="port-actions">
       <ng-container *ngIf="port.config.state?.isForwarded">


### PR DESCRIPTION
**What this PR does / why we need it**:
Lets the user enable port forwarding from the services summary page, similar to how `kubectl` allows the user to specify a service when setting up port-forwarding.

This has a few quirks that might not be obvious:

* If the service maps several ports to a single target port (weird but possible), then _all_ of those ports will display the same port-forwarding information.
* Because we have to forward directly to a pod, when enabling port-forwarding via a service, that same port-forwarding will also be visible on the pod summary page too.
* To make it easier to handle named ports, we resolve the named port to an integer port when generating the service summary information. We also display that port on the service summary page. That said, in complex deployments, a single service could be linking multiple groups of pods, and that named port could map to multiple integer ports, so displaying the resolved port could be confusing?

**Which issue(s) this PR fixes**
- Fixes #721 

**Special notes for your reviewer**:

**Release note**:
```
Service summary page now includes a button to enable port-forwarding for all ports listed
Service summary page resolves named ports against containers and displays the port
```
