### PR TITLE
Add sorting for Age columns

### DIFF
--- a/changelogs/unreleased/1114-GuessWhoSamFoo
+++ b/changelogs/unreleased/1114-GuessWhoSamFoo
@@ -1,0 +1,1 @@
+Added sorting for Age columns

--- a/web/src/app/modules/shared/components/presentation/datagrid/datagrid.component.html
+++ b/web/src/app/modules/shared/components/presentation/datagrid/datagrid.component.html
@@ -8,7 +8,10 @@
       All content has been filtered out.
     </ng-template>
   </clr-dg-placeholder>
-  <clr-dg-column *ngFor="let columnName of columns; trackBy: identifyColumn">
+  <clr-dg-column *ngFor="let columnName of columns; trackBy: identifyColumn"
+                  [clrDgSortBy]="columnName === 'Age' ? timeStampComparator : null"
+                  [(clrDgSortOrder)]="sortOrder"
+  >
     {{ columnName }}
     <clr-dg-filter *ngIf="filters[columnName]">
       <app-content-filter 
@@ -20,7 +23,8 @@
       <app-content-text-filter 
         [column]="columnName"
       ></app-content-text-filter>
-    </clr-dg-filter>  </clr-dg-column>
+    </clr-dg-filter>
+  </clr-dg-column>
   <clr-dg-row
     *clrDgItems="let row of rowsWithMetadata; trackBy: identifyRow"
     [ngClass]="row | filterDeletedDatagridRow"

--- a/web/src/app/modules/shared/components/presentation/datagrid/datagrid.component.ts
+++ b/web/src/app/modules/shared/components/presentation/datagrid/datagrid.component.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import { ClrDatagridSortOrder } from '@clr/angular';
 import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
 import {
   Confirmation,
@@ -15,6 +16,7 @@ import {
 } from 'src/app/modules/shared/models/content';
 import trackByIndex from 'src/app/util/trackBy/trackByIndex';
 import trackByIdentity from 'src/app/util/trackBy/trackByIdentity';
+import { TimestampComparator } from '../../../../../util/timestamp-comparator';
 import { ViewService } from '../../../services/view/view.service';
 import { ActionService } from '../../../services/action/action.service';
 
@@ -25,6 +27,8 @@ import { ActionService } from '../../../services/action/action.service';
 })
 export class DatagridComponent implements OnChanges {
   private v: TableView;
+  timeStampComparator = new TimestampComparator();
+  sortOrder: ClrDatagridSortOrder = ClrDatagridSortOrder.UNSORTED;
 
   @Input() set view(v: View) {
     this.v = v as TableView;

--- a/web/src/app/util/timestamp-comparator.ts
+++ b/web/src/app/util/timestamp-comparator.ts
@@ -1,0 +1,17 @@
+// Copyright (c) 2020 the Octant contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+import { ClrDatagridComparatorInterface } from '@clr/angular';
+import {
+  TableRowWithMetadata,
+  TimestampView,
+} from '../modules/shared/models/content';
+
+export class TimestampComparator
+  implements ClrDatagridComparatorInterface<TableRowWithMetadata> {
+  compare(a: TableRowWithMetadata, b: TableRowWithMetadata) {
+    const rowA = a.data.Age as TimestampView;
+    const rowB = b.data.Age as TimestampView;
+    return rowA.config.timestamp - rowB.config.timestamp;
+  }
+}


### PR DESCRIPTION
Not really a fan of this solution since it hard-codes `Age` as a special column, but datagrids currently don't have any knowledge of the data types in a row (due to the content switcher).

**Which issue(s) this PR fixes**
- Fixes #1107 

Signed-off-by: GuessWhoSamFoo <foos@vmware.com>

