### PR TITLE
regression: find the correct custom resource version

### DIFF
--- a/internal/describer/customresource.go
+++ b/internal/describer/customresource.go
@@ -30,7 +30,7 @@ func CustomResourceDefinition(ctx context.Context, name string, o store.Store) (
 	return crd, nil
 }
 
-func AddCRD(ctx context.Context, crd *unstructured.Unstructured, pm *PathMatcher, crdSection *CRDSection, m module.Module) {
+func AddCRD(ctx context.Context, crd *unstructured.Unstructured, pm *PathMatcher, crdSection *CRDSection, m module.Module, s store.Store) {
 	name := crd.GetName()
 
 	logger := log.From(ctx).With("crd-name", name, "module", m.Name())
@@ -45,8 +45,6 @@ func AddCRD(ctx context.Context, crd *unstructured.Unstructured, pm *PathMatcher
 		pm.Register(ctx, pf)
 	}
 
-	// TODO: there could be multiple paths here, so iterate through crd.spec.versions['name']
-
 	versions, err := crdVersions(crd)
 	if err != nil {
 		logger.WithErr(err).Errorf("get crd versions: %w", err)
@@ -54,7 +52,7 @@ func AddCRD(ctx context.Context, crd *unstructured.Unstructured, pm *PathMatcher
 	}
 
 	for _, version := range versions {
-		cd := newCRD(name, crdObjectPath(crd, version))
+		cd := newCRD(name, crdObjectPath(crd, version), version, s)
 		for _, pf := range cd.PathFilters() {
 			pm.Register(ctx, pf)
 		}

--- a/internal/describer/resource_loader.go
+++ b/internal/describer/resource_loader.go
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2020 the Octant contributors. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package describer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/vmware-tanzu/octant/internal/gvk"
+	"github.com/vmware-tanzu/octant/pkg/store"
+)
+
+// ResourceDescriptor describes a custom resource.
+type ResourceDescriptor struct {
+	CustomResourceDefinitionName string
+	Namespace                    string
+	CustomResourceVersion        string
+	CustomResourceName           string
+}
+
+// ResourceLoadResponse is a response from a from ResourceLoader.
+type ResourceLoadResponse struct {
+	// CustomResource is the custom resource.
+	CustomResource *unstructured.Unstructured
+	// CustomResourceDefinition is the custom resource definition.
+	CustomResourceDefinition *unstructured.Unstructured
+}
+
+// ResourceLoader is an interface which loads a custom resource.
+type ResourceLoader interface {
+	// Load loads a custom resource given a ResourceDescriptor.
+	Load(ctx context.Context, d ResourceDescriptor) (*ResourceLoadResponse, error)
+}
+
+// StoreResourceLoader is an interface which loads a custom resource using Octant's store.
+type StoreResourceLoader struct {
+	store store.Store
+}
+
+var _ ResourceLoader = &StoreResourceLoader{}
+
+// NewStoreResourceLoader creates an instance of StoreResourceLoader.
+func NewStoreResourceLoader(s store.Store) *StoreResourceLoader {
+	rl := &StoreResourceLoader{
+		store: s,
+	}
+	return rl
+}
+
+// Load loads a custom resource.
+func (rl *StoreResourceLoader) Load(ctx context.Context, d ResourceDescriptor) (*ResourceLoadResponse, error) {
+	crd, err := CustomResourceDefinition(ctx, d.CustomResourceDefinitionName, rl.store)
+	if err != nil {
+		return nil, fmt.Errorf("find custom resource definition %q: %w", d.CustomResourceDefinitionName, err)
+	}
+
+	crGVK, err := gvk.CustomResource(crd, d.CustomResourceVersion)
+	if err != nil {
+		return nil, fmt.Errorf("get group/version/kind for custom resource: %w", err)
+	}
+
+	apiVersion, kind := crGVK.ToAPIVersionAndKind()
+
+	key := store.Key{
+		Namespace:  d.Namespace,
+		APIVersion: apiVersion,
+		Kind:       kind,
+		Name:       d.CustomResourceName,
+	}
+
+	object, err := rl.store.Get(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+
+	if object == nil {
+		return nil, errors.New("object is nil")
+	}
+
+	return &ResourceLoadResponse{
+		CustomResource:           object,
+		CustomResourceDefinition: crd,
+	}, nil
+}

--- a/internal/describer/resource_loader_test.go
+++ b/internal/describer/resource_loader_test.go
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2020 the Octant contributors. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package describer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/vmware-tanzu/octant/internal/testutil"
+	"github.com/vmware-tanzu/octant/pkg/store"
+	"github.com/vmware-tanzu/octant/pkg/store/fake"
+)
+
+func TestStoreResourceLoader_Load(t *testing.T) {
+	myCR := testutil.CreateCustomResource("my-cr", func(u *unstructured.Unstructured) {
+		u.SetNamespace("test")
+	})
+	myCRD := testutil.ToUnstructured(t, testutil.CreateCRD("my-crd", func(definition *apiextv1.CustomResourceDefinition) {
+		definition.Spec.Group = myCR.GetObjectKind().GroupVersionKind().Group
+		definition.Spec.Names.Kind = myCR.GetKind()
+	}))
+	myCRD.SetAPIVersion("apiextensions.k8s.io/v1")
+
+	type ctorArgs struct {
+		store func(t *testing.T, ctrl *gomock.Controller) store.Store
+	}
+	type args struct {
+		descriptor ResourceDescriptor
+	}
+	tests := []struct {
+		name     string
+		ctorArgs ctorArgs
+		args     args
+		want     *ResourceLoadResponse
+		wantErr  bool
+	}{
+		{
+			name: "in general",
+			ctorArgs: ctorArgs{
+				store: func(t *testing.T, ctrl *gomock.Controller) store.Store {
+					s := fake.NewMockStore(ctrl)
+
+					crdKey, err := store.KeyFromObject(myCRD)
+					require.NoError(t, err)
+					s.EXPECT().
+						Get(gomock.Any(), crdKey).
+						Return(myCRD, nil)
+
+					crKey, err := store.KeyFromObject(myCR)
+					require.NoError(t, err)
+					s.EXPECT().
+						Get(gomock.Any(), crKey).
+						Return(myCR, nil)
+
+					return s
+				},
+			},
+			args: args{
+				descriptor: ResourceDescriptor{
+					CustomResourceDefinitionName: "my-crd",
+					Namespace:                    "test",
+					CustomResourceVersion:        "v1",
+					CustomResourceName:           "my-cr",
+				},
+			},
+			want: &ResourceLoadResponse{
+				CustomResource:           myCR,
+				CustomResourceDefinition: myCRD,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			rl := NewStoreResourceLoader(tt.ctorArgs.store(t, ctrl))
+
+			got, err := rl.Load(context.Background(), tt.args.descriptor)
+			testutil.RequireErrorOrNot(t, tt.wantErr, err)
+
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/gvk/gvk.go
+++ b/internal/gvk/gvk.go
@@ -6,6 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 package gvk
 
 import (
+	"errors"
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -64,9 +65,17 @@ func CustomResource(crd *unstructured.Unstructured, version string) (schema.Grou
 		return schema.GroupVersionKind{}, fmt.Errorf("get crd group: %w", err)
 	}
 
+	if group == "" {
+		return schema.GroupVersionKind{}, errors.New("group is blank")
+	}
+
 	kind, _, err := unstructured.NestedString(crd.Object, "spec", "names", "kind")
 	if err != nil {
 		return schema.GroupVersionKind{}, fmt.Errorf("get crd kind: %w", err)
+	}
+
+	if kind == "" {
+		return schema.GroupVersionKind{}, errors.New("kind is blank")
 	}
 
 	return schema.GroupVersionKind{

--- a/internal/modules/clusteroverview/clusteroverview.go
+++ b/internal/modules/clusteroverview/clusteroverview.go
@@ -80,7 +80,7 @@ func New(ctx context.Context, options Options) (*ClusterOverview, error) {
 				if object == nil {
 					return
 				}
-				describer.AddCRD(ctx, object, pathMatcher, customResourcesDescriber, co)
+				describer.AddCRD(ctx, object, pathMatcher, customResourcesDescriber, co, options.DashConfig.ObjectStore())
 				co.watchedCRDs = append(co.watchedCRDs, object)
 			}
 		}(pathMatcher, customResourcesDescriber),

--- a/internal/modules/overview/overview.go
+++ b/internal/modules/overview/overview.go
@@ -141,7 +141,7 @@ func (co *Overview) bootstrap(ctx context.Context) error {
 				if object == nil {
 					return
 				}
-				describer.AddCRD(ctx, object, pathMatcher, customResourcesDescriber, co)
+				describer.AddCRD(ctx, object, pathMatcher, customResourcesDescriber, co, co.dashConfig.ObjectStore())
 				co.watchedCRDs = append(co.watchedCRDs, object)
 			}
 		}(pathMatcher, customResourcesDescriber),

--- a/internal/objectstore/informer.go
+++ b/internal/objectstore/informer.go
@@ -58,7 +58,8 @@ func (f *informerFactory) watchErrorHandler(gvk schema.GroupVersionKind, stopCh 
 	}
 }
 
-// ForResource creates an informer and starts it given a group/version/resource.
+// ForResource creates an informer and starts it given a group/version/resource. Informers
+// are cached and will not be re-created if they already exist.
 func (f *informerFactory) ForResource(groupVersionKind schema.GroupVersionKind) (informers.GenericInformer, error) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
@@ -71,11 +72,12 @@ func (f *informerFactory) ForResource(groupVersionKind schema.GroupVersionKind) 
 	stopCh := f.informerContextCache.addChild(groupVersionKind)
 
 	gvr, _, err := f.client.Resource(groupVersionKind.GroupKind())
-	gvr.Version = groupVersionKind.Version
 	if err != nil {
 		return nil, fmt.Errorf("unable to find group version resource for group kind %s: %w",
 			groupVersionKind.GroupKind(), err)
 	}
+
+	gvr.Version = groupVersionKind.Version
 
 	dynamicClient, err := f.client.DynamicClient()
 	if err != nil {

--- a/internal/testutil/generator.go
+++ b/internal/testutil/generator.go
@@ -77,7 +77,7 @@ func WithGenericCRD() CRDOption {
 func CreateCRD(name string, options ...CRDOption) *apiextv1.CustomResourceDefinition {
 	crd := &apiextv1.CustomResourceDefinition{
 		TypeMeta:   genTypeMeta(gvk.CustomResourceDefinition),
-		ObjectMeta: genObjectMeta(name, true),
+		ObjectMeta: genObjectMeta(name, false),
 	}
 
 	for _, option := range options {
@@ -87,8 +87,11 @@ func CreateCRD(name string, options ...CRDOption) *apiextv1.CustomResourceDefini
 	return crd
 }
 
+// CustomResourceOption is an option for configuring CreateCustomResource.
+type CustomResourceOption func(u *unstructured.Unstructured)
+
 // CreateCustomResource creates a custom resource.
-func CreateCustomResource(name string) *unstructured.Unstructured {
+func CreateCustomResource(name string, options ...CustomResourceOption) *unstructured.Unstructured {
 	m := map[string]interface{}{
 		"apiVersion": "stable.example.com/v1",
 		"kind":       "CronTab",
@@ -103,6 +106,10 @@ func CreateCustomResource(name string) *unstructured.Unstructured {
 
 	u := &unstructured.Unstructured{Object: m}
 	u.SetNamespace(DefaultNamespace)
+
+	for _, option := range options {
+		option(u)
+	}
 
 	return u
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This change updates Octant to allow it to be able to detect the exact custom resource version to load when generating content. Previously, it used the first version which could be incorrect.

This change also:
* extracts custom resource loading to a new interface
* ensures the CRD is valid when trying to find the GVK for a CRD
* adds helpers to make generating CRD/CR easier

**Release note**:
```
Find the correct custom resource version when generating content
```
