### PR TITLE
Display error when unable to find valid local port

### DIFF
--- a/changelogs/unreleased/1144-ipsi
+++ b/changelogs/unreleased/1144-ipsi
@@ -1,0 +1,1 @@
+* Display alert when unable to find valid local port

--- a/internal/modules/overview/portforward.go
+++ b/internal/modules/overview/portforward.go
@@ -85,7 +85,7 @@ func createPortForward(ctx context.Context, body io.Reader, pfs portforward.Port
 		}
 	}
 
-	resp, err := pfs.Create(ctx, req.gvk(), req.Name, req.Namespace, req.Port)
+	resp, err := pfs.Create(ctx, nil, req.gvk(), req.Name, req.Namespace, req.Port)
 	if err != nil {
 		return &portForwardError{
 			code:     http.StatusInternalServerError,

--- a/internal/octant/port_forward.go
+++ b/internal/octant/port_forward.go
@@ -49,7 +49,7 @@ func (p *PortForward) Handle(ctx context.Context, alerter action.Alerter, payloa
 	}
 	p.logger.Debugf("%s", request)
 
-	_, err = p.portForwarder.Create(ctx, &alerter, request.gvk(), request.Name, request.Namespace, request.Port)
+	_, err = p.portForwarder.Create(ctx, alerter, request.gvk(), request.Name, request.Namespace, request.Port)
 	if err != nil {
 		return errors.Wrap(err, "create port forwarder")
 	}

--- a/internal/octant/port_forward.go
+++ b/internal/octant/port_forward.go
@@ -49,7 +49,7 @@ func (p *PortForward) Handle(ctx context.Context, alerter action.Alerter, payloa
 	}
 	p.logger.Debugf("%s", request)
 
-	_, err = p.portForwarder.Create(ctx, request.gvk(), request.Name, request.Namespace, request.Port)
+	_, err = p.portForwarder.Create(ctx, &alerter, request.gvk(), request.Name, request.Namespace, request.Port)
 	if err != nil {
 		return errors.Wrap(err, "create port forwarder")
 	}

--- a/internal/portforward/fake/mock_interface.go
+++ b/internal/portforward/fake/mock_interface.go
@@ -9,6 +9,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	"github.com/vmware-tanzu/octant/pkg/action"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 
 	portforward "github.com/vmware-tanzu/octant/internal/portforward"
@@ -67,7 +68,7 @@ func (mr *MockPortForwarderMockRecorder) Get(id interface{}) *gomock.Call {
 }
 
 // Create mocks base method
-func (m *MockPortForwarder) Create(ctx context.Context, gvk schema.GroupVersionKind, name, namespace string, remotePort uint16) (portforward.CreateResponse, error) {
+func (m *MockPortForwarder) Create(ctx context.Context, alerter *action.Alerter, gvk schema.GroupVersionKind, name string, namespace string, remotePort uint16) (portforward.CreateResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Create", ctx, gvk, name, namespace, remotePort)
 	ret0, _ := ret[0].(portforward.CreateResponse)

--- a/internal/portforward/fake/mock_interface.go
+++ b/internal/portforward/fake/mock_interface.go
@@ -68,7 +68,7 @@ func (mr *MockPortForwarderMockRecorder) Get(id interface{}) *gomock.Call {
 }
 
 // Create mocks base method
-func (m *MockPortForwarder) Create(ctx context.Context, alerter *action.Alerter, gvk schema.GroupVersionKind, name, namespace string, remotePort uint16) (portforward.CreateResponse, error) {
+func (m *MockPortForwarder) Create(ctx context.Context, alerter action.Alerter, gvk schema.GroupVersionKind, name, namespace string, remotePort uint16) (portforward.CreateResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Create", ctx, alerter, gvk, name, namespace, remotePort)
 	ret0, _ := ret[0].(portforward.CreateResponse)

--- a/internal/portforward/fake/mock_interface.go
+++ b/internal/portforward/fake/mock_interface.go
@@ -9,10 +9,10 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	"github.com/vmware-tanzu/octant/pkg/action"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 
 	portforward "github.com/vmware-tanzu/octant/internal/portforward"
+	action "github.com/vmware-tanzu/octant/pkg/action"
 )
 
 // MockPortForwarder is a mock of PortForwarder interface
@@ -68,18 +68,18 @@ func (mr *MockPortForwarderMockRecorder) Get(id interface{}) *gomock.Call {
 }
 
 // Create mocks base method
-func (m *MockPortForwarder) Create(ctx context.Context, alerter *action.Alerter, gvk schema.GroupVersionKind, name string, namespace string, remotePort uint16) (portforward.CreateResponse, error) {
+func (m *MockPortForwarder) Create(ctx context.Context, alerter *action.Alerter, gvk schema.GroupVersionKind, name, namespace string, remotePort uint16) (portforward.CreateResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Create", ctx, gvk, name, namespace, remotePort)
+	ret := m.ctrl.Call(m, "Create", ctx, alerter, gvk, name, namespace, remotePort)
 	ret0, _ := ret[0].(portforward.CreateResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Create indicates an expected call of Create
-func (mr *MockPortForwarderMockRecorder) Create(ctx, gvk, name, namespace, remotePort interface{}) *gomock.Call {
+func (mr *MockPortForwarderMockRecorder) Create(ctx, alerter, gvk, name, namespace, remotePort interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockPortForwarder)(nil).Create), ctx, gvk, name, namespace, remotePort)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockPortForwarder)(nil).Create), ctx, alerter, gvk, name, namespace, remotePort)
 }
 
 // FindTarget mocks base method

--- a/internal/portforward/portforward.go
+++ b/internal/portforward/portforward.go
@@ -6,14 +6,16 @@ SPDX-License-Identifier: Apache-2.0
 package portforward
 
 import (
-	"github.com/vmware-tanzu/octant/pkg/action"
 	"io"
+	"net/http"
+	"net/url"
+
 	"k8s.io/client-go/rest"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/transport/spdy"
-	"net/http"
-	"net/url"
+
+	"github.com/vmware-tanzu/octant/pkg/action"
 )
 
 // Options contains all the options for running a port-forward

--- a/internal/portforward/service.go
+++ b/internal/portforward/service.go
@@ -8,10 +8,11 @@ package portforward
 import (
 	"context"
 	"fmt"
-	"github.com/vmware-tanzu/octant/pkg/action"
 	"sort"
 	"sync"
 	"time"
+
+	"github.com/vmware-tanzu/octant/pkg/action"
 
 	"github.com/google/uuid"
 	"github.com/pkg/errors"

--- a/internal/portforward/service.go
+++ b/internal/portforward/service.go
@@ -38,7 +38,7 @@ var (
 type PortForwarder interface {
 	List(ctx context.Context) []State
 	Get(id string) (State, bool)
-	Create(ctx context.Context, alerter *action.Alerter, gvk schema.GroupVersionKind, name string, namespace string, remotePort uint16) (CreateResponse, error)
+	Create(ctx context.Context, alerter action.Alerter, gvk schema.GroupVersionKind, name string, namespace string, remotePort uint16) (CreateResponse, error)
 	FindTarget(namespace string, gvk schema.GroupVersionKind, name string) ([]State, error)
 	FindPod(namespace string, gvk schema.GroupVersionKind, name string) ([]State, error)
 	Stop()
@@ -290,7 +290,7 @@ func (s *Service) verifyPod(ctx context.Context, namespace, name string) (bool, 
 // createForwarder creates a port forwarder, forwards traffic, and blocks until
 // port state information is populated.
 // Returns forwarder id.
-func (s *Service) createForwarder(alerter *action.Alerter, targetRequest, podRequest CreateRequest) (string, error) {
+func (s *Service) createForwarder(alerter action.Alerter, targetRequest, podRequest CreateRequest) (string, error) {
 	logger := s.logger.With("context", "PortForwardService.createForwarder")
 
 	if s.opts.PortForwarder == nil {
@@ -495,7 +495,7 @@ func (s *Service) Get(id string) (State, bool) {
 
 // Create creates a new port forward for the specified object and remote port.
 // Implements PortForwardInterface.
-func (s *Service) Create(ctx context.Context, alerter *action.Alerter, gvk schema.GroupVersionKind, name string, namespace string, remotePort uint16) (CreateResponse, error) {
+func (s *Service) Create(ctx context.Context, alerter action.Alerter, gvk schema.GroupVersionKind, name string, namespace string, remotePort uint16) (CreateResponse, error) {
 	logger := s.logger.With("context", "PortForwardService.Create")
 	req := newForwardRequest(gvk, name, namespace, remotePort)
 

--- a/internal/portforward/service.go
+++ b/internal/portforward/service.go
@@ -50,14 +50,11 @@ type PortForwardPortSpec struct {
 	Local  uint16 `json:"local,omitempty"`
 }
 
-// PortForwardSpec describes a port forward.
-// TODO Merge with PortForwardState (GH#498)
-type PortForwardSpec struct {
-	ID        string                `json:"id"`
-	Status    string                `json:"status"`
-	Message   string                `json:"message"`
-	Ports     []PortForwardPortSpec `json:"ports"`
-	CreatedAt time.Time             `json:"createdAt"`
+// CreateResponse describes a port forward.
+// TODO Merge with State (GH#498)
+type CreateResponse struct {
+	ID    string                `json:"id"`
+	Ports []PortForwardPortSpec `json:"ports"`
 }
 
 type CreateRequest struct {
@@ -67,8 +64,6 @@ type CreateRequest struct {
 	Name       string                `json:"name"`
 	Ports      []PortForwardPortSpec `json:"ports"`
 }
-
-type CreateResponse PortForwardSpec
 
 // Target references a kubernetes object
 type Target struct {
@@ -418,14 +413,12 @@ func (s *Service) responseForCreate(id string) (CreateResponse, error) {
 	}
 
 	response.ID = id
-	response.CreatedAt = state.CreatedAt
 	rp := make([]PortForwardPortSpec, len(state.Ports))
 	for i := range state.Ports {
 		rp[i].Local = state.Ports[i].Local
 		rp[i].Remote = state.Ports[i].Remote
 	}
 	response.Ports = rp
-	response.Status = "ok"
 	return response, nil
 }
 

--- a/pkg/plugin/api/api_test.go
+++ b/pkg/plugin/api/api_test.go
@@ -126,7 +126,7 @@ func TestAPI(t *testing.T) {
 
 				mocks.pf.EXPECT().
 					Create(
-						gomock.Any(), gvk.Pod, "pod", "default", uint16(8080)).
+						gomock.Any(), gomock.Any(), gvk.Pod, "pod", "default", uint16(8080)).
 					Return(resp, nil)
 			},
 			doFunc: func(t *testing.T, client *api.Client) {
@@ -166,7 +166,7 @@ func TestAPI(t *testing.T) {
 
 				mocks.pf.EXPECT().
 					Create(
-						gomock.Any(), gvk.Pod, "pod", "default", uint16(8080)).
+						gomock.Any(), gomock.Any(), gvk.Pod, "pod", "default", uint16(8080)).
 					Return(resp, nil)
 			},
 			doFunc: func(t *testing.T, client *api.Client) {

--- a/pkg/plugin/api/server.go
+++ b/pkg/plugin/api/server.go
@@ -109,12 +109,7 @@ func (s *GRPCService) Create(ctx context.Context, object *unstructured.Unstructu
 
 // PortForward creates a port forward.
 func (s *GRPCService) PortForward(ctx context.Context, req PortForwardRequest) (PortForwardResponse, error) {
-	pfResponse, err := s.PortForwarder.Create(
-		ctx,
-		gvk.Pod,
-		req.PodName,
-		req.Namespace,
-		req.Port)
+	pfResponse, err := s.PortForwarder.Create(ctx, nil, gvk.Pod, req.PodName, req.Namespace, req.Port)
 	if err != nil {
 		return PortForwardResponse{}, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Displays an error when port-forwarding cannot occur due to an error (e.g. unable to resolve a local port)

**Which issue(s) this PR fixes**
- Fixes #497

**Special notes for your reviewer**:
Passing the `Alerter` all the way down the call chain is not ideal, but the other options have their own problems:

1. Blocking the `Handle` function until port-forwarding setup is complete
  This would work, but it doesn't seem to make a lot of sense given that this is currently done in a go-func, and the `Handle` function is called synchronously by the web socket process. If we want to block on the handle method, it might make more sense to not use go-funcs at all here and have the entire chain become blocking, and just pass the `err` back up in the normal way.
  It's not clear what other implications making this synchronous would have, so it feels like quite a big change.
1. Moving the `localPortsHandler` function up a few levels, so the `Handle` function can call it directly and pass in the `Alerter`
  This isn't really an option either - the `localPortsHandler` function relies on an `Options` struct that's created and passed in from `Service#createForwarder`, and passing that back up the chain doesn't seem appropriate.
1. Modify the `DefaultPortForwarder` struct to hold an `Alerter`
  

**Release note**:
```
Display alert if there is an error setting up port-forwarding
```
