### PR TITLE
Apply YAML UI

### DIFF
--- a/changelogs/unreleased/954-scothis
+++ b/changelogs/unreleased/954-scothis
@@ -1,0 +1,1 @@
+Apply YAML to current cluster and namespace

--- a/internal/cluster/fake/mock_client_interface.go
+++ b/internal/cluster/fake/mock_client_interface.go
@@ -67,12 +67,13 @@ func (mr *MockClientInterfaceMockRecorder) ResourceExists(arg0 interface{}) *gom
 }
 
 // Resource mocks base method
-func (m *MockClientInterface) Resource(arg0 schema.GroupKind) (schema.GroupVersionResource, error) {
+func (m *MockClientInterface) Resource(arg0 schema.GroupKind) (schema.GroupVersionResource, bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Resource", arg0)
 	ret0, _ := ret[0].(schema.GroupVersionResource)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // Resource indicates an expected call of Resource

--- a/internal/modules/configuration/applyyaml_describer.go
+++ b/internal/modules/configuration/applyyaml_describer.go
@@ -1,0 +1,46 @@
+/*
+Copyright (c) 2020 the Octant contributors. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package configuration
+
+import (
+	"context"
+
+	"github.com/vmware-tanzu/octant/internal/describer"
+	"github.com/vmware-tanzu/octant/internal/octant"
+	"github.com/vmware-tanzu/octant/pkg/view/component"
+)
+
+// ApplyYamlDescriber describes an apply
+type ApplyYamlDescriber struct {
+}
+
+var _ describer.Describer = (*ApplyYamlDescriber)(nil)
+
+// Describe describes the apply yaml interface
+func (d *ApplyYamlDescriber) Describe(ctx context.Context, namespace string, options describer.Options) (component.ContentResponse, error) {
+	title := append([]component.TitleComponent{}, component.NewText("Apply YAML"))
+	editor := component.NewEditor(component.TitleFromString("YAML"), "", false)
+	editor.Config.SubmitLabel = "Apply"
+	editor.Config.SubmitAction = octant.ActionApplyYaml
+	list := component.NewList(title, []component.Component{editor})
+
+	return component.ContentResponse{
+		Components: []component.Component{list},
+	}, nil
+}
+
+func (d *ApplyYamlDescriber) PathFilters() []describer.PathFilter {
+	filter := describer.NewPathFilter("/apply", d)
+	return []describer.PathFilter{*filter}
+}
+
+func (d *ApplyYamlDescriber) Reset(ctx context.Context) error {
+	return nil
+}
+
+func NewApplyYamlDescriber() *ApplyYamlDescriber {
+	return &ApplyYamlDescriber{}
+}

--- a/internal/modules/configuration/applyyaml_describer_test.go
+++ b/internal/modules/configuration/applyyaml_describer_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright (c) 2020 the Octant contributors. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package configuration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+
+	configFake "github.com/vmware-tanzu/octant/internal/config/fake"
+	"github.com/vmware-tanzu/octant/internal/describer"
+	"github.com/vmware-tanzu/octant/pkg/view/component"
+)
+
+func TestApplyYamlDescriber(t *testing.T) {
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	namespace := "default"
+
+	dashConfig := configFake.NewMockDash(controller)
+
+	p := NewApplyYamlDescriber()
+
+	options := describer.Options{
+		Dash: dashConfig,
+	}
+
+	cResponse, err := p.Describe(context.TODO(), namespace, options)
+	require.NoError(t, err)
+
+	list := component.NewList(append([]component.TitleComponent{}, component.NewText("Apply YAML")), nil)
+
+	editor := component.NewEditor(component.TitleFromString("YAML"), "", false)
+	editor.Config.SubmitAction = "action.octant.dev/apply"
+	editor.Config.SubmitLabel = "Apply"
+	list.Add(editor)
+
+	require.Len(t, cResponse.Components, 1)
+	component.AssertEqual(t, list, cResponse.Components[0])
+
+	pf := p.PathFilters()
+	require.Equal(t, "/apply", pf[0].String())
+
+	err = p.Reset(context.TODO())
+	require.NoError(t, err)
+}

--- a/internal/modules/configuration/objects.go
+++ b/internal/modules/configuration/objects.go
@@ -8,11 +8,14 @@ package configuration
 import "github.com/vmware-tanzu/octant/internal/describer"
 
 var (
-	pluginDescriber = &PluginListDescriber{}
+	pluginDescriber = NewPluginListDescriber()
+
+	applyYamlDescriber = NewApplyYamlDescriber()
 
 	rootDescriber = describer.NewSection(
 		"/",
 		"Configuration",
 		pluginDescriber,
+		applyYamlDescriber,
 	)
 )

--- a/internal/modules/overview/overview.go
+++ b/internal/modules/overview/overview.go
@@ -279,6 +279,7 @@ func (co *Overview) ActionPaths() map[string]action.DispatcherFunc {
 		octant.NewCronJobSuspend(co.dashConfig.ObjectStore(), co.dashConfig.ClusterClient()),
 		octant.NewCronJobResume(co.dashConfig.ObjectStore(), co.dashConfig.ClusterClient()),
 		octant.NewObjectUpdaterDispatcher(co.dashConfig.ObjectStore()),
+		octant.NewApplyYaml(co.logger, co.dashConfig.ObjectStore(), co.dashConfig.ClusterClient()),
 	}
 
 	return dispatchers.ToActionPaths()

--- a/internal/objectstore/access.go
+++ b/internal/objectstore/access.go
@@ -8,11 +8,11 @@ package objectstore
 import (
 	"context"
 	"fmt"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sync"
 
 	"go.opencensus.io/trace"
 	authorizationv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/vmware-tanzu/octant/internal/cluster"
 	oerrors "github.com/vmware-tanzu/octant/internal/errors"
@@ -158,7 +158,7 @@ func (r *resourceAccess) keyToAccessKey(key store.Key, verb string) (AccessKey, 
 		return AccessKey{}, fmt.Errorf("unable to check access for key %s", key.String())
 	}
 
-	gvr, err := r.client.Resource(gvk.GroupKind())
+	gvr, _, err := r.client.Resource(gvk.GroupKind())
 	if err != nil {
 		return AccessKey{}, fmt.Errorf("unable to get resource for group kind %s: %w", gvk.GroupKind(), err)
 	}

--- a/internal/objectstore/access_test.go
+++ b/internal/objectstore/access_test.go
@@ -118,7 +118,7 @@ func Test_ResourceAccess_HasAccess(t *testing.T) {
 				Version:  gvk.Version,
 				Resource: ts.resource,
 			}
-			client.EXPECT().Resource(gomock.Eq(gvk.GroupKind())).Return(podGVR, nil)
+			client.EXPECT().Resource(gomock.Eq(gvk.GroupKind())).Return(podGVR, true, nil)
 
 			if ts.expectErr {
 				require.Error(t, r.HasAccess(ctx, ts.key, "get"))

--- a/internal/objectstore/dynamic_cache.go
+++ b/internal/objectstore/dynamic_cache.go
@@ -304,7 +304,7 @@ func (dc *DynamicCache) listFromDynamicClient(ctx context.Context, key store.Key
 		return nil, err
 	}
 
-	gvr, err := dc.client.Resource(key.GroupVersionKind().GroupKind())
+	gvr, _, err := dc.client.Resource(key.GroupVersionKind().GroupKind())
 	if err != nil {
 		return nil, err
 	}
@@ -402,7 +402,7 @@ func (dc *DynamicCache) getFromDynamicClient(ctx context.Context, key store.Key)
 		return nil, err
 	}
 
-	gvr, err := dc.client.Resource(key.GroupVersionKind().GroupKind())
+	gvr, _, err := dc.client.Resource(key.GroupVersionKind().GroupKind())
 	if err != nil {
 		return nil, err
 	}
@@ -477,7 +477,7 @@ func (dc *DynamicCache) Delete(ctx context.Context, key store.Key) error {
 		return err
 	}
 
-	gvr, err := dc.client.Resource(key.GroupVersionKind().GroupKind())
+	gvr, _, err := dc.client.Resource(key.GroupVersionKind().GroupKind())
 	if err != nil {
 		return err
 	}
@@ -551,7 +551,7 @@ func (dc *DynamicCache) Update(ctx context.Context, key store.Key, updater func(
 
 		gvk := object.GroupVersionKind()
 
-		gvr, err := dc.client.Resource(gvk.GroupKind())
+		gvr, _, err := dc.client.Resource(gvk.GroupKind())
 		if err != nil {
 			return err
 		}
@@ -608,7 +608,7 @@ func (dc *DynamicCache) Create(ctx context.Context, object *unstructured.Unstruc
 		return err
 	}
 
-	gvr, err := dc.client.Resource(key.GroupVersionKind().GroupKind())
+	gvr, _, err := dc.client.Resource(key.GroupVersionKind().GroupKind())
 	if err != nil {
 		return err
 	}

--- a/internal/objectstore/informer.go
+++ b/internal/objectstore/informer.go
@@ -70,7 +70,7 @@ func (f *informerFactory) ForResource(groupVersionKind schema.GroupVersionKind) 
 
 	stopCh := f.informerContextCache.addChild(groupVersionKind)
 
-	gvr, err := f.client.Resource(groupVersionKind.GroupKind())
+	gvr, _, err := f.client.Resource(groupVersionKind.GroupKind())
 	if err != nil {
 		return nil, fmt.Errorf("unable to find group version resource for group kind %s: %w",
 			groupVersionKind.GroupKind(), err)

--- a/internal/octant/actions.go
+++ b/internal/octant/actions.go
@@ -21,6 +21,7 @@ const (
 	ActionOverviewServiceEditor   = "action.octant.dev/serviceEditor"
 	ActionDeploymentConfiguration = "action.octant.dev/deploymentConfiguration"
 	ActionUpdateObject            = "action.octant.dev/update"
+	ActionApplyYaml               = "action.octant.dev/apply"
 )
 
 func sendAlert(alerter action.Alerter, alertType action.AlertType, message string, expiration *time.Time) {

--- a/internal/octant/apply_yaml.go
+++ b/internal/octant/apply_yaml.go
@@ -1,0 +1,221 @@
+/*
+Copyright (c) 2020 the Octant contributors. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package octant
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/pkg/errors"
+	"github.com/vmware-tanzu/octant/internal/cluster"
+	"github.com/vmware-tanzu/octant/pkg/action"
+	"github.com/vmware-tanzu/octant/pkg/log"
+	"github.com/vmware-tanzu/octant/pkg/store"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	sigyaml "sigs.k8s.io/yaml"
+)
+
+// ApplyYaml creates a yaml applier
+type ApplyYaml struct {
+	logger        log.Logger
+	objectStore   store.Store
+	clusterClient cluster.ClientInterface
+}
+
+var _ action.Dispatcher = (*ApplyYaml)(nil)
+
+// NewApplyYaml creates an instance of ApplyYaml
+func NewApplyYaml(logger log.Logger, objectStore store.Store, clusterClient cluster.ClientInterface) *ApplyYaml {
+	return &ApplyYaml{
+		logger:        logger,
+		objectStore:   objectStore,
+		clusterClient: clusterClient,
+	}
+}
+
+// ActionName returns the name of this action
+func (p *ApplyYaml) ActionName() string {
+	return ActionApplyYaml
+}
+
+// Handle applies the requested yaml to the cluster
+func (p *ApplyYaml) Handle(ctx context.Context, alerter action.Alerter, payload action.Payload) error {
+	p.logger.With("payload", payload).Debugf("received action payload")
+	request, err := applyYamlRequestFromPayload(payload)
+	if err != nil {
+		return errors.Wrap(err, "convert payload to apply yaml request")
+	}
+	p.logger.Debugf("%s", request)
+
+	results := []string{}
+	err = request.WithDoc(func(doc map[string]interface{}) error {
+		p.logger.Debugf("apply resource %#v", doc)
+
+		unstructuredObj := &unstructured.Unstructured{Object: doc}
+		key, err := store.KeyFromObject(unstructuredObj)
+		if err != nil {
+			return err
+		}
+		gvr, namespaced, err := p.clusterClient.Resource(key.GroupVersionKind().GroupKind())
+		if err != nil {
+			return fmt.Errorf("unable to discover resource: %w", err)
+		}
+		if namespaced && key.Namespace == "" {
+			unstructuredObj.SetNamespace(request.Namespace)
+			key.Namespace = request.Namespace
+		}
+
+		if _, err := p.objectStore.Get(ctx, key); err != nil {
+			if !kerrors.IsNotFound(err) {
+				// unexpected error
+				return fmt.Errorf("unable to get resource: %w", err)
+			}
+
+			// create object
+			err := p.objectStore.Create(ctx, &unstructured.Unstructured{Object: doc})
+			if err != nil {
+				return fmt.Errorf("unable to create resource: %w", err)
+			}
+
+			result := fmt.Sprintf("Created %s (%s) %s", key.Kind, key.APIVersion, key.Name)
+			if namespaced {
+				result = fmt.Sprintf("%s in %s", result, key.Namespace)
+			}
+			results = append(results, result)
+
+			return nil
+		}
+
+		// update object
+		unstructuredYaml, err := sigyaml.Marshal(doc)
+		if err != nil {
+			return fmt.Errorf("unable to marshal resource as yaml: %w", err)
+		}
+		client, err := p.clusterClient.DynamicClient()
+		if err != nil {
+			return fmt.Errorf("unable to get dynamic client: %w", err)
+		}
+
+		withForce := true
+		if namespaced {
+			_, err = client.Resource(gvr).Namespace(key.Namespace).Patch(
+				ctx,
+				key.Name,
+				types.ApplyPatchType,
+				unstructuredYaml,
+				metav1.PatchOptions{FieldManager: "octant", Force: &withForce},
+			)
+			if err != nil {
+				return fmt.Errorf("unable to patch resource: %w", err)
+			}
+		} else {
+			_, err = client.Resource(gvr).Patch(
+				ctx,
+				key.Name,
+				types.ApplyPatchType,
+				unstructuredYaml,
+				metav1.PatchOptions{FieldManager: "octant", Force: &withForce},
+			)
+			if err != nil {
+				return fmt.Errorf("unable to patch resource: %w", err)
+			}
+		}
+
+		result := fmt.Sprintf("Updated %s (%s) %s", key.Kind, key.APIVersion, key.Name)
+		if namespaced {
+			result = fmt.Sprintf("%s in %s", result, key.Namespace)
+		}
+		results = append(results, result)
+
+		return nil
+	})
+
+	if err != nil {
+		p.logger.Warnf("unable to apply yaml: %s", err)
+		message := fmt.Sprintf("Unable to apply yaml: %s", err)
+		alerter.SendAlert(action.CreateAlert(action.AlertTypeError, message, action.DefaultAlertExpiration))
+		// do not return to send partial results to the client
+	}
+
+	switch len(results) {
+	case 0:
+		// nothing to do
+	case 1:
+		message := results[0]
+		alerter.SendAlert(action.CreateAlert(action.AlertTypeInfo, message, action.DefaultAlertExpiration))
+	default:
+		// TODO(scothis) send detailed results to client
+		message := fmt.Sprintf("Applied %d resources", len(results))
+		alerter.SendAlert(action.CreateAlert(action.AlertTypeInfo, message, action.DefaultAlertExpiration))
+	}
+	return nil
+}
+
+type applyYamlRequest struct {
+	Namespace string `json:"namespace,omitempty"`
+	Update    string `json:"update,omitempty"`
+}
+
+func (req *applyYamlRequest) Validate() error {
+	if req.Namespace == "" {
+		return errors.New("namespace is blank")
+	}
+
+	if req.Update == "" {
+		return errors.New("update is blank")
+	}
+
+	return nil
+}
+
+func (req *applyYamlRequest) WithDoc(cb func(doc map[string]interface{}) error) error {
+	d := yaml.NewYAMLOrJSONDecoder(bytes.NewBufferString(req.Update), 4096)
+	for {
+		doc := map[string]interface{}{}
+		if err := d.Decode(&doc); err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return fmt.Errorf("unable to parse yaml: %w", err)
+		}
+		if len(doc) == 0 {
+			// skip empty documents
+			continue
+		}
+		if err := cb(doc); err != nil {
+			return err
+		}
+	}
+}
+
+func applyYamlRequestFromPayload(payload action.Payload) (*applyYamlRequest, error) {
+	namespace, err := payload.String("namespace")
+	if err != nil {
+		return nil, err
+	}
+
+	update, err := payload.String("update")
+	if err != nil {
+		return nil, err
+	}
+
+	req := &applyYamlRequest{
+		Namespace: namespace,
+		Update:    update,
+	}
+
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}

--- a/internal/octant/apply_yaml_test.go
+++ b/internal/octant/apply_yaml_test.go
@@ -1,0 +1,374 @@
+/*
+ * Copyright (c) 2020 the Octant contributors. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package octant
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	sigyaml "sigs.k8s.io/yaml"
+
+	clusterFake "github.com/vmware-tanzu/octant/internal/cluster/fake"
+	"github.com/vmware-tanzu/octant/internal/log"
+	"github.com/vmware-tanzu/octant/pkg/action"
+	actionFake "github.com/vmware-tanzu/octant/pkg/action/fake"
+	"github.com/vmware-tanzu/octant/pkg/store"
+	"github.com/vmware-tanzu/octant/pkg/store/fake"
+)
+
+func TestNewApplyYaml_NamespacedCreate(t *testing.T) {
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	logger := log.NopLogger()
+	objectStore := fake.NewMockStore(controller)
+	clusterClient := clusterFake.NewMockClientInterface(controller)
+	alerter := actionFake.NewMockAlerter(controller)
+
+	gvr := schema.GroupVersionResource{
+		Version:  "v1",
+		Resource: "configmaps",
+	}
+	clusterClient.EXPECT().
+		Resource(schema.GroupKind{Kind: "ConfigMap"}).
+		Return(gvr, true, nil)
+
+	key := store.Key{
+		Namespace:  "default",
+		APIVersion: "v1",
+		Kind:       "ConfigMap",
+		Name:       "greeting",
+	}
+	objectStore.EXPECT().
+		Get(gomock.Any(), key).
+		Return(nil, kerrors.NewNotFound(gvr.GroupResource(), "greeting"))
+
+	uGreeting := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]interface{}{
+				"name":      "greeting",
+				"namespace": "default",
+			},
+			"data": map[string]interface{}{
+				"hello": "world",
+			},
+		},
+	}
+	objectStore.EXPECT().
+		Create(gomock.Any(), uGreeting).
+		Return(nil)
+
+	alerter.EXPECT().
+		SendAlert(gomock.Any()).
+		DoAndReturn(func(alert action.Alert) {
+			assert.Equal(t, action.AlertTypeInfo, alert.Type)
+			assert.Equal(t, "Created ConfigMap (v1) greeting in default", alert.Message)
+			assert.NotNil(t, alert.Expiration)
+		})
+
+	applyYaml := NewApplyYaml(logger, objectStore, clusterClient)
+
+	ctx := context.Background()
+
+	payload := action.CreatePayload(ActionApplyYaml, map[string]interface{}{
+		"update": `
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: greeting
+data:
+  hello: world
+`,
+		"namespace": "default",
+	})
+
+	require.NoError(t, applyYaml.Handle(ctx, alerter, payload))
+}
+
+func TestNewApplyYaml_NamespacedUpdate(t *testing.T) {
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	logger := log.NopLogger()
+	objectStore := fake.NewMockStore(controller)
+	clusterClient := clusterFake.NewMockClientInterface(controller)
+	dynamicClient := clusterFake.NewMockDynamicInterface(controller)
+	dynamicNamespaceableResourceClient := clusterFake.NewMockNamespaceableResourceInterface(controller)
+	dynamicResourceClient := clusterFake.NewMockResourceInterface(controller)
+	alerter := actionFake.NewMockAlerter(controller)
+
+	gvr := schema.GroupVersionResource{
+		Version:  "v1",
+		Resource: "configmaps",
+	}
+	clusterClient.EXPECT().
+		Resource(schema.GroupKind{Kind: "ConfigMap"}).
+		Return(gvr, true, nil)
+
+	key := store.Key{
+		Namespace:  "default",
+		APIVersion: "v1",
+		Kind:       "ConfigMap",
+		Name:       "greeting",
+	}
+	objectStore.EXPECT().
+		Get(gomock.Any(), key).
+		// should return the ConfigMap, but we don't actually care
+		Return(nil, nil)
+
+	clusterClient.EXPECT().
+		DynamicClient().
+		Return(dynamicClient, nil)
+	dynamicClient.EXPECT().
+		Resource(gvr).
+		Return(dynamicNamespaceableResourceClient)
+	dynamicNamespaceableResourceClient.EXPECT().
+		Namespace("default").
+		Return(dynamicResourceClient)
+
+	unstructuredYaml, _ := sigyaml.Marshal(map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata": map[string]interface{}{
+			"name":      "greeting",
+			"namespace": "default",
+		},
+		"data": map[string]interface{}{
+			"hello": "world",
+		},
+	})
+	withForce := true
+	dynamicResourceClient.EXPECT().
+		Patch(
+			gomock.Any(),
+			"greeting",
+			types.ApplyPatchType,
+			unstructuredYaml,
+			metav1.PatchOptions{FieldManager: "octant", Force: &withForce},
+		).
+		// should return the ConfigMap, but we don't actually care
+		Return(nil, nil)
+
+	alerter.EXPECT().
+		SendAlert(gomock.Any()).
+		DoAndReturn(func(alert action.Alert) {
+			assert.Equal(t, action.AlertTypeInfo, alert.Type)
+			assert.Equal(t, "Updated ConfigMap (v1) greeting in default", alert.Message)
+			assert.NotNil(t, alert.Expiration)
+		})
+
+	applyYaml := NewApplyYaml(logger, objectStore, clusterClient)
+
+	ctx := context.Background()
+
+	payload := action.CreatePayload(ActionApplyYaml, map[string]interface{}{
+		"update": `
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: greeting
+data:
+  hello: world
+`,
+		"namespace": "default",
+	})
+
+	require.NoError(t, applyYaml.Handle(ctx, alerter, payload))
+}
+
+func TestNewApplyYaml_ClusterCreate(t *testing.T) {
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	logger := log.NopLogger()
+	objectStore := fake.NewMockStore(controller)
+	clusterClient := clusterFake.NewMockClientInterface(controller)
+	alerter := actionFake.NewMockAlerter(controller)
+
+	gvr := schema.GroupVersionResource{
+		Version:  "v1",
+		Resource: "namespaces",
+	}
+	clusterClient.EXPECT().
+		Resource(schema.GroupKind{Kind: "Namespace"}).
+		Return(gvr, false, nil)
+
+	key := store.Key{
+		APIVersion: "v1",
+		Kind:       "Namespace",
+		Name:       "greeting-system",
+	}
+	objectStore.EXPECT().
+		Get(gomock.Any(), key).
+		Return(nil, kerrors.NewNotFound(gvr.GroupResource(), "greeting-system"))
+
+	uGreeting := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Namespace",
+			"metadata": map[string]interface{}{
+				"name": "greeting-system",
+			},
+		},
+	}
+	objectStore.EXPECT().
+		Create(gomock.Any(), uGreeting).
+		Return(nil)
+
+	alerter.EXPECT().
+		SendAlert(gomock.Any()).
+		DoAndReturn(func(alert action.Alert) {
+			assert.Equal(t, action.AlertTypeInfo, alert.Type)
+			assert.Equal(t, "Created Namespace (v1) greeting-system", alert.Message)
+			assert.NotNil(t, alert.Expiration)
+		})
+
+	applyYaml := NewApplyYaml(logger, objectStore, clusterClient)
+
+	ctx := context.Background()
+
+	payload := action.CreatePayload(ActionApplyYaml, map[string]interface{}{
+		"update": `
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: greeting-system
+`,
+		"namespace": "default",
+	})
+
+	require.NoError(t, applyYaml.Handle(ctx, alerter, payload))
+}
+
+func TestNewApplyYaml_ClusterUpdate(t *testing.T) {
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	logger := log.NopLogger()
+	objectStore := fake.NewMockStore(controller)
+	clusterClient := clusterFake.NewMockClientInterface(controller)
+	dynamicClient := clusterFake.NewMockDynamicInterface(controller)
+	dynamicResourceClient := clusterFake.NewMockNamespaceableResourceInterface(controller)
+	alerter := actionFake.NewMockAlerter(controller)
+
+	gvr := schema.GroupVersionResource{
+		Version:  "v1",
+		Resource: "namespaces",
+	}
+	clusterClient.EXPECT().
+		Resource(schema.GroupKind{Kind: "Namespace"}).
+		Return(gvr, false, nil)
+
+	key := store.Key{
+		APIVersion: "v1",
+		Kind:       "Namespace",
+		Name:       "greeting-system",
+	}
+	objectStore.EXPECT().
+		Get(gomock.Any(), key).
+		// should return the ConfigMap, but we don't actually care
+		Return(nil, nil)
+
+	clusterClient.EXPECT().
+		DynamicClient().
+		Return(dynamicClient, nil)
+	dynamicClient.EXPECT().
+		Resource(gvr).
+		Return(dynamicResourceClient)
+
+	unstructuredYaml, _ := sigyaml.Marshal(map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Namespace",
+		"metadata": map[string]interface{}{
+			"name": "greeting-system",
+		},
+	})
+	withForce := true
+	dynamicResourceClient.EXPECT().
+		Patch(
+			gomock.Any(),
+			"greeting-system",
+			types.ApplyPatchType,
+			unstructuredYaml,
+			metav1.PatchOptions{FieldManager: "octant", Force: &withForce},
+		).
+		// should return the ConfigMap, but we don't actually care
+		Return(nil, nil)
+
+	alerter.EXPECT().
+		SendAlert(gomock.Any()).
+		DoAndReturn(func(alert action.Alert) {
+			assert.Equal(t, action.AlertTypeInfo, alert.Type)
+			assert.Equal(t, "Updated Namespace (v1) greeting-system", alert.Message)
+			assert.NotNil(t, alert.Expiration)
+		})
+
+	applyYaml := NewApplyYaml(logger, objectStore, clusterClient)
+
+	ctx := context.Background()
+
+	payload := action.CreatePayload(ActionApplyYaml, map[string]interface{}{
+		"update": `
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: greeting-system
+`,
+		"namespace": "default",
+	})
+
+	require.NoError(t, applyYaml.Handle(ctx, alerter, payload))
+}
+
+func TestNewApplyYaml_Error(t *testing.T) {
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	logger := log.NopLogger()
+	objectStore := fake.NewMockStore(controller)
+	clusterClient := clusterFake.NewMockClientInterface(controller)
+	alerter := actionFake.NewMockAlerter(controller)
+
+	alerter.EXPECT().
+		SendAlert(gomock.Any()).
+		DoAndReturn(func(alert action.Alert) {
+			assert.Equal(t, action.AlertTypeError, alert.Type)
+			assert.Contains(t, alert.Message, "Unable to apply yaml:")
+			assert.NotNil(t, alert.Expiration)
+		})
+
+	applyYaml := NewApplyYaml(logger, objectStore, clusterClient)
+
+	ctx := context.Background()
+
+	payload := action.CreatePayload(ActionApplyYaml, map[string]interface{}{
+		"update": `
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: greeting
+data: {
+`,
+		"namespace": "default",
+	})
+
+	require.NoError(t, applyYaml.Handle(ctx, alerter, payload))
+}

--- a/internal/octant/pod_metrics_loader.go
+++ b/internal/octant/pod_metrics_loader.go
@@ -6,9 +6,9 @@
 package octant
 
 import (
+	"context"
 	"fmt"
 	"sync"
-	"context"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/view/component/editor.go
+++ b/pkg/view/component/editor.go
@@ -23,9 +23,11 @@ type Editor struct {
 
 // CodeConfig is the contents of Value
 type EditorConfig struct {
-	Value    string            `json:"value"`
-	ReadOnly bool              `json:"readOnly"`
-	Metadata map[string]string `json:"metadata"`
+	Value        string            `json:"value"`
+	ReadOnly     bool              `json:"readOnly"`
+	Metadata     map[string]string `json:"metadata"`
+	SubmitAction string            `json:"submitAction"`
+	SubmitLabel  string            `json:"submitLabel"`
 }
 
 // NewCodeBlock creates a code component

--- a/web/src/app/modules/shared/components/smart/editor/editor.component.html
+++ b/web/src/app/modules/shared/components/smart/editor/editor.component.html
@@ -9,7 +9,7 @@
 
     <div class="controls">
         <button (click)="reset()" [disabled]="isUpdateEnabled()" class="btn">Reset</button>
-        <button (click)="update()" [disabled]="isUpdateEnabled()" class="btn btn-primary">Update</button>
+        <button (click)="submit()" [disabled]="isUpdateEnabled()" class="btn btn-primary">{{ submitLabel }}</button>
     </div>
 
 </div>

--- a/web/src/app/modules/shared/components/smart/editor/editor.component.ts
+++ b/web/src/app/modules/shared/components/smart/editor/editor.component.ts
@@ -4,8 +4,9 @@ SPDX-License-Identifier: Apache-2.0
 */
 
 import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
-import { EditorView, View } from 'src/app/modules/shared/models/content';
+import { EditorView, View } from '../../../models/content';
 import { ThemeService } from '../../../../sugarloaf/components/smart/theme-switch/theme-switch.service';
+import { NamespaceService } from '../../../services/namespace/namespace.service';
 import { ActionService } from '../../../services/action/action.service';
 
 interface Options {
@@ -49,8 +50,12 @@ export class EditorComponent implements OnChanges {
 
   options: Options;
 
+  submitAction = 'action.octant.dev/update';
+  submitLabel = 'Update';
+
   constructor(
     private themeService: ThemeService,
+    private namespaceService: NamespaceService,
     private actionService: ActionService
   ) {
     this.options = {} as Options;
@@ -67,16 +72,22 @@ export class EditorComponent implements OnChanges {
         this.options.readOnly = view.config.readOnly;
         this.options.language = view.config.language;
       }
+
+      this.submitAction = view.config.submitAction || this.submitAction;
+      this.submitLabel = view.config.submitLabel || this.submitLabel;
+
       this.options.theme =
         this.themeService.currentType() === 'dark' ? 'vs-dark' : 'vs';
     }
   }
 
-  update() {
+  submit() {
     const payload = {
-      action: 'action.octant.dev/update',
+      action: this.submitAction,
       update: this.value,
-      ...this.metadata,
+      ...(this.metadata || {
+        namespace: this.namespaceService.activeNamespace.value,
+      }),
     };
     this.actionService.perform(payload);
   }

--- a/web/src/app/modules/shared/models/content.ts
+++ b/web/src/app/modules/shared/models/content.ts
@@ -434,6 +434,8 @@ export interface EditorView extends View {
     language: string;
     readOnly: boolean;
     metadata: { [key: string]: string };
+    submitAction: string;
+    submitLabel: string;
   };
 }
 

--- a/web/src/app/modules/sugarloaf/components/smart/container/container.component.html
+++ b/web/src/app/modules/sugarloaf/components/smart/container/container.component.html
@@ -18,6 +18,14 @@
       </div>
     </div>
     <div class="header-actions">
+      <a
+        [routerLink]="['/configuration/apply']"
+        class="header-link"
+        title="Create or update resources"
+      >
+        <clr-icon shape="upload"></clr-icon>
+        <span>Apply YAML</span>
+      </a>
       <div class="namespace-switcher header-centered">
         <app-namespace></app-namespace>
       </div>

--- a/web/src/app/modules/sugarloaf/components/smart/container/container.component.scss
+++ b/web/src/app/modules/sugarloaf/components/smart/container/container.component.scss
@@ -70,6 +70,20 @@
         width: 300px;
       }
     }
+
+    .header-actions {
+      .header-link {
+        margin: auto 0.8rem;
+        color: white;
+        line-height: 50px;
+        text-decoration: none;
+        outline: none;
+
+        clr-icon {
+          margin-right: 0.2rem;
+        }
+      }
+    }
   }
 
   .content-container {


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a link in the header to an empty YAML editor that uploads resources
to the cluster and defines an action `action.octant.dev/apply` which
parses the YAML and creates or updates each resources on the cluster.

Resources are processed and applied in the order they are defined.
New resources are created and existing resources are patched with the
changes applied server side, which requires k8s 1.16+.

Errors will stop the processing of new resources. Successfully applied
resources will be reported alongside any errors. When multiple resources
are applied, a summary is reported. Errors are lightly processed and may
not be user friendly.

Namespaced resources that do not define a namespace are defaulted to
the current namespace.

**Which issue(s) this PR fixes**
- Fixes #954

**Special notes for your reviewer**:

There are no tests at the moment, opening this PR to share the implementation and to gather feedback.

<img width="1189" alt="Screen Shot 2020-07-10 at 4 29 19 PM" src="https://user-images.githubusercontent.com/302992/87201472-a96f9300-c2cc-11ea-9c0f-64fbde5e9f3c.png">
<img width="1189" alt="Screen Shot 2020-07-10 at 4 25 00 PM" src="https://user-images.githubusercontent.com/302992/87201476-aa082980-c2cc-11ea-9447-b0fbb37e36b6.png">
<img width="1189" alt="Screen Shot 2020-07-10 at 4 28 44 PM" src="https://user-images.githubusercontent.com/302992/87201478-aa082980-c2cc-11ea-87be-c9311ac4cde8.png">
<img width="1189" alt="Screen Shot 2020-07-10 at 4 25 31 PM" src="https://user-images.githubusercontent.com/302992/87201479-aaa0c000-c2cc-11ea-839e-a2de1a620155.png">
<img width="1189" alt="Screen Shot 2020-07-10 at 4 25 50 PM" src="https://user-images.githubusercontent.com/302992/87201480-aaa0c000-c2cc-11ea-9183-636404422d80.png">
<img width="1189" alt="Screen Shot 2020-07-10 at 4 26 30 PM" src="https://user-images.githubusercontent.com/302992/87201482-ab395680-c2cc-11ea-81ac-089a8ae5a3eb.png">


**Release note**:
```
Upload YAML applying to current cluster and namespace
```
