### PR TITLE
Fixed dark theme breadcrumb color

### DIFF
--- a/web/src/app/modules/shared/components/presentation/breadcrumb/breadcrumb.component.scss
+++ b/web/src/app/modules/shared/components/presentation/breadcrumb/breadcrumb.component.scss
@@ -2,6 +2,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+:host-context(body) {
+  --creadcrumb-link-color: #0079b8;
+}
+
+:host-context(body.dark) {
+  --creadcrumb-link-color: #49AFD9;
+}
+
 .breadcrumb {
   &-body {
     display: flex;
@@ -23,6 +31,6 @@
   }
 
   a {
-    color: #0079b8;
+    color: var(--creadcrumb-link-color);
   }
 }


### PR DESCRIPTION
Signed-off-by: Milan Klanjsek <mklanjsek@pivotal.io>
Quick fix for breadcrumb link color used in dark theme. Good catch @rossfenrick - this makes dark theme look much better.

**Which issue(s) this PR fixes**
- Fixes #1126 
