### PR TITLE
Fix for broken storybook build take 2

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8645,9 +8645,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.12.48",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.48.tgz",
-      "integrity": "sha512-m3Nmo/YaDUfYzdCQlxjF5pIy7TNyDTAJhIa//xtHcF0dlgYIBKULKnmloCPtByDxtZXrWV8Pge1AKT6/lRvVWg==",
+      "version": "12.12.40",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.40.tgz",
+      "integrity": "sha512-DGOupyZgr0TnemMORnkgR4G3ow5PV61uVW3w51pcnPIo6NV5hc36l59jxZJ/immrBpV5d7h6tn8/YgSgiA9oTw==",
       "dev": true
     },
     "@types/node-fetch": {
@@ -10746,9 +10746,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",


### PR DESCRIPTION
What this PR does / why we need it:
Storybook build got broken after update to @types/node in #1070. This change reverts it back to original version 12.12.40