### PR TITLE
Fix multiple kubeconfigs passed in file path

### DIFF
--- a/changelogs/unreleased/1176-GuessWhoSamFoo
+++ b/changelogs/unreleased/1176-GuessWhoSamFoo
@@ -1,0 +1,1 @@
+Fixed bug where kubeconfigs specified by multiple file paths were not watched

--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	golang.org/x/tools v0.0.0-20200716134326-a8f9df4c9543
 	google.golang.org/grpc v1.30.0
 	google.golang.org/grpc/examples v0.0.0-20200707005602-4258d12073b4 // indirect
+	gotest.tools v2.2.0+incompatible // indirect
 	k8s.io/api v0.19.0-alpha.3
 	k8s.io/apiextensions-apiserver v0.19.0-alpha.3
 	k8s.io/apimachinery v0.19.0-beta.2

--- a/go.sum
+++ b/go.sum
@@ -825,6 +825,7 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 h1:tQIYjPdBoyREyB9XMu+nnTclpTYkz2zFM+lzLJFO4gQ=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/pkg/dash/dash.go
+++ b/pkg/dash/dash.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -544,8 +545,19 @@ func enableOpenCensus() error {
 
 // findKubeConfig looks for kube config from .kube or provided by user
 func findKubeConfig(logger log.Logger, kubeConfig string) error {
-	if _, err := os.Stat(kubeConfig); err == nil {
-		logger.Infof("using kube config: %v", kubeConfig)
+	found := false
+	paths := filepath.SplitList(kubeConfig)
+
+	for _, path := range paths {
+		if _, err := os.Stat(path); err == nil {
+			logger.Infof("found kube config: %v", path)
+			found = true
+			continue
+		}
+		logger.Infof("cannot find kube config: %v", path)
+	}
+
+	if found {
 		return nil
 	}
 	return fmt.Errorf("no kubeconfig found")

--- a/pkg/dash/dash_test.go
+++ b/pkg/dash/dash_test.go
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2020 the Octant contributors. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package dash
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vmware-tanzu/octant/internal/log"
+)
+
+func TestRunner_ValidateKubeconfig(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	afero.WriteFile(fs, "/test1", []byte(""), 0755)
+	afero.WriteFile(fs, "/test2", []byte(""), 0755)
+
+	separator := string(filepath.ListSeparator)
+
+	tests := []struct {
+		name     string
+		fileList string
+		expected string
+		isErr    bool
+	}{
+		{
+			name:     "single path",
+			fileList: "/test1",
+			expected: "/test1",
+			isErr:    false,
+		},
+		{
+			name:     "multiple paths",
+			fileList: "/test1" + separator + "/test2",
+			expected: "/test1" + separator + "/test2",
+			isErr:    false,
+		},
+		{
+			name:     "single path not found",
+			fileList: "/unknown",
+			expected: "",
+			isErr:    true,
+		},
+		{
+			name:     "multiple paths not found",
+			fileList: "/unknown" + separator + "/unknown2",
+			expected: "",
+			isErr:    true,
+		},
+		{
+			name:     "multiple file path; missing a config",
+			fileList: "/test1" + separator + "/unknown",
+			expected: "/test1",
+			isErr:    false,
+		},
+		{
+			name:     "invalid path",
+			fileList: "not a filepath",
+			expected: "",
+			isErr:    true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			logger := log.NopLogger()
+			path, err := ValidateKubeConfig(logger, test.fileList, fs)
+			if test.isErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, path, test.expected)
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
`os.Stat` would be passed a string of file paths separated by a color and would not be returning the correct error. This PR will check for the existence of each kube config (although the watcher will fail and octant will not start if any of them do not exist).

**Which issue(s) this PR fixes**
- Partially fixes #518 

