### PR TITLE
Fix default theme on load

### DIFF
--- a/changelogs/unreleased/1130-scothis
+++ b/changelogs/unreleased/1130-scothis
@@ -1,0 +1,1 @@
+Fix inconsistent theming of editors

--- a/web/src/app/components/smart/home/home.component.spec.ts
+++ b/web/src/app/components/smart/home/home.component.spec.ts
@@ -41,15 +41,11 @@ describe('HomeComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should use themeService', () => {
-    expect(themeService.currentType()).toBe('light');
-  });
-
   it('should load light theme when component mounts', () => {
     spyOn(themeService, 'loadTheme');
     component.ngOnInit();
 
-    expect(themeService.currentType()).toBe('light');
+    expect(themeService.isLightThemeEnabled()).toBeTruthy();
     expect(themeService.loadTheme).toHaveBeenCalled();
   });
 });

--- a/web/src/app/components/smart/home/home.component.ts
+++ b/web/src/app/components/smart/home/home.component.ts
@@ -1,6 +1,5 @@
 import { Component, OnInit, Renderer2 } from '@angular/core';
 import { ThemeService } from 'src/app/modules/sugarloaf/components/smart/theme-switch/theme-switch.service';
-import { MonacoProviderService } from 'ng-monaco-editor';
 import { ElectronService } from '../../../modules/shared/services/electron/electron.service';
 
 @Component({
@@ -10,14 +9,13 @@ import { ElectronService } from '../../../modules/shared/services/electron/elect
 })
 export class HomeComponent implements OnInit {
   constructor(
-    private monacoService: MonacoProviderService,
     private renderer: Renderer2,
     private themeService: ThemeService,
     private electronService: ElectronService
   ) {}
 
   ngOnInit() {
-    this.themeService.loadTheme(this.monacoService, this.renderer);
+    this.themeService.loadTheme();
 
     if (this.electronService.isElectron()) {
       this.renderer.addClass(document.body, 'electron');

--- a/web/src/app/modules/shared/components/smart/editor/editor.component.ts
+++ b/web/src/app/modules/shared/components/smart/editor/editor.component.ts
@@ -5,14 +5,12 @@ SPDX-License-Identifier: Apache-2.0
 
 import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { EditorView, View } from '../../../models/content';
-import { ThemeService } from '../../../../sugarloaf/components/smart/theme-switch/theme-switch.service';
 import { NamespaceService } from '../../../services/namespace/namespace.service';
 import { ActionService } from '../../../services/action/action.service';
 
 interface Options {
   readOnly: boolean;
   language: string;
-  theme: string;
 }
 
 @Component({
@@ -54,7 +52,6 @@ export class EditorComponent implements OnChanges {
   submitLabel = 'Update';
 
   constructor(
-    private themeService: ThemeService,
     private namespaceService: NamespaceService,
     private actionService: ActionService
   ) {
@@ -75,9 +72,6 @@ export class EditorComponent implements OnChanges {
 
       this.submitAction = view.config.submitAction || this.submitAction;
       this.submitLabel = view.config.submitLabel || this.submitLabel;
-
-      this.options.theme =
-        this.themeService.currentType() === 'dark' ? 'vs-dark' : 'vs';
     }
   }
 

--- a/web/src/app/modules/shared/services/init/init.service.ts
+++ b/web/src/app/modules/shared/services/init/init.service.ts
@@ -1,32 +1,11 @@
-import { Injectable, Renderer2, RendererFactory2 } from '@angular/core';
-import {
-  lightTheme,
-  ThemeService,
-} from '../../../sugarloaf/components/smart/theme-switch/theme-switch.service';
-import { MonacoProviderService } from 'ng-monaco-editor';
+import { Injectable } from '@angular/core';
+import { ThemeService } from '../../../sugarloaf/components/smart/theme-switch/theme-switch.service';
 
 @Injectable()
 export class InitService {
-  private renderer: Renderer2;
-
-  constructor(
-    rendererFactory: RendererFactory2,
-    private themeService: ThemeService,
-    private monacoService: MonacoProviderService
-  ) {
-    this.renderer = rendererFactory.createRenderer(null, null);
-  }
+  constructor(private themeService: ThemeService) {}
 
   init(): Promise<any> {
-    return new Promise((resolve, reject) => {
-      try {
-        this.themeService.loadCSS(lightTheme.assetPath);
-        this.monacoService.changeTheme('vs');
-        this.renderer.addClass(document.body, 'light');
-        resolve();
-      } catch (e) {
-        reject(e);
-      }
-    });
+    return this.themeService.loadTheme();
   }
 }

--- a/web/src/app/modules/sugarloaf/components/smart/theme-switch/theme-switch-button.component.spec.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/theme-switch/theme-switch-button.component.spec.ts
@@ -32,26 +32,16 @@ describe('ThemeSwitchButtonComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should indicate if the light theme is active or not', () => {
-    component.lightThemeEnabled = true;
-    expect(component.lightThemeEnabled).toBe(true);
-
-    component.lightThemeEnabled = false;
-    expect(component.lightThemeEnabled).toBe(false);
-  });
-
   it('should switch theme', () => {
-    component.lightThemeEnabled = false;
-    localStorage.setItem('theme', 'dark');
-    component.switchTheme();
-
-    expect(localStorage.getItem('theme')).toBe('light');
-    expect(component.lightThemeEnabled).toBe(true);
-
     component.switchTheme();
 
     expect(localStorage.getItem('theme')).toBe('dark');
     expect(component.lightThemeEnabled).toBe(false);
+
+    component.switchTheme();
+
+    expect(localStorage.getItem('theme')).toBe('light');
+    expect(component.lightThemeEnabled).toBe(true);
   });
 
   it('should render the right button', () => {
@@ -60,6 +50,6 @@ describe('ThemeSwitchButtonComponent', () => {
     const switchButton = fixture.debugElement.query(By.css('#switchButton'))
       .nativeElement;
 
-    expect(switchButton.innerHTML).toContain('light');
+    expect(switchButton.innerHTML).toContain('dark');
   });
 });

--- a/web/src/app/modules/sugarloaf/components/smart/theme-switch/theme-switch-button.component.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/theme-switch/theme-switch-button.component.ts
@@ -1,35 +1,28 @@
 // Copyright (c) 2019 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
-import { Component, Input, OnInit, Renderer2 } from '@angular/core';
-import { ThemeService, ThemeType } from './theme-switch.service';
-import { MonacoProviderService } from 'ng-monaco-editor';
+import { Component, Input, OnInit } from '@angular/core';
+import { ThemeService } from './theme-switch.service';
 
 @Component({
   selector: 'app-theme-switch-button',
   templateUrl: './theme-switch-button.component.html',
   styleUrls: ['./theme-switch-button.component.scss'],
-  providers: [ThemeService, MonacoProviderService],
+  providers: [ThemeService],
 })
 export class ThemeSwitchButtonComponent implements OnInit {
-  themeType: ThemeType;
   @Input() public collapsed: boolean;
 
   lightThemeEnabled: boolean;
 
-  constructor(
-    private themeService: ThemeService,
-    private monacoService: MonacoProviderService,
-    private renderer: Renderer2
-  ) {}
+  constructor(private themeService: ThemeService) {}
 
   ngOnInit() {
-    this.themeType = this.themeService.currentType();
     this.lightThemeEnabled = this.themeService.isLightThemeEnabled();
   }
 
   switchTheme() {
-    this.lightThemeEnabled = !this.lightThemeEnabled;
-    this.themeService.switchTheme(this.monacoService, this.renderer);
+    this.themeService.switchTheme();
+    this.lightThemeEnabled = this.themeService.isLightThemeEnabled();
   }
 }

--- a/web/src/app/testing/theme-service-stub.ts
+++ b/web/src/app/testing/theme-service-stub.ts
@@ -6,5 +6,5 @@ import { ThemeService } from '../modules/sugarloaf/components/smart/theme-switch
 export const themeServiceStub: Partial<ThemeService> = {
   loadCSS: () => void 0,
   loadTheme: () => void 0,
-  currentType: () => 'light',
+  isLightThemeEnabled: () => true,
 };


### PR DESCRIPTION
**What this PR does / why we need it**:

Octant should use the light theme by default, however, it was using dark
as a quirk of how the starting theme was set. This led to the editor
using a different theme than Octant.

Now the light theme is used consistently by default. A previously
toggled theme is preserved.

**Which issue(s) this PR fixes**
- Fixes #1130 

**Special notes for your reviewer**:

This change reduces the number of places where the theme state is
stored, and synchronized. In particular, we now avoid unnecessary
lookups from local storage, which are quite slow due to being
synchronous disk i/o.

**Release note**:
```
Fix inconsistent theming of editors
```
