### PR TITLE
Refactor apply_yaml action to use ObjectStore.CreateFromYAML

### DIFF
--- a/internal/modules/overview/overview.go
+++ b/internal/modules/overview/overview.go
@@ -279,7 +279,7 @@ func (co *Overview) ActionPaths() map[string]action.DispatcherFunc {
 		octant.NewCronJobSuspend(co.dashConfig.ObjectStore(), co.dashConfig.ClusterClient()),
 		octant.NewCronJobResume(co.dashConfig.ObjectStore(), co.dashConfig.ClusterClient()),
 		octant.NewObjectUpdaterDispatcher(co.dashConfig.ObjectStore()),
-		octant.NewApplyYaml(co.logger, co.dashConfig.ObjectStore(), co.dashConfig.ClusterClient()),
+		octant.NewApplyYaml(co.logger, co.dashConfig.ObjectStore()),
 	}
 
 	return dispatchers.ToActionPaths()

--- a/internal/octant/apply_yaml.go
+++ b/internal/octant/apply_yaml.go
@@ -6,20 +6,11 @@ SPDX-License-Identifier: Apache-2.0
 package octant
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"io"
 
 	"github.com/pkg/errors"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/yaml"
-	sigyaml "sigs.k8s.io/yaml"
 
-	"github.com/vmware-tanzu/octant/internal/cluster"
 	"github.com/vmware-tanzu/octant/pkg/action"
 	"github.com/vmware-tanzu/octant/pkg/log"
 	"github.com/vmware-tanzu/octant/pkg/store"
@@ -27,19 +18,17 @@ import (
 
 // ApplyYaml creates a yaml applier
 type ApplyYaml struct {
-	logger        log.Logger
-	objectStore   store.Store
-	clusterClient cluster.ClientInterface
+	logger      log.Logger
+	objectStore store.Store
 }
 
 var _ action.Dispatcher = (*ApplyYaml)(nil)
 
 // NewApplyYaml creates an instance of ApplyYaml
-func NewApplyYaml(logger log.Logger, objectStore store.Store, clusterClient cluster.ClientInterface) *ApplyYaml {
+func NewApplyYaml(logger log.Logger, objectStore store.Store) *ApplyYaml {
 	return &ApplyYaml{
-		logger:        logger,
-		objectStore:   objectStore,
-		clusterClient: clusterClient,
+		logger:      logger,
+		objectStore: objectStore,
 	}
 }
 
@@ -51,95 +40,14 @@ func (p *ApplyYaml) ActionName() string {
 // Handle applies the requested yaml to the cluster
 func (p *ApplyYaml) Handle(ctx context.Context, alerter action.Alerter, payload action.Payload) error {
 	p.logger.With("payload", payload).Debugf("received action payload")
+
 	request, err := applyYamlRequestFromPayload(payload)
 	if err != nil {
 		return errors.Wrap(err, "convert payload to apply yaml request")
 	}
 	p.logger.Debugf("%s", request)
 
-	results := []string{}
-	err = request.WithDoc(func(doc map[string]interface{}) error {
-		p.logger.Debugf("apply resource %#v", doc)
-
-		unstructuredObj := &unstructured.Unstructured{Object: doc}
-		key, err := store.KeyFromObject(unstructuredObj)
-		if err != nil {
-			return err
-		}
-		gvr, namespaced, err := p.clusterClient.Resource(key.GroupVersionKind().GroupKind())
-		if err != nil {
-			return fmt.Errorf("unable to discover resource: %w", err)
-		}
-		if namespaced && key.Namespace == "" {
-			unstructuredObj.SetNamespace(request.Namespace)
-			key.Namespace = request.Namespace
-		}
-
-		if _, err := p.objectStore.Get(ctx, key); err != nil {
-			if !kerrors.IsNotFound(err) {
-				// unexpected error
-				return fmt.Errorf("unable to get resource: %w", err)
-			}
-
-			// create object
-			err := p.objectStore.Create(ctx, &unstructured.Unstructured{Object: doc})
-			if err != nil {
-				return fmt.Errorf("unable to create resource: %w", err)
-			}
-
-			result := fmt.Sprintf("Created %s (%s) %s", key.Kind, key.APIVersion, key.Name)
-			if namespaced {
-				result = fmt.Sprintf("%s in %s", result, key.Namespace)
-			}
-			results = append(results, result)
-
-			return nil
-		}
-
-		// update object
-		unstructuredYaml, err := sigyaml.Marshal(doc)
-		if err != nil {
-			return fmt.Errorf("unable to marshal resource as yaml: %w", err)
-		}
-		client, err := p.clusterClient.DynamicClient()
-		if err != nil {
-			return fmt.Errorf("unable to get dynamic client: %w", err)
-		}
-
-		withForce := true
-		if namespaced {
-			_, err = client.Resource(gvr).Namespace(key.Namespace).Patch(
-				ctx,
-				key.Name,
-				types.ApplyPatchType,
-				unstructuredYaml,
-				metav1.PatchOptions{FieldManager: "octant", Force: &withForce},
-			)
-			if err != nil {
-				return fmt.Errorf("unable to patch resource: %w", err)
-			}
-		} else {
-			_, err = client.Resource(gvr).Patch(
-				ctx,
-				key.Name,
-				types.ApplyPatchType,
-				unstructuredYaml,
-				metav1.PatchOptions{FieldManager: "octant", Force: &withForce},
-			)
-			if err != nil {
-				return fmt.Errorf("unable to patch resource: %w", err)
-			}
-		}
-
-		result := fmt.Sprintf("Updated %s (%s) %s", key.Kind, key.APIVersion, key.Name)
-		if namespaced {
-			result = fmt.Sprintf("%s in %s", result, key.Namespace)
-		}
-		results = append(results, result)
-
-		return nil
-	})
-
+	results, err := p.objectStore.CreateOrUpdateFromYAML(ctx, request.Namespace, request.Update)
 	if err != nil {
 		p.logger.Warnf("unable to apply yaml: %s", err)
 		message := fmt.Sprintf("Unable to apply yaml: %s", err)
@@ -176,26 +84,6 @@ func (req *applyYamlRequest) Validate() error {
 	}
 
 	return nil
-}
-
-func (req *applyYamlRequest) WithDoc(cb func(doc map[string]interface{}) error) error {
-	d := yaml.NewYAMLOrJSONDecoder(bytes.NewBufferString(req.Update), 4096)
-	for {
-		doc := map[string]interface{}{}
-		if err := d.Decode(&doc); err != nil {
-			if err == io.EOF {
-				return nil
-			}
-			return fmt.Errorf("unable to parse yaml: %w", err)
-		}
-		if len(doc) == 0 {
-			// skip empty documents
-			continue
-		}
-		if err := cb(doc); err != nil {
-			return err
-		}
-	}
 }
 
 func applyYamlRequestFromPayload(payload action.Payload) (*applyYamlRequest, error) {

--- a/pkg/store/fake/mock_store.go
+++ b/pkg/store/fake/mock_store.go
@@ -54,6 +54,21 @@ func (mr *MockStoreMockRecorder) Create(arg0, arg1 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockStore)(nil).Create), arg0, arg1)
 }
 
+// CreateOrUpdateFromYAML mocks base method
+func (m *MockStore) CreateOrUpdateFromYAML(arg0 context.Context, arg1, arg2 string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateOrUpdateFromYAML", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateOrUpdateFromYAML indicates an expected call of CreateOrUpdateFromYAML
+func (mr *MockStoreMockRecorder) CreateOrUpdateFromYAML(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdateFromYAML", reflect.TypeOf((*MockStore)(nil).CreateOrUpdateFromYAML), arg0, arg1, arg2)
+}
+
 // Delete mocks base method
 func (m *MockStore) Delete(arg0 context.Context, arg1 store.Key) error {
 	m.ctrl.T.Helper()

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -38,6 +38,7 @@ type Store interface {
 	Update(ctx context.Context, key Key, updater func(*unstructured.Unstructured) error) error
 	IsLoading(ctx context.Context, key Key) bool
 	Create(ctx context.Context, object *unstructured.Unstructured) error
+	CreateOrUpdateFromYAML(ctx context.Context, namespace, input string) ([]string, error)
 }
 
 // Key is a key for the object store.


### PR DESCRIPTION
Signed-off-by: Wayne Witzel III <wayne@riotousliving.com>


**What this PR does / why we need it**:

Make it easier for other parts of Octant to take advantage of the CreateFromYAML logic that was added in #954 