### PR TITLE
fix error logger, missing failed watch path

### DIFF
--- a/pkg/plugin/manager.go
+++ b/pkg/plugin/manager.go
@@ -360,7 +360,7 @@ func (m *Manager) watchJS(ctx context.Context) {
 
 	for _, dir := range dirs {
 		if err := watcher.Add(dir); err != nil {
-			logger.Errorf("unable to add %s to JavaScript plugin watcher")
+			logger.Warnf("unable to add %s to JavaScript plugin watcher", dir)
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Wayne Witzel III <wayne@riotousliving.com>

If Octant fails to watch a plugin folder, ensure the error output contains the path.

related #1173 
