### PR TITLE
Switch Mutating/ValidatingWebhookConfiguration version to v1beta1

### DIFF
--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/install"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -92,7 +92,7 @@ func newCluster(ctx context.Context, clientConfig clientcmd.ClientConfig, restCl
 	logger := internalLog.From(ctx).With("component", "cluster client")
 
 	install.Install(scheme.Scheme)
-	admissionregistrationv1.AddToScheme(scheme.Scheme)
+	admissionregistrationv1beta1.AddToScheme(scheme.Scheme)
 	apiregistrationv1.AddToScheme(scheme.Scheme)
 
 	kubernetesClient, err := kubernetes.NewForConfig(restClient)

--- a/internal/gvk/gvk.go
+++ b/internal/gvk/gvk.go
@@ -28,7 +28,7 @@ var (
 	HorizontalPodAutoscaler        = schema.GroupVersionKind{Group: "autoscaling", Version: "v1", Kind: "HorizontalPodAutoscaler"}
 	Ingress                        = schema.GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "Ingress"}
 	Job                            = schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"}
-	MutatingWebhookConfiguration   = schema.GroupVersionKind{Group: "admissionregistration.k8s.io", Version: "v1", Kind: "MutatingWebhookConfiguration"}
+	MutatingWebhookConfiguration   = schema.GroupVersionKind{Group: "admissionregistration.k8s.io", Version: "v1beta1", Kind: "MutatingWebhookConfiguration"}
 	Node                           = schema.GroupVersionKind{Version: "v1", Kind: "Node"}
 	Namespace                      = schema.GroupVersionKind{Version: "v1", Kind: "Namespace"}
 	NetworkPolicy                  = schema.GroupVersionKind{Group: "networking.k8s.io", Version: "v1", Kind: "NetworkPolicy"}
@@ -43,7 +43,7 @@ var (
 	StatefulSet                    = schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "StatefulSet"}
 	RoleBinding                    = schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "RoleBinding"}
 	Role                           = schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "Role"}
-	ValidatingWebhookConfiguration = schema.GroupVersionKind{Group: "admissionregistration.k8s.io", Version: "v1", Kind: "ValidatingWebhookConfiguration"}
+	ValidatingWebhookConfiguration = schema.GroupVersionKind{Group: "admissionregistration.k8s.io", Version: "v1beta1", Kind: "ValidatingWebhookConfiguration"}
 )
 
 // CustomResource generates a `schema.GroupVersionKind` for a custom resource given a version.

--- a/internal/modules/clusteroverview/objects.go
+++ b/internal/modules/clusteroverview/objects.go
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 package clusteroverview
 
 import (
-	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -128,9 +128,9 @@ var (
 
 	apiServerValidatingWebhooks = describer.NewResource(describer.ResourceOptions{
 		Path:           "/api-server/validating-webhooks",
-		ObjectStoreKey: store.Key{APIVersion: "admissionregistration.k8s.io/v1", Kind: "ValidatingWebhookConfiguration"},
-		ListType:       &admissionregistrationv1.ValidatingWebhookConfigurationList{},
-		ObjectType:     &admissionregistrationv1.ValidatingWebhookConfiguration{},
+		ObjectStoreKey: store.Key{APIVersion: "admissionregistration.k8s.io/v1beta1", Kind: "ValidatingWebhookConfiguration"},
+		ListType:       &admissionregistrationv1beta1.ValidatingWebhookConfigurationList{},
+		ObjectType:     &admissionregistrationv1beta1.ValidatingWebhookConfiguration{},
 		Titles:         describer.ResourceTitle{List: "Validating Webhook Configurations", Object: "Validating Webhook Configuration"},
 		ClusterWide:    true,
 		IconName:       icon.ApiServer,
@@ -139,9 +139,9 @@ var (
 
 	apiServerMutatingWebhooks = describer.NewResource(describer.ResourceOptions{
 		Path:           "/api-server/mutating-webhooks",
-		ObjectStoreKey: store.Key{APIVersion: "admissionregistration.k8s.io/v1", Kind: "MutatingWebhookConfiguration"},
-		ListType:       &admissionregistrationv1.MutatingWebhookConfigurationList{},
-		ObjectType:     &admissionregistrationv1.MutatingWebhookConfiguration{},
+		ObjectStoreKey: store.Key{APIVersion: "admissionregistration.k8s.io/v1beta1", Kind: "MutatingWebhookConfiguration"},
+		ListType:       &admissionregistrationv1beta1.MutatingWebhookConfigurationList{},
+		ObjectType:     &admissionregistrationv1beta1.MutatingWebhookConfiguration{},
 		Titles:         describer.ResourceTitle{List: "Mutating Webhook Configurations", Object: "Mutating Webhook Configuration"},
 		ClusterWide:    true,
 		IconName:       icon.ApiServer,

--- a/internal/modules/clusteroverview/path.go
+++ b/internal/modules/clusteroverview/path.go
@@ -53,9 +53,9 @@ func gvkPath(namespace, apiVersion, kind, name string) (string, error) {
 		p = "/custom-resource-definitions"
 	case apiVersion == "apiregistration.k8s.io/v1" && kind == "APIService":
 		p = "/api-server/api-services"
-	case apiVersion == "admissionregistration.k8s.io/v1" && kind == "MutatingWebhookConfiguration":
+	case apiVersion == "admissionregistration.k8s.io/v1beta1" && kind == "MutatingWebhookConfiguration":
 		p = "/api-server/mutating-webhooks"
-	case apiVersion == "admissionregistration.k8s.io/v1" && kind == "ValidatingWebhookConfiguration":
+	case apiVersion == "admissionregistration.k8s.io/v1beta1" && kind == "ValidatingWebhookConfiguration":
 		p = "/api-server/validating-webhooks"
 	default:
 		return "", fmt.Errorf("unknown object %s %s", apiVersion, kind)

--- a/internal/objectstore/informer.go
+++ b/internal/objectstore/informer.go
@@ -71,6 +71,7 @@ func (f *informerFactory) ForResource(groupVersionKind schema.GroupVersionKind) 
 	stopCh := f.informerContextCache.addChild(groupVersionKind)
 
 	gvr, _, err := f.client.Resource(groupVersionKind.GroupKind())
+	gvr.Version = groupVersionKind.Version
 	if err != nil {
 		return nil, fmt.Errorf("unable to find group version resource for group kind %s: %w",
 			groupVersionKind.GroupKind(), err)

--- a/internal/objectvisitor/mutatingwebhookconfiguration.go
+++ b/internal/objectvisitor/mutatingwebhookconfiguration.go
@@ -11,7 +11,7 @@ import (
 	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
 	"golang.org/x/sync/errgroup"
-	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -49,7 +49,7 @@ func (p *MutatingWebhookConfiguration) Visit(ctx context.Context, object *unstru
 		return errors.New("objectStore is nil")
 	}
 
-	mutatingwebhookconfiguration := &admissionregistrationv1.MutatingWebhookConfiguration{}
+	mutatingwebhookconfiguration := &admissionregistrationv1beta1.MutatingWebhookConfiguration{}
 	if err := kubernetes.FromUnstructured(object, mutatingwebhookconfiguration); err != nil {
 		return err
 	}

--- a/internal/objectvisitor/mutatingwebhookconfiguration_test.go
+++ b/internal/objectvisitor/mutatingwebhookconfiguration_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
-	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -31,11 +31,11 @@ func TestMutatingWebhookConfiguration_Visit(t *testing.T) {
 	service := testutil.CreateService("service")
 
 	object := testutil.CreateMutatingWebhookConfiguration("mutatingWebhookConfiguration")
-	object.Webhooks = []admissionregistrationv1.MutatingWebhook{
+	object.Webhooks = []admissionregistrationv1beta1.MutatingWebhook{
 		{
 			Name: "mutatingWebhook",
-			ClientConfig: admissionregistrationv1.WebhookClientConfig{
-				Service: &admissionregistrationv1.ServiceReference{
+			ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{
+				Service: &admissionregistrationv1beta1.ServiceReference{
 					Namespace: service.Namespace,
 					Name:      service.Name,
 				},
@@ -89,11 +89,11 @@ func TestMutatingWebhookConfiguration_Visit_notfound(t *testing.T) {
 	service := testutil.CreateService("service")
 
 	object := testutil.CreateMutatingWebhookConfiguration("mutatingWebhookConfiguration")
-	object.Webhooks = []admissionregistrationv1.MutatingWebhook{
+	object.Webhooks = []admissionregistrationv1beta1.MutatingWebhook{
 		{
 			Name: "mutatingWebhook",
-			ClientConfig: admissionregistrationv1.WebhookClientConfig{
-				Service: &admissionregistrationv1.ServiceReference{
+			ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{
+				Service: &admissionregistrationv1beta1.ServiceReference{
 					Namespace: service.Namespace,
 					Name:      service.Name,
 				},
@@ -143,10 +143,10 @@ func TestMutatingWebhookConfiguration_Visit_url(t *testing.T) {
 
 	object := testutil.CreateMutatingWebhookConfiguration("mutatingWebhookConfiguration")
 	webhookUrl := "https://example.com"
-	object.Webhooks = []admissionregistrationv1.MutatingWebhook{
+	object.Webhooks = []admissionregistrationv1beta1.MutatingWebhook{
 		{
 			Name: "mutatingWebhook",
-			ClientConfig: admissionregistrationv1.WebhookClientConfig{
+			ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{
 				URL: &webhookUrl,
 			},
 		},
@@ -179,5 +179,5 @@ func TestMutatingWebhookConfiguration_Visit_url(t *testing.T) {
 }
 
 func init() {
-	admissionregistrationv1.AddToScheme(scheme.Scheme)
+	admissionregistrationv1beta1.AddToScheme(scheme.Scheme)
 }

--- a/internal/objectvisitor/service_test.go
+++ b/internal/objectvisitor/service_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
-	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	extv1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -41,11 +41,11 @@ func TestService_Visit(t *testing.T) {
 	mutatingWebhookConfiguration := testutil.CreateMutatingWebhookConfiguration("mutatingWebhookConfiguration")
 	q.EXPECT().
 		MutatingWebhookConfigurationsForService(gomock.Any(), object).
-		Return([]*admissionregistrationv1.MutatingWebhookConfiguration{mutatingWebhookConfiguration}, nil)
+		Return([]*admissionregistrationv1beta1.MutatingWebhookConfiguration{mutatingWebhookConfiguration}, nil)
 	validatingWebhookConfiguration := testutil.CreateValidatingWebhookConfiguration("validatingWebhookConfiguration")
 	q.EXPECT().
 		ValidatingWebhookConfigurationsForService(gomock.Any(), object).
-		Return([]*admissionregistrationv1.ValidatingWebhookConfiguration{validatingWebhookConfiguration}, nil)
+		Return([]*admissionregistrationv1beta1.ValidatingWebhookConfiguration{validatingWebhookConfiguration}, nil)
 
 	handler := fake.NewMockObjectHandler(controller)
 	handler.EXPECT().

--- a/internal/objectvisitor/validatingwebhookconfiguration.go
+++ b/internal/objectvisitor/validatingwebhookconfiguration.go
@@ -11,7 +11,7 @@ import (
 	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
 	"golang.org/x/sync/errgroup"
-	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -49,7 +49,7 @@ func (p *ValidatingWebhookConfiguration) Visit(ctx context.Context, object *unst
 		return errors.New("objectStore is nil")
 	}
 
-	validatingwebhookconfiguration := &admissionregistrationv1.ValidatingWebhookConfiguration{}
+	validatingwebhookconfiguration := &admissionregistrationv1beta1.ValidatingWebhookConfiguration{}
 	if err := kubernetes.FromUnstructured(object, validatingwebhookconfiguration); err != nil {
 		return err
 	}

--- a/internal/objectvisitor/validatingwebhookconfiguration_test.go
+++ b/internal/objectvisitor/validatingwebhookconfiguration_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
-	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -31,11 +31,11 @@ func TestValidatingWebhookConfiguration_Visit(t *testing.T) {
 	service := testutil.CreateService("service")
 
 	object := testutil.CreateValidatingWebhookConfiguration("validatingWebhookConfiguration")
-	object.Webhooks = []admissionregistrationv1.ValidatingWebhook{
+	object.Webhooks = []admissionregistrationv1beta1.ValidatingWebhook{
 		{
 			Name: "validatingWebhook",
-			ClientConfig: admissionregistrationv1.WebhookClientConfig{
-				Service: &admissionregistrationv1.ServiceReference{
+			ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{
+				Service: &admissionregistrationv1beta1.ServiceReference{
 					Namespace: service.Namespace,
 					Name:      service.Name,
 				},
@@ -89,11 +89,11 @@ func TestValidatingWebhookConfiguration_Visit_notfound(t *testing.T) {
 	service := testutil.CreateService("service")
 
 	object := testutil.CreateValidatingWebhookConfiguration("validatingWebhookConfiguration")
-	object.Webhooks = []admissionregistrationv1.ValidatingWebhook{
+	object.Webhooks = []admissionregistrationv1beta1.ValidatingWebhook{
 		{
 			Name: "validatingWebhook",
-			ClientConfig: admissionregistrationv1.WebhookClientConfig{
-				Service: &admissionregistrationv1.ServiceReference{
+			ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{
+				Service: &admissionregistrationv1beta1.ServiceReference{
 					Namespace: service.Namespace,
 					Name:      service.Name,
 				},
@@ -143,10 +143,10 @@ func TestValidatingWebhookConfiguration_Visit_url(t *testing.T) {
 
 	object := testutil.CreateValidatingWebhookConfiguration("validatingWebhookConfiguration")
 	webhookUrl := "https://example.com"
-	object.Webhooks = []admissionregistrationv1.ValidatingWebhook{
+	object.Webhooks = []admissionregistrationv1beta1.ValidatingWebhook{
 		{
 			Name: "validatingWebhook",
-			ClientConfig: admissionregistrationv1.WebhookClientConfig{
+			ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{
 				URL: &webhookUrl,
 			},
 		},
@@ -179,5 +179,5 @@ func TestValidatingWebhookConfiguration_Visit_url(t *testing.T) {
 }
 
 func init() {
-	admissionregistrationv1.AddToScheme(scheme.Scheme)
+	admissionregistrationv1beta1.AddToScheme(scheme.Scheme)
 }

--- a/internal/printer/admissionwebhookconfiguration.go
+++ b/internal/printer/admissionwebhookconfiguration.go
@@ -8,7 +8,7 @@ package printer
 import (
 	"fmt"
 
-	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 
@@ -25,7 +25,7 @@ func printYaml(obj interface{}) string {
 	return string(b)
 }
 
-func admissionWebhookRules(rules []admissionregistrationv1.RuleWithOperations, options Options) (component.Component, error) {
+func admissionWebhookRules(rules []admissionregistrationv1beta1.RuleWithOperations, options Options) (component.Component, error) {
 	columns := component.NewTableCols("API Groups", "API Versions", "Resources", "Operations", "Scope")
 	table := component.NewTable("Rules", "There are no webhook rules!", columns)
 
@@ -53,7 +53,7 @@ func admissionWebhookRules(rules []admissionregistrationv1.RuleWithOperations, o
 			row["Operations"] = component.NewMarkdownText(printYaml(rule.Operations))
 		}
 		if rule.Scope == nil {
-			row["Scope"] = component.NewText(string(admissionregistrationv1.AllScopes))
+			row["Scope"] = component.NewText(string(admissionregistrationv1beta1.AllScopes))
 		} else {
 			row["Scope"] = component.NewText(string(*rule.Scope))
 		}
@@ -71,7 +71,7 @@ func admissionWebhookTimeout(timeoutSeconds *int32) component.Component {
 	return component.NewTextf("%ds", *timeoutSeconds)
 }
 
-func admissionWebhookClientConfig(clientConfig admissionregistrationv1.WebhookClientConfig, options Options) (component.Component, error) {
+func admissionWebhookClientConfig(clientConfig admissionregistrationv1beta1.WebhookClientConfig, options Options) (component.Component, error) {
 	if clientConfig.Service != nil {
 		return options.Link.ForGVK(
 			clientConfig.Service.Namespace,
@@ -86,23 +86,23 @@ func admissionWebhookClientConfig(clientConfig admissionregistrationv1.WebhookCl
 	return component.NewText("unknown"), nil
 }
 
-func admissionWebhookFailurePolicy(failurePolicy *admissionregistrationv1.FailurePolicyType) component.Component {
+func admissionWebhookFailurePolicy(failurePolicy *admissionregistrationv1beta1.FailurePolicyType) component.Component {
 	if failurePolicy == nil {
-		return component.NewTextf("%s", admissionregistrationv1.Fail)
+		return component.NewTextf("%s", admissionregistrationv1beta1.Fail)
 	}
 	return component.NewTextf("%s", *failurePolicy)
 }
 
-func admissionWebhookMatchPolicy(matchPolicy *admissionregistrationv1.MatchPolicyType) component.Component {
+func admissionWebhookMatchPolicy(matchPolicy *admissionregistrationv1beta1.MatchPolicyType) component.Component {
 	if matchPolicy == nil {
-		return component.NewTextf("%s", admissionregistrationv1.Equivalent)
+		return component.NewTextf("%s", admissionregistrationv1beta1.Equivalent)
 	}
 	return component.NewTextf("%s", *matchPolicy)
 }
 
-func admissionWebhookSideEffects(sideEffects *admissionregistrationv1.SideEffectClass) component.Component {
+func admissionWebhookSideEffects(sideEffects *admissionregistrationv1beta1.SideEffectClass) component.Component {
 	if sideEffects == nil {
-		return component.NewTextf("%s", admissionregistrationv1.SideEffectClassUnknown)
+		return component.NewTextf("%s", admissionregistrationv1beta1.SideEffectClassUnknown)
 	}
 	return component.NewTextf("%s", *sideEffects)
 }
@@ -129,9 +129,9 @@ func admissionWebhookAdmissionReviewVersions(admissionReviewVersions []string) c
 	return component.NewMarkdownText(printYaml(admissionReviewVersions))
 }
 
-func admissionWebhookReinvocationPolicy(reinvocationPolicy *admissionregistrationv1.ReinvocationPolicyType) component.Component {
+func admissionWebhookReinvocationPolicy(reinvocationPolicy *admissionregistrationv1beta1.ReinvocationPolicyType) component.Component {
 	if reinvocationPolicy == nil {
-		return component.NewTextf("%s", admissionregistrationv1.NeverReinvocationPolicy)
+		return component.NewTextf("%s", admissionregistrationv1beta1.NeverReinvocationPolicy)
 	}
 	return component.NewTextf("%s", *reinvocationPolicy)
 }

--- a/internal/printer/mutatingwebhookconfiguration.go
+++ b/internal/printer/mutatingwebhookconfiguration.go
@@ -13,11 +13,11 @@ import (
 
 	"github.com/vmware-tanzu/octant/pkg/view/component"
 
-	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 )
 
 // MutatingWebhookConfigurationListHandler is a printFunc that prints mutating webhook configurations
-func MutatingWebhookConfigurationListHandler(ctx context.Context, list *admissionregistrationv1.MutatingWebhookConfigurationList, options Options) (component.Component, error) {
+func MutatingWebhookConfigurationListHandler(ctx context.Context, list *admissionregistrationv1beta1.MutatingWebhookConfigurationList, options Options) (component.Component, error) {
 	if list == nil {
 		return nil, errors.New("mutating webhook configuration list is nil")
 	}
@@ -45,7 +45,7 @@ func MutatingWebhookConfigurationListHandler(ctx context.Context, list *admissio
 }
 
 // MutatingWebhookConfigurationHandler is a printFunc that prints a mutating webhook configurations
-func MutatingWebhookConfigurationHandler(ctx context.Context, mutatingWebhookConfiguration *admissionregistrationv1.MutatingWebhookConfiguration, options Options) (component.Component, error) {
+func MutatingWebhookConfigurationHandler(ctx context.Context, mutatingWebhookConfiguration *admissionregistrationv1beta1.MutatingWebhookConfiguration, options Options) (component.Component, error) {
 	o := NewObject(mutatingWebhookConfiguration)
 
 	ch, err := newMutatingWebhookConfigurationHandler(mutatingWebhookConfiguration, o)
@@ -65,14 +65,14 @@ type mutatingWebhookConfigurationObject interface {
 }
 
 type mutatingWebhookConfigurationHandler struct {
-	mutatingWebhookConfiguration *admissionregistrationv1.MutatingWebhookConfiguration
-	webhookFunc                  func(*admissionregistrationv1.MutatingWebhook, Options) (*component.Summary, error)
+	mutatingWebhookConfiguration *admissionregistrationv1beta1.MutatingWebhookConfiguration
+	webhookFunc                  func(*admissionregistrationv1beta1.MutatingWebhook, Options) (*component.Summary, error)
 	object                       *Object
 }
 
 var _ mutatingWebhookConfigurationObject = (*mutatingWebhookConfigurationHandler)(nil)
 
-func newMutatingWebhookConfigurationHandler(mutatingWebhookConfiguration *admissionregistrationv1.MutatingWebhookConfiguration, object *Object) (*mutatingWebhookConfigurationHandler, error) {
+func newMutatingWebhookConfigurationHandler(mutatingWebhookConfiguration *admissionregistrationv1beta1.MutatingWebhookConfiguration, object *Object) (*mutatingWebhookConfigurationHandler, error) {
 	if mutatingWebhookConfiguration == nil {
 		return nil, errors.New("can't print a nil mutatingwebhookconfiguration")
 	}
@@ -104,17 +104,17 @@ func (c *mutatingWebhookConfigurationHandler) Webhooks(options Options) error {
 	return nil
 }
 
-func defaultMutatingWebhook(mutatingWebhook *admissionregistrationv1.MutatingWebhook, options Options) (*component.Summary, error) {
+func defaultMutatingWebhook(mutatingWebhook *admissionregistrationv1beta1.MutatingWebhook, options Options) (*component.Summary, error) {
 	return NewMutatingWebhook(mutatingWebhook).Create(options)
 }
 
 // MutatingWebhook generates a mutating webhook
 type MutatingWebhook struct {
-	mutatingWebhook *admissionregistrationv1.MutatingWebhook
+	mutatingWebhook *admissionregistrationv1beta1.MutatingWebhook
 }
 
 // NewMutatingWebhook creates an instance of MutatingWebhook
-func NewMutatingWebhook(mutatingWebhook *admissionregistrationv1.MutatingWebhook) *MutatingWebhook {
+func NewMutatingWebhook(mutatingWebhook *admissionregistrationv1beta1.MutatingWebhook) *MutatingWebhook {
 	return &MutatingWebhook{
 		mutatingWebhook: mutatingWebhook,
 	}

--- a/internal/printer/mutatingwebhookconfiguration_test.go
+++ b/internal/printer/mutatingwebhookconfiguration_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
-	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 
@@ -23,8 +23,8 @@ func Test_MutatingWebhookConfigurationListHandler(t *testing.T) {
 	object := testutil.CreateMutatingWebhookConfiguration("mutatingWebhookConfiguration")
 	object.CreationTimestamp = *testutil.CreateTimestamp()
 
-	list := &admissionregistrationv1.MutatingWebhookConfigurationList{
-		Items: []admissionregistrationv1.MutatingWebhookConfiguration{*object},
+	list := &admissionregistrationv1beta1.MutatingWebhookConfigurationList{
+		Items: []admissionregistrationv1beta1.MutatingWebhookConfiguration{*object},
 	}
 
 	controller := gomock.NewController(t)
@@ -47,7 +47,7 @@ func Test_MutatingWebhookConfigurationListHandler(t *testing.T) {
 	expected.Add(component.TableRow{
 		"Name": component.NewLink("", object.Name, "/path",
 			genObjectStatus(component.TextStatusOK, []string{
-				"admissionregistration.k8s.io/v1 MutatingWebhookConfiguration is OK",
+				"admissionregistration.k8s.io/v1beta1 MutatingWebhookConfiguration is OK",
 			})),
 		"Age": component.NewTimestamp(now),
 		component.GridActionKey: gridActionsFactory([]component.GridAction{
@@ -59,39 +59,39 @@ func Test_MutatingWebhookConfigurationListHandler(t *testing.T) {
 }
 
 func Test_NewMutatingWebhook(t *testing.T) {
-	namespacedScope := admissionregistrationv1.NamespacedScope
-	ifNeededReinvocationPolicy := admissionregistrationv1.IfNeededReinvocationPolicy
-	ignore := admissionregistrationv1.Ignore
-	exact := admissionregistrationv1.Exact
-	sideEffectClassNone := admissionregistrationv1.SideEffectClassNone
+	namespacedScope := admissionregistrationv1beta1.NamespacedScope
+	ifNeededReinvocationPolicy := admissionregistrationv1beta1.IfNeededReinvocationPolicy
+	ignore := admissionregistrationv1beta1.Ignore
+	exact := admissionregistrationv1beta1.Exact
+	sideEffectClassNone := admissionregistrationv1beta1.SideEffectClassNone
 
 	cases := []struct {
 		name            string
-		mutatingWebhook *admissionregistrationv1.MutatingWebhook
+		mutatingWebhook *admissionregistrationv1beta1.MutatingWebhook
 		isErr           bool
 		expected        *component.Summary
 	}{
 		{
 			name: "normal",
-			mutatingWebhook: &admissionregistrationv1.MutatingWebhook{
+			mutatingWebhook: &admissionregistrationv1beta1.MutatingWebhook{
 				Name: "test-webhook",
-				ClientConfig: admissionregistrationv1.WebhookClientConfig{
-					Service: &admissionregistrationv1.ServiceReference{
+				ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{
+					Service: &admissionregistrationv1beta1.ServiceReference{
 						Namespace: "default",
 						Name:      "service",
 					},
 				},
-				Rules: []admissionregistrationv1.RuleWithOperations{
+				Rules: []admissionregistrationv1beta1.RuleWithOperations{
 					{
-						Rule: admissionregistrationv1.Rule{
+						Rule: admissionregistrationv1beta1.Rule{
 							APIGroups:   []string{"apps"},
 							APIVersions: []string{"v1"},
 							Resources:   []string{"*"},
 							Scope:       &namespacedScope,
 						},
-						Operations: []admissionregistrationv1.OperationType{
-							admissionregistrationv1.Create,
-							admissionregistrationv1.Update,
+						Operations: []admissionregistrationv1beta1.OperationType{
+							admissionregistrationv1beta1.Create,
+							admissionregistrationv1beta1.Update,
 						},
 					},
 				},
@@ -158,7 +158,7 @@ func Test_NewMutatingWebhook(t *testing.T) {
 		},
 		{
 			name: "default",
-			mutatingWebhook: &admissionregistrationv1.MutatingWebhook{
+			mutatingWebhook: &admissionregistrationv1beta1.MutatingWebhook{
 				Name: "test-webhook",
 			},
 			expected: component.NewSummary("test-webhook", []component.SummarySection{
@@ -239,5 +239,5 @@ func Test_NewMutatingWebhook(t *testing.T) {
 }
 
 func init() {
-	admissionregistrationv1.AddToScheme(scheme.Scheme)
+	admissionregistrationv1beta1.AddToScheme(scheme.Scheme)
 }

--- a/internal/printer/validatingwebhookconfiguration.go
+++ b/internal/printer/validatingwebhookconfiguration.go
@@ -13,11 +13,11 @@ import (
 
 	"github.com/vmware-tanzu/octant/pkg/view/component"
 
-	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 )
 
 // ValidatingWebhookConfigurationListHandler is a printFunc that prints validating webhook configurations
-func ValidatingWebhookConfigurationListHandler(ctx context.Context, list *admissionregistrationv1.ValidatingWebhookConfigurationList, options Options) (component.Component, error) {
+func ValidatingWebhookConfigurationListHandler(ctx context.Context, list *admissionregistrationv1beta1.ValidatingWebhookConfigurationList, options Options) (component.Component, error) {
 	if list == nil {
 		return nil, errors.New("validating webhook configuration list is nil")
 	}
@@ -45,7 +45,7 @@ func ValidatingWebhookConfigurationListHandler(ctx context.Context, list *admiss
 }
 
 // ValidatingWebhookConfigurationHandler is a printFunc that prints a validating webhook configurations
-func ValidatingWebhookConfigurationHandler(ctx context.Context, validatingWebhookConfiguration *admissionregistrationv1.ValidatingWebhookConfiguration, options Options) (component.Component, error) {
+func ValidatingWebhookConfigurationHandler(ctx context.Context, validatingWebhookConfiguration *admissionregistrationv1beta1.ValidatingWebhookConfiguration, options Options) (component.Component, error) {
 	o := NewObject(validatingWebhookConfiguration)
 
 	ch, err := newValidatingWebhookConfigurationHandler(validatingWebhookConfiguration, o)
@@ -65,14 +65,14 @@ type validatingWebhookConfigurationObject interface {
 }
 
 type validatingWebhookConfigurationHandler struct {
-	validatingWebhookConfiguration *admissionregistrationv1.ValidatingWebhookConfiguration
-	webhookFunc                    func(*admissionregistrationv1.ValidatingWebhook, Options) (*component.Summary, error)
+	validatingWebhookConfiguration *admissionregistrationv1beta1.ValidatingWebhookConfiguration
+	webhookFunc                    func(*admissionregistrationv1beta1.ValidatingWebhook, Options) (*component.Summary, error)
 	object                         *Object
 }
 
 var _ validatingWebhookConfigurationObject = (*validatingWebhookConfigurationHandler)(nil)
 
-func newValidatingWebhookConfigurationHandler(validatingWebhookConfiguration *admissionregistrationv1.ValidatingWebhookConfiguration, object *Object) (*validatingWebhookConfigurationHandler, error) {
+func newValidatingWebhookConfigurationHandler(validatingWebhookConfiguration *admissionregistrationv1beta1.ValidatingWebhookConfiguration, object *Object) (*validatingWebhookConfigurationHandler, error) {
 	if validatingWebhookConfiguration == nil {
 		return nil, errors.New("can't print a nil validatingwebhookconfiguration")
 	}
@@ -104,17 +104,17 @@ func (c *validatingWebhookConfigurationHandler) Webhooks(options Options) error 
 	return nil
 }
 
-func defaultValidatingWebhook(validatingWebhook *admissionregistrationv1.ValidatingWebhook, options Options) (*component.Summary, error) {
+func defaultValidatingWebhook(validatingWebhook *admissionregistrationv1beta1.ValidatingWebhook, options Options) (*component.Summary, error) {
 	return NewValidatingWebhook(validatingWebhook).Create(options)
 }
 
 // ValidatingWebhook generates a validating webhook
 type ValidatingWebhook struct {
-	validatingWebhook *admissionregistrationv1.ValidatingWebhook
+	validatingWebhook *admissionregistrationv1beta1.ValidatingWebhook
 }
 
 // NewValidatingWebhook creates an instance of ValidatingWebhook
-func NewValidatingWebhook(validatingWebhook *admissionregistrationv1.ValidatingWebhook) *ValidatingWebhook {
+func NewValidatingWebhook(validatingWebhook *admissionregistrationv1beta1.ValidatingWebhook) *ValidatingWebhook {
 	return &ValidatingWebhook{
 		validatingWebhook: validatingWebhook,
 	}

--- a/internal/printer/validatingwebhookconfiguration_test.go
+++ b/internal/printer/validatingwebhookconfiguration_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
-	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 
@@ -23,8 +23,8 @@ func Test_ValidatingWebhookConfigurationListHandler(t *testing.T) {
 	object := testutil.CreateValidatingWebhookConfiguration("validatingWebhookConfiguration")
 	object.CreationTimestamp = *testutil.CreateTimestamp()
 
-	list := &admissionregistrationv1.ValidatingWebhookConfigurationList{
-		Items: []admissionregistrationv1.ValidatingWebhookConfiguration{*object},
+	list := &admissionregistrationv1beta1.ValidatingWebhookConfigurationList{
+		Items: []admissionregistrationv1beta1.ValidatingWebhookConfiguration{*object},
 	}
 
 	controller := gomock.NewController(t)
@@ -47,7 +47,7 @@ func Test_ValidatingWebhookConfigurationListHandler(t *testing.T) {
 	expected.Add(component.TableRow{
 		"Name": component.NewLink("", object.Name, "/path",
 			genObjectStatus(component.TextStatusOK, []string{
-				"admissionregistration.k8s.io/v1 ValidatingWebhookConfiguration is OK",
+				"admissionregistration.k8s.io/v1beta1 ValidatingWebhookConfiguration is OK",
 			})),
 		"Age": component.NewTimestamp(now),
 		component.GridActionKey: gridActionsFactory([]component.GridAction{
@@ -59,38 +59,38 @@ func Test_ValidatingWebhookConfigurationListHandler(t *testing.T) {
 }
 
 func Test_NewValidatingWebhook(t *testing.T) {
-	namespacedScope := admissionregistrationv1.NamespacedScope
-	ignore := admissionregistrationv1.Ignore
-	exact := admissionregistrationv1.Exact
-	sideEffectClassNone := admissionregistrationv1.SideEffectClassNone
+	namespacedScope := admissionregistrationv1beta1.NamespacedScope
+	ignore := admissionregistrationv1beta1.Ignore
+	exact := admissionregistrationv1beta1.Exact
+	sideEffectClassNone := admissionregistrationv1beta1.SideEffectClassNone
 
 	cases := []struct {
 		name              string
-		validatingWebhook *admissionregistrationv1.ValidatingWebhook
+		validatingWebhook *admissionregistrationv1beta1.ValidatingWebhook
 		isErr             bool
 		expected          *component.Summary
 	}{
 		{
 			name: "normal",
-			validatingWebhook: &admissionregistrationv1.ValidatingWebhook{
+			validatingWebhook: &admissionregistrationv1beta1.ValidatingWebhook{
 				Name: "test-webhook",
-				ClientConfig: admissionregistrationv1.WebhookClientConfig{
-					Service: &admissionregistrationv1.ServiceReference{
+				ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{
+					Service: &admissionregistrationv1beta1.ServiceReference{
 						Namespace: "default",
 						Name:      "service",
 					},
 				},
-				Rules: []admissionregistrationv1.RuleWithOperations{
+				Rules: []admissionregistrationv1beta1.RuleWithOperations{
 					{
-						Rule: admissionregistrationv1.Rule{
+						Rule: admissionregistrationv1beta1.Rule{
 							APIGroups:   []string{"apps"},
 							APIVersions: []string{"v1"},
 							Resources:   []string{"*"},
 							Scope:       &namespacedScope,
 						},
-						Operations: []admissionregistrationv1.OperationType{
-							admissionregistrationv1.Create,
-							admissionregistrationv1.Update,
+						Operations: []admissionregistrationv1beta1.OperationType{
+							admissionregistrationv1beta1.Create,
+							admissionregistrationv1beta1.Update,
 						},
 					},
 				},
@@ -152,7 +152,7 @@ func Test_NewValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "default",
-			validatingWebhook: &admissionregistrationv1.ValidatingWebhook{
+			validatingWebhook: &admissionregistrationv1beta1.ValidatingWebhook{
 				Name: "test-webhook",
 			},
 			expected: component.NewSummary("test-webhook", []component.SummarySection{
@@ -229,5 +229,5 @@ func Test_NewValidatingWebhook(t *testing.T) {
 }
 
 func init() {
-	admissionregistrationv1.AddToScheme(scheme.Scheme)
+	admissionregistrationv1beta1.AddToScheme(scheme.Scheme)
 }

--- a/internal/queryer/fake/mock_queryer.go
+++ b/internal/queryer/fake/mock_queryer.go
@@ -9,13 +9,13 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	v1 "k8s.io/api/admissionregistration/v1"
-	v10 "k8s.io/api/autoscaling/v1"
-	v11 "k8s.io/api/core/v1"
-	v1beta1 "k8s.io/api/extensions/v1beta1"
-	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	v1 "k8s.io/api/autoscaling/v1"
+	v10 "k8s.io/api/core/v1"
+	v1beta10 "k8s.io/api/extensions/v1beta1"
+	v11 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	v13 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+	v12 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 )
 
 // MockQueryer is a mock of Queryer interface
@@ -42,10 +42,10 @@ func (m *MockQueryer) EXPECT() *MockQueryerMockRecorder {
 }
 
 // APIServicesForService mocks base method
-func (m *MockQueryer) APIServicesForService(arg0 context.Context, arg1 *v11.Service) ([]*v13.APIService, error) {
+func (m *MockQueryer) APIServicesForService(arg0 context.Context, arg1 *v10.Service) ([]*v12.APIService, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "APIServicesForService", arg0, arg1)
-	ret0, _ := ret[0].([]*v13.APIService)
+	ret0, _ := ret[0].([]*v12.APIService)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -72,10 +72,10 @@ func (mr *MockQueryerMockRecorder) Children(arg0, arg1 interface{}) *gomock.Call
 }
 
 // ConfigMapsForPod mocks base method
-func (m *MockQueryer) ConfigMapsForPod(arg0 context.Context, arg1 *v11.Pod) ([]*v11.ConfigMap, error) {
+func (m *MockQueryer) ConfigMapsForPod(arg0 context.Context, arg1 *v10.Pod) ([]*v10.ConfigMap, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConfigMapsForPod", arg0, arg1)
-	ret0, _ := ret[0].([]*v11.ConfigMap)
+	ret0, _ := ret[0].([]*v10.ConfigMap)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -87,10 +87,10 @@ func (mr *MockQueryerMockRecorder) ConfigMapsForPod(arg0, arg1 interface{}) *gom
 }
 
 // Events mocks base method
-func (m *MockQueryer) Events(arg0 context.Context, arg1 v12.Object) ([]*v11.Event, error) {
+func (m *MockQueryer) Events(arg0 context.Context, arg1 v11.Object) ([]*v10.Event, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Events", arg0, arg1)
-	ret0, _ := ret[0].([]*v11.Event)
+	ret0, _ := ret[0].([]*v10.Event)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -102,10 +102,10 @@ func (mr *MockQueryerMockRecorder) Events(arg0, arg1 interface{}) *gomock.Call {
 }
 
 // IngressesForService mocks base method
-func (m *MockQueryer) IngressesForService(arg0 context.Context, arg1 *v11.Service) ([]*v1beta1.Ingress, error) {
+func (m *MockQueryer) IngressesForService(arg0 context.Context, arg1 *v10.Service) ([]*v1beta10.Ingress, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IngressesForService", arg0, arg1)
-	ret0, _ := ret[0].([]*v1beta1.Ingress)
+	ret0, _ := ret[0].([]*v1beta10.Ingress)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -117,10 +117,10 @@ func (mr *MockQueryerMockRecorder) IngressesForService(arg0, arg1 interface{}) *
 }
 
 // MutatingWebhookConfigurationsForService mocks base method
-func (m *MockQueryer) MutatingWebhookConfigurationsForService(arg0 context.Context, arg1 *v11.Service) ([]*v1.MutatingWebhookConfiguration, error) {
+func (m *MockQueryer) MutatingWebhookConfigurationsForService(arg0 context.Context, arg1 *v10.Service) ([]*v1beta1.MutatingWebhookConfiguration, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MutatingWebhookConfigurationsForService", arg0, arg1)
-	ret0, _ := ret[0].([]*v1.MutatingWebhookConfiguration)
+	ret0, _ := ret[0].([]*v1beta1.MutatingWebhookConfiguration)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -148,10 +148,10 @@ func (mr *MockQueryerMockRecorder) OwnerReference(arg0, arg1 interface{}) *gomoc
 }
 
 // PodsForService mocks base method
-func (m *MockQueryer) PodsForService(arg0 context.Context, arg1 *v11.Service) ([]*v11.Pod, error) {
+func (m *MockQueryer) PodsForService(arg0 context.Context, arg1 *v10.Service) ([]*v10.Pod, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PodsForService", arg0, arg1)
-	ret0, _ := ret[0].([]*v11.Pod)
+	ret0, _ := ret[0].([]*v10.Pod)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -163,7 +163,7 @@ func (mr *MockQueryerMockRecorder) PodsForService(arg0, arg1 interface{}) *gomoc
 }
 
 // ScaleTarget mocks base method
-func (m *MockQueryer) ScaleTarget(arg0 context.Context, arg1 *v10.HorizontalPodAutoscaler) (map[string]interface{}, error) {
+func (m *MockQueryer) ScaleTarget(arg0 context.Context, arg1 *v1.HorizontalPodAutoscaler) (map[string]interface{}, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ScaleTarget", arg0, arg1)
 	ret0, _ := ret[0].(map[string]interface{})
@@ -178,10 +178,10 @@ func (mr *MockQueryerMockRecorder) ScaleTarget(arg0, arg1 interface{}) *gomock.C
 }
 
 // SecretsForPod mocks base method
-func (m *MockQueryer) SecretsForPod(arg0 context.Context, arg1 *v11.Pod) ([]*v11.Secret, error) {
+func (m *MockQueryer) SecretsForPod(arg0 context.Context, arg1 *v10.Pod) ([]*v10.Secret, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SecretsForPod", arg0, arg1)
-	ret0, _ := ret[0].([]*v11.Secret)
+	ret0, _ := ret[0].([]*v10.Secret)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -193,10 +193,10 @@ func (mr *MockQueryerMockRecorder) SecretsForPod(arg0, arg1 interface{}) *gomock
 }
 
 // ServiceAccountForPod mocks base method
-func (m *MockQueryer) ServiceAccountForPod(arg0 context.Context, arg1 *v11.Pod) (*v11.ServiceAccount, error) {
+func (m *MockQueryer) ServiceAccountForPod(arg0 context.Context, arg1 *v10.Pod) (*v10.ServiceAccount, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ServiceAccountForPod", arg0, arg1)
-	ret0, _ := ret[0].(*v11.ServiceAccount)
+	ret0, _ := ret[0].(*v10.ServiceAccount)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -208,7 +208,7 @@ func (mr *MockQueryerMockRecorder) ServiceAccountForPod(arg0, arg1 interface{}) 
 }
 
 // ServicesForIngress mocks base method
-func (m *MockQueryer) ServicesForIngress(arg0 context.Context, arg1 *v1beta1.Ingress) (*unstructured.UnstructuredList, error) {
+func (m *MockQueryer) ServicesForIngress(arg0 context.Context, arg1 *v1beta10.Ingress) (*unstructured.UnstructuredList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ServicesForIngress", arg0, arg1)
 	ret0, _ := ret[0].(*unstructured.UnstructuredList)
@@ -223,10 +223,10 @@ func (mr *MockQueryerMockRecorder) ServicesForIngress(arg0, arg1 interface{}) *g
 }
 
 // ServicesForPod mocks base method
-func (m *MockQueryer) ServicesForPod(arg0 context.Context, arg1 *v11.Pod) ([]*v11.Service, error) {
+func (m *MockQueryer) ServicesForPod(arg0 context.Context, arg1 *v10.Pod) ([]*v10.Service, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ServicesForPod", arg0, arg1)
-	ret0, _ := ret[0].([]*v11.Service)
+	ret0, _ := ret[0].([]*v10.Service)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -238,10 +238,10 @@ func (mr *MockQueryerMockRecorder) ServicesForPod(arg0, arg1 interface{}) *gomoc
 }
 
 // ValidatingWebhookConfigurationsForService mocks base method
-func (m *MockQueryer) ValidatingWebhookConfigurationsForService(arg0 context.Context, arg1 *v11.Service) ([]*v1.ValidatingWebhookConfiguration, error) {
+func (m *MockQueryer) ValidatingWebhookConfigurationsForService(arg0 context.Context, arg1 *v10.Service) ([]*v1beta1.ValidatingWebhookConfiguration, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ValidatingWebhookConfigurationsForService", arg0, arg1)
-	ret0, _ := ret[0].([]*v1.ValidatingWebhookConfiguration)
+	ret0, _ := ret[0].([]*v1beta1.ValidatingWebhookConfiguration)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/internal/queryer/queryer.go
+++ b/internal/queryer/queryer.go
@@ -13,7 +13,7 @@ import (
 	"go.opencensus.io/trace"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
-	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
@@ -46,8 +46,8 @@ type Queryer interface {
 	Events(ctx context.Context, object metav1.Object) ([]*corev1.Event, error)
 	IngressesForService(ctx context.Context, service *corev1.Service) ([]*extv1beta1.Ingress, error)
 	APIServicesForService(ctx context.Context, service *corev1.Service) ([]*apiregistrationv1.APIService, error)
-	MutatingWebhookConfigurationsForService(ctx context.Context, service *corev1.Service) ([]*admissionregistrationv1.MutatingWebhookConfiguration, error)
-	ValidatingWebhookConfigurationsForService(ctx context.Context, service *corev1.Service) ([]*admissionregistrationv1.ValidatingWebhookConfiguration, error)
+	MutatingWebhookConfigurationsForService(ctx context.Context, service *corev1.Service) ([]*admissionregistrationv1beta1.MutatingWebhookConfiguration, error)
+	ValidatingWebhookConfigurationsForService(ctx context.Context, service *corev1.Service) ([]*admissionregistrationv1beta1.ValidatingWebhookConfiguration, error)
 	OwnerReference(ctx context.Context, object *unstructured.Unstructured) (bool, []*unstructured.Unstructured, error)
 	ScaleTarget(ctx context.Context, hpa *autoscalingv1.HorizontalPodAutoscaler) (map[string]interface{}, error)
 	PodsForService(ctx context.Context, service *corev1.Service) ([]*corev1.Pod, error)
@@ -445,7 +445,7 @@ func (osq *ObjectStoreQueryer) APIServicesForService(ctx context.Context, servic
 	return results, nil
 }
 
-func (osq *ObjectStoreQueryer) MutatingWebhookConfigurationsForService(ctx context.Context, service *corev1.Service) ([]*admissionregistrationv1.MutatingWebhookConfiguration, error) {
+func (osq *ObjectStoreQueryer) MutatingWebhookConfigurationsForService(ctx context.Context, service *corev1.Service) ([]*admissionregistrationv1beta1.MutatingWebhookConfiguration, error) {
 	if service == nil {
 		return nil, errors.New("nil service")
 	}
@@ -456,10 +456,10 @@ func (osq *ObjectStoreQueryer) MutatingWebhookConfigurationsForService(ctx conte
 		return nil, errors.Wrap(err, "retrieving mutatingwebhookconfigurations")
 	}
 
-	var results []*admissionregistrationv1.MutatingWebhookConfiguration
+	var results []*admissionregistrationv1beta1.MutatingWebhookConfiguration
 
 	for i := range ul.Items {
-		mutatingwebhookconfiguration := &admissionregistrationv1.MutatingWebhookConfiguration{}
+		mutatingwebhookconfiguration := &admissionregistrationv1beta1.MutatingWebhookConfiguration{}
 		err := kubernetes.FromUnstructured(&ul.Items[i], mutatingwebhookconfiguration)
 		if err != nil {
 			return nil, errors.Wrap(err, "converting unstructured mutatingwebhookconfiguration")
@@ -477,7 +477,7 @@ func (osq *ObjectStoreQueryer) MutatingWebhookConfigurationsForService(ctx conte
 	return results, nil
 }
 
-func (osq *ObjectStoreQueryer) ValidatingWebhookConfigurationsForService(ctx context.Context, service *corev1.Service) ([]*admissionregistrationv1.ValidatingWebhookConfiguration, error) {
+func (osq *ObjectStoreQueryer) ValidatingWebhookConfigurationsForService(ctx context.Context, service *corev1.Service) ([]*admissionregistrationv1beta1.ValidatingWebhookConfiguration, error) {
 	if service == nil {
 		return nil, errors.New("nil service")
 	}
@@ -488,10 +488,10 @@ func (osq *ObjectStoreQueryer) ValidatingWebhookConfigurationsForService(ctx con
 		return nil, errors.Wrap(err, "retrieving validatingwebhookconfigurations")
 	}
 
-	var results []*admissionregistrationv1.ValidatingWebhookConfiguration
+	var results []*admissionregistrationv1beta1.ValidatingWebhookConfiguration
 
 	for i := range ul.Items {
-		validatingwebhookconfiguration := &admissionregistrationv1.ValidatingWebhookConfiguration{}
+		validatingwebhookconfiguration := &admissionregistrationv1beta1.ValidatingWebhookConfiguration{}
 		err := kubernetes.FromUnstructured(&ul.Items[i], validatingwebhookconfiguration)
 		if err != nil {
 			return nil, errors.Wrap(err, "converting unstructured validatingwebhookconfiguration")

--- a/internal/queryer/queryer_test.go
+++ b/internal/queryer/queryer_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
@@ -486,13 +486,13 @@ func TestCacheQueryer_MutatingWebhookConfigurationsForService(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "service", Namespace: "default"},
 	}
 
-	mutatingWebhookConfiguration1 := &admissionregistrationv1.MutatingWebhookConfiguration{
-		TypeMeta:   metav1.TypeMeta{APIVersion: "admissionregistration.k8s.io/v1", Kind: "MutatingWebhookConfiguration"},
+	mutatingWebhookConfiguration1 := &admissionregistrationv1beta1.MutatingWebhookConfiguration{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "admissionregistration.k8s.io/v1beta1", Kind: "MutatingWebhookConfiguration"},
 		ObjectMeta: metav1.ObjectMeta{Name: "mutatingWebhookConfiguration1"},
-		Webhooks: []admissionregistrationv1.MutatingWebhook{
+		Webhooks: []admissionregistrationv1beta1.MutatingWebhook{
 			{
-				ClientConfig: admissionregistrationv1.WebhookClientConfig{
-					Service: &admissionregistrationv1.ServiceReference{
+				ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{
+					Service: &admissionregistrationv1beta1.ServiceReference{
 						Namespace: "default",
 						Name:      "service",
 					},
@@ -501,17 +501,17 @@ func TestCacheQueryer_MutatingWebhookConfigurationsForService(t *testing.T) {
 		},
 	}
 
-	mutatingWebhookConfiguration2 := &admissionregistrationv1.MutatingWebhookConfiguration{
-		TypeMeta:   metav1.TypeMeta{APIVersion: "admissionregistration.k8s.io/v1", Kind: "MutatingWebhookConfiguration"},
+	mutatingWebhookConfiguration2 := &admissionregistrationv1beta1.MutatingWebhookConfiguration{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "admissionregistration.k8s.io/v1beta1", Kind: "MutatingWebhookConfiguration"},
 		ObjectMeta: metav1.ObjectMeta{Name: "mutatingWebhookConfiguration2"},
-		Webhooks:   []admissionregistrationv1.MutatingWebhook{},
+		Webhooks:   []admissionregistrationv1beta1.MutatingWebhook{},
 	}
 
 	cases := []struct {
 		name     string
 		service  *corev1.Service
 		setup    func(t *testing.T, o *storeFake.MockStore)
-		expected []*admissionregistrationv1.MutatingWebhookConfiguration
+		expected []*admissionregistrationv1beta1.MutatingWebhookConfiguration
 		isErr    bool
 	}{
 		{
@@ -519,14 +519,14 @@ func TestCacheQueryer_MutatingWebhookConfigurationsForService(t *testing.T) {
 			service: service,
 			setup: func(t *testing.T, o *storeFake.MockStore) {
 				mutatingWebhookConfigurationKey := store.Key{
-					APIVersion: "admissionregistration.k8s.io/v1",
+					APIVersion: "admissionregistration.k8s.io/v1beta1",
 					Kind:       "MutatingWebhookConfiguration",
 				}
 				o.EXPECT().
 					List(gomock.Any(), gomock.Eq(mutatingWebhookConfigurationKey)).
 					Return(testutil.ToUnstructuredList(t, mutatingWebhookConfiguration1, mutatingWebhookConfiguration2), false, nil)
 			},
-			expected: []*admissionregistrationv1.MutatingWebhookConfiguration{
+			expected: []*admissionregistrationv1beta1.MutatingWebhookConfiguration{
 				mutatingWebhookConfiguration1,
 			},
 		},
@@ -540,7 +540,7 @@ func TestCacheQueryer_MutatingWebhookConfigurationsForService(t *testing.T) {
 			service: service,
 			setup: func(t *testing.T, o *storeFake.MockStore) {
 				mutatingWebhookConfigurationKey := store.Key{
-					APIVersion: "admissionregistration.k8s.io/v1",
+					APIVersion: "admissionregistration.k8s.io/v1beta1",
 					Kind:       "MutatingWebhookConfiguration",
 				}
 				o.EXPECT().
@@ -584,13 +584,13 @@ func TestCacheQueryer_ValidatingWebhookConfigurationsForService(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "service", Namespace: "default"},
 	}
 
-	validatingWebhookConfiguration1 := &admissionregistrationv1.ValidatingWebhookConfiguration{
-		TypeMeta:   metav1.TypeMeta{APIVersion: "admissionregistration.k8s.io/v1", Kind: "ValidatingWebhookConfiguration"},
+	validatingWebhookConfiguration1 := &admissionregistrationv1beta1.ValidatingWebhookConfiguration{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "admissionregistration.k8s.io/v1beta1", Kind: "ValidatingWebhookConfiguration"},
 		ObjectMeta: metav1.ObjectMeta{Name: "validatingWebhookConfiguration1"},
-		Webhooks: []admissionregistrationv1.ValidatingWebhook{
+		Webhooks: []admissionregistrationv1beta1.ValidatingWebhook{
 			{
-				ClientConfig: admissionregistrationv1.WebhookClientConfig{
-					Service: &admissionregistrationv1.ServiceReference{
+				ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{
+					Service: &admissionregistrationv1beta1.ServiceReference{
 						Namespace: "default",
 						Name:      "service",
 					},
@@ -599,17 +599,17 @@ func TestCacheQueryer_ValidatingWebhookConfigurationsForService(t *testing.T) {
 		},
 	}
 
-	validatingWebhookConfiguration2 := &admissionregistrationv1.ValidatingWebhookConfiguration{
-		TypeMeta:   metav1.TypeMeta{APIVersion: "admissionregistration.k8s.io/v1", Kind: "ValidatingWebhookConfiguration"},
+	validatingWebhookConfiguration2 := &admissionregistrationv1beta1.ValidatingWebhookConfiguration{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "admissionregistration.k8s.io/v1beta1", Kind: "ValidatingWebhookConfiguration"},
 		ObjectMeta: metav1.ObjectMeta{Name: "validatingWebhookConfiguration2"},
-		Webhooks:   []admissionregistrationv1.ValidatingWebhook{},
+		Webhooks:   []admissionregistrationv1beta1.ValidatingWebhook{},
 	}
 
 	cases := []struct {
 		name     string
 		service  *corev1.Service
 		setup    func(t *testing.T, o *storeFake.MockStore)
-		expected []*admissionregistrationv1.ValidatingWebhookConfiguration
+		expected []*admissionregistrationv1beta1.ValidatingWebhookConfiguration
 		isErr    bool
 	}{
 		{
@@ -617,14 +617,14 @@ func TestCacheQueryer_ValidatingWebhookConfigurationsForService(t *testing.T) {
 			service: service,
 			setup: func(t *testing.T, o *storeFake.MockStore) {
 				validatingWebhookConfigurationKey := store.Key{
-					APIVersion: "admissionregistration.k8s.io/v1",
+					APIVersion: "admissionregistration.k8s.io/v1beta1",
 					Kind:       "ValidatingWebhookConfiguration",
 				}
 				o.EXPECT().
 					List(gomock.Any(), gomock.Eq(validatingWebhookConfigurationKey)).
 					Return(testutil.ToUnstructuredList(t, validatingWebhookConfiguration1, validatingWebhookConfiguration2), false, nil)
 			},
-			expected: []*admissionregistrationv1.ValidatingWebhookConfiguration{
+			expected: []*admissionregistrationv1beta1.ValidatingWebhookConfiguration{
 				validatingWebhookConfiguration1,
 			},
 		},
@@ -638,7 +638,7 @@ func TestCacheQueryer_ValidatingWebhookConfigurationsForService(t *testing.T) {
 			service: service,
 			setup: func(t *testing.T, o *storeFake.MockStore) {
 				validatingWebhookConfigurationKey := store.Key{
-					APIVersion: "admissionregistration.k8s.io/v1",
+					APIVersion: "admissionregistration.k8s.io/v1beta1",
 					Kind:       "ValidatingWebhookConfiguration",
 				}
 				o.EXPECT().
@@ -1516,6 +1516,6 @@ func genEventFor(t *testing.T, object runtime.Object, name string) *corev1.Event
 }
 
 func init() {
-	admissionregistrationv1.AddToScheme(scheme.Scheme)
+	admissionregistrationv1beta1.AddToScheme(scheme.Scheme)
 	apiregistrationv1.AddToScheme(scheme.Scheme)
 }

--- a/internal/testutil/generator.go
+++ b/internal/testutil/generator.go
@@ -8,7 +8,7 @@ package testutil
 import (
 	"fmt"
 
-	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -465,19 +465,19 @@ func CreateAPIService(version, group string) *apiregistrationv1.APIService {
 	}
 }
 
-func CreateMutatingWebhookConfiguration(name string) *admissionregistrationv1.MutatingWebhookConfiguration {
-	return &admissionregistrationv1.MutatingWebhookConfiguration{
+func CreateMutatingWebhookConfiguration(name string) *admissionregistrationv1beta1.MutatingWebhookConfiguration {
+	return &admissionregistrationv1beta1.MutatingWebhookConfiguration{
 		TypeMeta:   genTypeMeta(gvk.MutatingWebhookConfiguration),
 		ObjectMeta: genObjectMeta(name, false),
-		Webhooks:   []admissionregistrationv1.MutatingWebhook{},
+		Webhooks:   []admissionregistrationv1beta1.MutatingWebhook{},
 	}
 }
 
-func CreateValidatingWebhookConfiguration(name string) *admissionregistrationv1.ValidatingWebhookConfiguration {
-	return &admissionregistrationv1.ValidatingWebhookConfiguration{
+func CreateValidatingWebhookConfiguration(name string) *admissionregistrationv1beta1.ValidatingWebhookConfiguration {
+	return &admissionregistrationv1beta1.ValidatingWebhookConfiguration{
 		TypeMeta:   genTypeMeta(gvk.ValidatingWebhookConfiguration),
 		ObjectMeta: genObjectMeta(name, false),
-		Webhooks:   []admissionregistrationv1.ValidatingWebhook{},
+		Webhooks:   []admissionregistrationv1beta1.ValidatingWebhook{},
 	}
 }
 

--- a/vendor/github.com/hashicorp/go-plugin/go.mod
+++ b/vendor/github.com/hashicorp/go-plugin/go.mod
@@ -1,5 +1,7 @@
 module github.com/hashicorp/go-plugin
 
+go 1.14
+
 require (
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
 	github.com/golang/protobuf v1.2.0


### PR DESCRIPTION
**What this PR does / why we need it**:

Cluster before Kubernetes 1.16 don't support admissionregistration.k8s.io/v1.
The v1beta1 version was deprecated in k8s 1.16, but is still available
and semantically equivalent.

**Which issue(s) this PR fixes**
- Fixes #1168 

**Special notes for your reviewer**:

This change also fixes a bug in the ObjectStore where it might return
objects for a different version than requested. Instead of the requested
version, the server's default version for the resource was used. With
this change, it is possible that we will have multiple informers for the
same resource at different versions. While inefficient the conversion
logic is on the server, where it belongs.

**Release note**:
```
none
```
