### PR TITLE
Move "Namespaces" and "Custom Resource Definitions" under "API Server"

### DIFF
--- a/internal/modules/clusteroverview/clusteroverview.go
+++ b/internal/modules/clusteroverview/clusteroverview.go
@@ -180,10 +180,10 @@ func (co *ClusterOverview) Navigation(ctx context.Context, _ string, root string
 	navigationEntries := octant.NavigationEntries{
 		Lookup: map[string]string{
 			"Namespaces":                  "namespaces",
-			"API Server":                  "api-server",
 			"Custom Resources":            "custom-resources",
 			"Custom Resource Definitions": "custom-resource-definitions",
 			"RBAC":                        "rbac",
+			"Webhooks":                    "webhooks",
 			"Nodes":                       "nodes",
 			"Storage":                     "storage",
 			"Port Forwards":               "port-forward",
@@ -191,10 +191,10 @@ func (co *ClusterOverview) Navigation(ctx context.Context, _ string, root string
 		EntriesFuncs: map[string]octant.EntriesFunc{
 			"Cluster Overview":            nil,
 			"Namespaces":                  nil,
-			"API Server":                  apiServerEntries,
 			"Custom Resources":            navigation.CRDEntries,
 			"Custom Resource Definitions": nil,
 			"RBAC":                        rbacEntries,
+			"Webhooks":                    webhookEntries,
 			"Nodes":                       nil,
 			"Storage":                     storageEntries,
 			"Port Forwards":               nil,
@@ -202,10 +202,10 @@ func (co *ClusterOverview) Navigation(ctx context.Context, _ string, root string
 		IconMap: map[string]string{
 			"Cluster Overview":            icon.Overview,
 			"Namespaces":                  icon.Namespaces,
-			"API Server":                  icon.ApiServer,
 			"Custom Resources":            icon.CustomResources,
 			"Custom Resource Definitions": icon.CustomResourceDefinition,
 			"RBAC":                        icon.RBAC,
+			"Webhooks":                    icon.Webhooks,
 			"Nodes":                       icon.Nodes,
 			"Storage":                     icon.ConfigAndStorage,
 			"Port Forwards":               icon.PortForwards,
@@ -213,10 +213,10 @@ func (co *ClusterOverview) Navigation(ctx context.Context, _ string, root string
 		Order: []string{
 			"Cluster Overview",
 			"Namespaces",
-			"API Server",
 			"Custom Resources",
 			"Custom Resource Definitions",
 			"RBAC",
+			"Webhooks",
 			"Nodes",
 			"Storage",
 			"Port Forwards",
@@ -251,15 +251,13 @@ func (co *ClusterOverview) Generators() []octant.Generator {
 	return []octant.Generator{}
 }
 
-func apiServerEntries(ctx context.Context, prefix, namespace string, objectStore store.Store, _ bool) ([]navigation.Navigation, bool, error) {
+func rbacEntries(ctx context.Context, prefix, namespace string, objectStore store.Store, _ bool) ([]navigation.Navigation, bool, error) {
 	neh := navigation.EntriesHelper{}
 
-	neh.Add("API Services", "api-services",
-		loading.IsObjectLoading(ctx, namespace, store.KeyFromGroupVersionKind(gvk.APIService), objectStore))
-	neh.Add("Mutating Webhooks", "mutating-webhooks",
-		loading.IsObjectLoading(ctx, namespace, store.KeyFromGroupVersionKind(gvk.MutatingWebhookConfiguration), objectStore))
-	neh.Add("Validating Webhooks", "validating-webhooks",
-		loading.IsObjectLoading(ctx, namespace, store.KeyFromGroupVersionKind(gvk.ValidatingWebhookConfiguration), objectStore))
+	neh.Add("Cluster Roles", "cluster-roles",
+		loading.IsObjectLoading(ctx, namespace, store.KeyFromGroupVersionKind(gvk.ClusterRole), objectStore))
+	neh.Add("Cluster Role Bindings", "cluster-role-bindings",
+		loading.IsObjectLoading(ctx, namespace, store.KeyFromGroupVersionKind(gvk.ClusterRoleBinding), objectStore))
 
 	children, err := neh.Generate(prefix, namespace, "")
 	if err != nil {
@@ -269,13 +267,13 @@ func apiServerEntries(ctx context.Context, prefix, namespace string, objectStore
 	return children, false, nil
 }
 
-func rbacEntries(ctx context.Context, prefix, namespace string, objectStore store.Store, _ bool) ([]navigation.Navigation, bool, error) {
+func webhookEntries(ctx context.Context, prefix, namespace string, objectStore store.Store, _ bool) ([]navigation.Navigation, bool, error) {
 	neh := navigation.EntriesHelper{}
 
-	neh.Add("Cluster Roles", "cluster-roles",
-		loading.IsObjectLoading(ctx, namespace, store.KeyFromGroupVersionKind(gvk.ClusterRole), objectStore))
-	neh.Add("Cluster Role Bindings", "cluster-role-bindings",
-		loading.IsObjectLoading(ctx, namespace, store.KeyFromGroupVersionKind(gvk.ClusterRoleBinding), objectStore))
+	neh.Add("Mutating Webhooks", "mutating-webhooks",
+		loading.IsObjectLoading(ctx, namespace, store.KeyFromGroupVersionKind(gvk.MutatingWebhookConfiguration), objectStore))
+	neh.Add("Validating Webhooks", "validating-webhooks",
+		loading.IsObjectLoading(ctx, namespace, store.KeyFromGroupVersionKind(gvk.ValidatingWebhookConfiguration), objectStore))
 
 	children, err := neh.Generate(prefix, namespace, "")
 	if err != nil {

--- a/internal/modules/clusteroverview/objects.go
+++ b/internal/modules/clusteroverview/objects.go
@@ -64,6 +64,35 @@ var (
 		rbacClusterRoleBindings,
 	)
 
+	webhooksDescriber = describer.NewSection(
+		"/webhooks",
+		"Webhooks",
+		webhooksMutatingWebhooks,
+		webhooksValidatingWebhooks,
+	)
+
+	webhooksValidatingWebhooks = describer.NewResource(describer.ResourceOptions{
+		Path:           "/webhooks/validating-webhooks",
+		ObjectStoreKey: store.Key{APIVersion: "admissionregistration.k8s.io/v1beta1", Kind: "ValidatingWebhookConfiguration"},
+		ListType:       &admissionregistrationv1beta1.ValidatingWebhookConfigurationList{},
+		ObjectType:     &admissionregistrationv1beta1.ValidatingWebhookConfiguration{},
+		Titles:         describer.ResourceTitle{List: "Validating Webhook Configurations", Object: "Validating Webhook Configuration"},
+		ClusterWide:    true,
+		IconName:       icon.Webhooks,
+		RootPath:       describer.ResourceLink{Title: "Cluster Overview", Url: "/cluster-overview"},
+	})
+
+	webhooksMutatingWebhooks = describer.NewResource(describer.ResourceOptions{
+		Path:           "/webhooks/mutating-webhooks",
+		ObjectStoreKey: store.Key{APIVersion: "admissionregistration.k8s.io/v1beta1", Kind: "MutatingWebhookConfiguration"},
+		ListType:       &admissionregistrationv1beta1.MutatingWebhookConfigurationList{},
+		ObjectType:     &admissionregistrationv1beta1.MutatingWebhookConfiguration{},
+		Titles:         describer.ResourceTitle{List: "Mutating Webhook Configurations", Object: "Mutating Webhook Configuration"},
+		ClusterWide:    true,
+		IconName:       icon.Webhooks,
+		RootPath:       describer.ResourceLink{Title: "Cluster Overview", Url: "/cluster-overview"},
+	})
+
 	nodesDescriber = describer.NewResource(describer.ResourceOptions{
 		Path:                  "/nodes",
 		ObjectStoreKey:        store.Key{APIVersion: "v1", Kind: "Node"},
@@ -111,8 +140,6 @@ var (
 		"/api-server",
 		"API Server",
 		apiServerApiServices,
-		apiServerMutatingWebhooks,
-		apiServerValidatingWebhooks,
 	)
 
 	apiServerApiServices = describer.NewResource(describer.ResourceOptions{
@@ -126,38 +153,17 @@ var (
 		RootPath:       describer.ResourceLink{Title: "Cluster Overview", Url: "/cluster-overview"},
 	})
 
-	apiServerValidatingWebhooks = describer.NewResource(describer.ResourceOptions{
-		Path:           "/api-server/validating-webhooks",
-		ObjectStoreKey: store.Key{APIVersion: "admissionregistration.k8s.io/v1beta1", Kind: "ValidatingWebhookConfiguration"},
-		ListType:       &admissionregistrationv1beta1.ValidatingWebhookConfigurationList{},
-		ObjectType:     &admissionregistrationv1beta1.ValidatingWebhookConfiguration{},
-		Titles:         describer.ResourceTitle{List: "Validating Webhook Configurations", Object: "Validating Webhook Configuration"},
-		ClusterWide:    true,
-		IconName:       icon.ApiServer,
-		RootPath:       describer.ResourceLink{Title: "Cluster Overview", Url: "/cluster-overview"},
-	})
-
-	apiServerMutatingWebhooks = describer.NewResource(describer.ResourceOptions{
-		Path:           "/api-server/mutating-webhooks",
-		ObjectStoreKey: store.Key{APIVersion: "admissionregistration.k8s.io/v1beta1", Kind: "MutatingWebhookConfiguration"},
-		ListType:       &admissionregistrationv1beta1.MutatingWebhookConfigurationList{},
-		ObjectType:     &admissionregistrationv1beta1.MutatingWebhookConfiguration{},
-		Titles:         describer.ResourceTitle{List: "Mutating Webhook Configurations", Object: "Mutating Webhook Configuration"},
-		ClusterWide:    true,
-		IconName:       icon.ApiServer,
-		RootPath:       describer.ResourceLink{Title: "Cluster Overview", Url: "/cluster-overview"},
-	})
-
 	rootDescriber = describer.NewSection(
 		"/",
 		"Cluster Overview",
 		namespacesDescriber,
-		apiServerDescriber,
 		customResourcesDescriber,
 		crdsDescriber,
 		rbacDescriber,
+		webhooksDescriber,
 		nodesDescriber,
 		storageDescriber,
 		portForwardDescriber,
+		apiServerDescriber,
 	)
 )

--- a/internal/modules/clusteroverview/path.go
+++ b/internal/modules/clusteroverview/path.go
@@ -54,9 +54,9 @@ func gvkPath(namespace, apiVersion, kind, name string) (string, error) {
 	case apiVersion == "apiregistration.k8s.io/v1" && kind == "APIService":
 		p = "/api-server/api-services"
 	case apiVersion == "admissionregistration.k8s.io/v1beta1" && kind == "MutatingWebhookConfiguration":
-		p = "/api-server/mutating-webhooks"
+		p = "/webhooks/mutating-webhooks"
 	case apiVersion == "admissionregistration.k8s.io/v1beta1" && kind == "ValidatingWebhookConfiguration":
-		p = "/api-server/validating-webhooks"
+		p = "/webhooks/validating-webhooks"
 	default:
 		return "", fmt.Errorf("unknown object %s %s", apiVersion, kind)
 	}

--- a/pkg/icon/icon.go
+++ b/pkg/icon/icon.go
@@ -18,6 +18,7 @@ const (
 	Namespaces      = "namespace"
 	ApiServer       = "hard-disk"
 	CustomResources = "file-group"
+	Webhooks        = "animation"
 	Nodes           = "nodes"
 	PortForwards    = "router"
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove the "API Server" navigation bar group, moving the mutating and validating webhook resources into a new navigation bar group named "Webhooks". APIServices are no longer linked directly from the navigation, but are still present in the resource graph and via deep links.

**Which issue(s) this PR fixes**
- Fixes #1142

**Special notes for your reviewer**:

<img width="1224" alt="Screen Shot 2020-08-04 at 10 30 39 AM" src="https://user-images.githubusercontent.com/302992/89306253-9a66d100-d63d-11ea-9497-b60b10a4442c.png">

**Release note**:
```
Remove "API Server" nav group, moving webhook resoruces under "Webhooks" nav group
```
