### PR TITLE
Fix container dropdown losing focus on certain browsers

### DIFF
--- a/changelogs/unreleased/1151-GuessWhoSamFoo
+++ b/changelogs/unreleased/1151-GuessWhoSamFoo
@@ -1,0 +1,1 @@
+Fixed container dropdown losing focus on certain browsers

--- a/web/src/app/modules/shared/components/smart/terminal/terminal.component.ts
+++ b/web/src/app/modules/shared/components/smart/terminal/terminal.component.ts
@@ -40,10 +40,6 @@ export class TerminalComponent implements OnDestroy, AfterViewInit {
   trackByIdentity = trackByIdentity;
   @Input() view: TerminalView;
   @ViewChild('terminal', { static: true }) terminalDiv: ElementRef;
-  @HostListener('click') onClick() {
-    this.term.focus();
-    this.fitAddon.fit();
-  }
 
   ngOnDestroy(): void {
     if (this.terminalStream) {
@@ -107,6 +103,8 @@ export class TerminalComponent implements OnDestroy, AfterViewInit {
     this.selectedContainer = containerSelection;
     this.term.reset();
     this.initStream();
+    this.term.focus();
+    this.fitAddon.fit();
   }
 
   initStream() {


### PR DESCRIPTION
**What this PR does / why we need it**:
On certain browsers, `terminal.focus()` was firing off while clicking the select dropdown which made it impossible to switch containers. This was caused by the host listener which was intended to focus the terminal on container change.

One side effect is that users will have to click inside the terminal rather than the anywhere in the document body to focus the terminal.

**Which issue(s) this PR fixes**
- Fixes #1111 

