### PR TITLE
Move ellipsis to middle of context; added title on hover

### DIFF
--- a/web/src/app/modules/shared/components/smart/context-selector/context-selector.component.html
+++ b/web/src/app/modules/shared/components/smart/context-selector/context-selector.component.html
@@ -5,7 +5,7 @@
   <clr-dropdown class= "dropdown-top" [clrCloseMenuOnItemClick]="true">
     <button class="dropdown-button" type="button" clrDropdownTrigger>
       <clr-icon shape="cluster"></clr-icon>
-      {{ selected }}
+      {{ selected | truncate }}
       <clr-icon shape="caret down"></clr-icon>
     </button>
     <clr-dropdown-menu class="dropdown-top" *clrIfOpen [clrPosition]="'bottom-right'">
@@ -18,8 +18,9 @@
           [ngClass]="contextClass(context)"
           clrDropdownItem
           (click)="selectContext(context)"
+          title="{{ context.name }}"
         >
-          {{ context.name }}
+          {{ context.name | truncate }}
         </button>
       </ng-container>
     </clr-dropdown-menu>

--- a/web/src/app/modules/shared/components/smart/context-selector/context-selector.component.scss
+++ b/web/src/app/modules/shared/components/smart/context-selector/context-selector.component.scss
@@ -2,12 +2,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 .dropdown-top {
-  max-width: 10rem;
+  max-width: 12rem;
 }
 
 .dropdown-button {
-  max-width: 9rem;
-  text-overflow: ellipsis;
+  max-width: 12rem;
+  text-overflow: clip;
   overflow: hidden;
   padding: 0.15rem 0.4rem 0.15rem 1rem;
 }

--- a/web/src/app/modules/shared/components/smart/context-selector/context-selector.component.spec.ts
+++ b/web/src/app/modules/shared/components/smart/context-selector/context-selector.component.spec.ts
@@ -8,6 +8,7 @@ import { ContextSelectorComponent } from './context-selector.component';
 import { KubeContextService } from '../../../services/kube-context/kube-context.service';
 import { of } from 'rxjs';
 import { By } from '@angular/platform-browser';
+import { TruncatePipe } from '../../../pipes/truncate/truncate.pipe';
 
 const contexts = [
   {
@@ -34,7 +35,7 @@ describe('ContextSelectorComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ContextSelectorComponent],
+      declarations: [ContextSelectorComponent, TruncatePipe],
       providers: [
         { provide: KubeContextService, useClass: MockKubeContextService },
       ],
@@ -88,10 +89,13 @@ describe('ContextSelectorComponent', () => {
   });
 
   it('shows the currently active context name', () => {
+    const pipe = new TruncatePipe();
     const dropDownToggle: HTMLButtonElement = fixture.debugElement.query(
       By.css('button.dropdown-toggle')
     ).nativeElement;
 
-    expect(dropDownToggle.textContent.trim()).toBe(contexts[0].name);
+    expect(dropDownToggle.textContent.trim()).toBe(
+      pipe.transform(contexts[0].name)
+    );
   });
 });

--- a/web/src/app/modules/shared/pipes/truncate/truncate.pipe.spec.ts
+++ b/web/src/app/modules/shared/pipes/truncate/truncate.pipe.spec.ts
@@ -1,0 +1,25 @@
+import { TruncatePipe } from './truncate.pipe';
+
+describe('TruncatePipe', () => {
+  const pipe = new TruncatePipe();
+
+  it('create an instance', () => {
+    expect(pipe).toBeTruthy();
+  });
+
+  it('more than 28 chars', () => {
+    expect(pipe.transform('abcdefghijklmnopqrstuvwxyz123456789')).toEqual(
+      'abcdefghij...vwxyz123456789'
+    );
+  });
+
+  it('equal to 28 chars', () => {
+    expect(pipe.transform('abcdefghijklmnopqrstuvwxyz12')).toEqual(
+      'abcdefghijklmnopqrstuvwxyz12'
+    );
+  });
+
+  it('less than 28 chars', () => {
+    expect(pipe.transform('abc')).toEqual('abc');
+  });
+});

--- a/web/src/app/modules/shared/pipes/truncate/truncate.pipe.ts
+++ b/web/src/app/modules/shared/pipes/truncate/truncate.pipe.ts
@@ -1,0 +1,15 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'truncate',
+})
+export class TruncatePipe implements PipeTransform {
+  transform(name: string): string {
+    if (name.length > 28) {
+      return (
+        name.substr(0, 10) + '...' + name.substr(name.length - 14, name.length)
+      );
+    }
+    return name;
+  }
+}

--- a/web/src/app/modules/shared/shared.module.ts
+++ b/web/src/app/modules/shared/shared.module.ts
@@ -70,6 +70,7 @@ import { PreferencesComponent } from './components/presentation/preferences/pref
 import { HelperComponent } from './components/smart/helper/helper.component';
 import { FilterDeletedDatagridRowPipe } from './pipes/filterDeletedDatagridRow/filter-deleted-datagrid-row.pipe';
 import { ContentTextFilterComponent } from './components/presentation/content-text-filter/content-text-filter.component';
+import { TruncatePipe } from './pipes/truncate/truncate.pipe';
 
 @NgModule({
   declarations: [
@@ -119,6 +120,7 @@ import { ContentTextFilterComponent } from './components/presentation/content-te
     AnsiPipe,
     FormatPathPipe,
     RelativePipe,
+    TruncatePipe,
     SelectorsComponent,
     SingleStatComponent,
     SliderViewComponent,
@@ -203,6 +205,7 @@ import { ContentTextFilterComponent } from './components/presentation/content-te
     TextComponent,
     TimestampComponent,
     TitleComponent,
+    TruncatePipe,
     YamlComponent,
     OverflowLabelsComponent,
     PreferencesComponent,


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR sets a 28 character limit for displaying context names. Longer names are truncated in the middle instead of the end via CSS because of patterns seen in users with context names containing information about the cloud provider, team, environment, etc. A title is added to support viewing the full name on hover.

**Which issue(s) this PR fixes**
- Fixes #909

