### PR TITLE
ensure FindBox call happens after init

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -8,7 +8,6 @@ package plugin
 import (
 	"context"
 
-	rice "github.com/GeertJohan/go.rice"
 	"github.com/hashicorp/go-plugin"
 	"google.golang.org/grpc"
 
@@ -21,7 +20,6 @@ var (
 	pluginMap = map[string]plugin.Plugin{
 		Name: &ServicePlugin{},
 	}
-	box = rice.MustFindBox("_files")
 )
 
 // ServicePlugin is the GRPC plugin for Service.

--- a/pkg/plugin/tsloader.go
+++ b/pkg/plugin/tsloader.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	rice "github.com/GeertJohan/go.rice"
 	"github.com/dop251/goja"
 )
 
@@ -15,7 +16,12 @@ type TSLoader struct {
 }
 
 func NewTSLoader(vm *goja.Runtime) (*TSLoader, error) {
-	if err := initTypescriptServices(vm); err != nil {
+	box, err := rice.FindBox("_files")
+	if err != nil {
+		return nil, err
+	}
+
+	if err := initTypescriptServices(box, vm); err != nil {
 		return nil, err
 	}
 	return &TSLoader{
@@ -116,7 +122,7 @@ func (t *TSLoader) TranspileAndRun(path string) (goja.Value, error) {
 	return t.vm.RunString(string(b[:]))
 }
 
-func initTypescriptServices(vm *goja.Runtime) error {
+func initTypescriptServices(box *rice.Box, vm *goja.Runtime) error {
 	f, err := box.Open("typescriptServices.js")
 	if err != nil {
 		return err


### PR DESCRIPTION
Signed-off-by: Wayne Witzel III <wayne@riotousliving.com>

Fixes Octant from being able to find the `_files` rice box due to the variable being creating before the init of rice-box.go has been called.
