### PR TITLE
Add node cache to github actions

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -24,14 +24,18 @@ jobs:
           path: ${{ steps.npm-cache.outputs.dir }}
           key: ${{ runner.os }}-node-push-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
+            ${{ runner.os }}-node-push-${{ hashFiles('**/package-lock.json') }}
             ${{ runner.os }}-node-push-
       - uses: actions/cache@v2
         if: github.event_name == 'pull_request'
         with:
           path: ${{ steps.npm-cache.outputs.dir }}
-          key: ${{ runner.os }}-node-pr-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-node-pr-${{ github.event.number }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-node-pr-
+            ${{ runner.os }}-node-pr-${{ github.event.number }}-${{ hashFiles('**/package-lock.json') }}
+            ${{ runner.os }}-node-pr-${{ github.event.number }}-
+            ${{ runner.os }}-node-push-${{ hashFiles('**/package-lock.json') }}
+            ${{ runner.os }}-node-push-
       - name: Build node modules
         run: |
           cd web

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -14,6 +14,24 @@ jobs:
         with:
           go-version: '1.14'
       - uses: actions/checkout@v2
+      - name: Get npm cache directory
+          id: npm-cache
+          run: |
+            echo "::set-output name=dir::$(npm config get cache)"
+      - uses: actions/cache@v2
+        if: github.event_name == 'push'
+        with:
+          path: ${{ steps.npm-cache.outputs.dir }}
+          key: ${{ runner.os }}-node-push-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-push-
+      - uses: actions/cache@v2
+        if: github.event_name == 'pull_request'
+        with:
+          path: ${{ steps.npm-cache.outputs.dir }}
+          key: ${{ runner.os }}-node-pr-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-pr-
       - name: Build node modules
         run: |
           cd web

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Build node modules
         run: |
           cd web
-          npm ci
+          npm ci --prefer-offline --no-audit
           npm run-script build
         shell: bash
       - name: Go tools

--- a/.github/workflows/preflight-checks.yaml
+++ b/.github/workflows/preflight-checks.yaml
@@ -62,11 +62,19 @@ jobs:
         run: |
           echo "::set-output name=dir::$(npm config get cache)"
       - uses: actions/cache@v2
+        if: github.event_name == 'push'
         with:
           path: ${{ steps.npm-cache.outputs.dir }}
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-node-push-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-node-
+            ${{ runner.os }}-node-push-
+      - uses: actions/cache@v2
+        if: github.event_name == 'pull_request'
+        with:
+          path: ${{ steps.npm-cache.outputs.dir }}
+          key: ${{ runner.os }}-node-pr-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-pr-
       - name: run_karma
         run: |
           cd web
@@ -95,11 +103,19 @@ jobs:
         run: |
           echo "::set-output name=dir::$(npm config get cache)"
       - uses: actions/cache@v2
+        if: github.event_name == 'push'
         with:
           path: ${{ steps.npm-cache.outputs.dir }}
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-node-push-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-node-
+            ${{ runner.os }}-node-push-
+      - uses: actions/cache@v2
+        if: github.event_name == 'pull_request'
+        with:
+          path: ${{ steps.npm-cache.outputs.dir }}
+          key: ${{ runner.os }}-node-pr-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-pr-
       - name: Build node modules
         run: |
           cd web

--- a/.github/workflows/preflight-checks.yaml
+++ b/.github/workflows/preflight-checks.yaml
@@ -67,14 +67,18 @@ jobs:
           path: ${{ steps.npm-cache.outputs.dir }}
           key: ${{ runner.os }}-node-push-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
+            ${{ runner.os }}-node-push-${{ hashFiles('**/package-lock.json') }}
             ${{ runner.os }}-node-push-
       - uses: actions/cache@v2
         if: github.event_name == 'pull_request'
         with:
           path: ${{ steps.npm-cache.outputs.dir }}
-          key: ${{ runner.os }}-node-pr-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-node-pr-${{ github.event.number }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-node-pr-
+            ${{ runner.os }}-node-pr-${{ github.event.number }}-${{ hashFiles('**/package-lock.json') }}
+            ${{ runner.os }}-node-pr-${{ github.event.number }}-
+            ${{ runner.os }}-node-push-${{ hashFiles('**/package-lock.json') }}
+            ${{ runner.os }}-node-push-
       - name: run_karma
         run: |
           cd web
@@ -108,14 +112,18 @@ jobs:
           path: ${{ steps.npm-cache.outputs.dir }}
           key: ${{ runner.os }}-node-push-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
+            ${{ runner.os }}-node-push-${{ hashFiles('**/package-lock.json') }}
             ${{ runner.os }}-node-push-
       - uses: actions/cache@v2
         if: github.event_name == 'pull_request'
         with:
           path: ${{ steps.npm-cache.outputs.dir }}
-          key: ${{ runner.os }}-node-pr-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-node-pr-${{ github.event.number }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-node-pr-
+            ${{ runner.os }}-node-pr-${{ github.event.number }}-${{ hashFiles('**/package-lock.json') }}
+            ${{ runner.os }}-node-pr-${{ github.event.number }}-
+            ${{ runner.os }}-node-push-${{ hashFiles('**/package-lock.json') }}
+            ${{ runner.os }}-node-push-
       - name: Build node modules
         run: |
           cd web

--- a/.github/workflows/preflight-checks.yaml
+++ b/.github/workflows/preflight-checks.yaml
@@ -57,10 +57,20 @@ jobs:
         with:
           node-version: 10.x
       - uses: actions/checkout@v2
+      - name: Get npm cache directory
+        id: npm-cache
+        run: |
+          echo "::set-output name=dir::$(npm config get cache)"
+      - uses: actions/cache@v2
+        with:
+          path: ${{ steps.npm-cache.outputs.dir }}
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
       - name: run_karma
         run: |
           cd web
-          npm ci
+          npm ci --prefer-offline --no-audit
           npm run test:headless
 
   bundle_assets:
@@ -80,10 +90,20 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
       - uses: actions/checkout@v2
+      - name: Get npm cache directory
+        id: npm-cache
+        run: |
+          echo "::set-output name=dir::$(npm config get cache)"
+      - uses: actions/cache@v2
+        with:
+          path: ${{ steps.npm-cache.outputs.dir }}
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
       - name: Build node modules
         run: |
           cd web
-          npm ci
+          npm ci --prefer-offline --no-audit
           npm run-script build
         shell: bash
       - name: Go tools

--- a/web/package.json
+++ b/web/package.json
@@ -7,7 +7,7 @@
     "start": "ng serve",
     "build": "node --max-old-space-size=8000 ./node_modules/@angular/cli/bin/ng build --prod --output-hashing=all",
     "test": "ng test --browsers=ChromeDebug",
-    "test:headless": "ng test --watch=false --browsers=ChromeHeadless",
+    "test:headless": "ng test --watch=false --browsers=ChromeHeadless --source-map=false",
     "lint": "ng lint",
     "e2e": "ng e2e",
     "prettier": "prettier --write \"src/{app,environments,assets}/**/*{.ts,.js,.json,.css,.scss}\"",

--- a/web/src/karma.conf.js
+++ b/web/src/karma.conf.js
@@ -48,7 +48,7 @@ module.exports = function(config) {
     customLaunchers: {
       ChromeDebug: {
         base: 'Chrome',
-        flags: ['--remote-debugging-port=9333'],
+        flags: ['--remote-debugging-port=9333', '--no-sandbox', '--disable-extensions'],
       },
     },
   });


### PR DESCRIPTION
**What this PR does / why we need it**:
Speeds up CI by caching npm downloads and using less memory for karma test setup.

**Which issue(s) this PR fixes**
- Fixes #1121 , #1137 

**Special notes for your reviewer**:
There was some experimentation moving storybook related packages to optionalDependencies instead of devDependencies. This could reduce the size of cache but made little different on `npm build`.

**Release note**:
