### PR TITLE
Fix for UI stutter when changing views

### DIFF
--- a/changelogs/unreleased/1205-mklanjsek
+++ b/changelogs/unreleased/1205-mklanjsek
@@ -1,0 +1,1 @@
+Fixed UI stutter when changing views

--- a/web/src/app/modules/shared/models/content.ts
+++ b/web/src/app/modules/shared/models/content.ts
@@ -4,6 +4,7 @@
 
 export interface ContentResponse {
   content: Content;
+  currentPath: string;
 }
 
 export interface PathItem {

--- a/web/src/app/modules/shared/services/content/content.service.spec.ts
+++ b/web/src/app/modules/shared/services/content/content.service.spec.ts
@@ -65,7 +65,10 @@ describe('ContentService', () => {
 
     it('triggers a content change', () => {
       service.current.subscribe(current =>
-        expect(current).toEqual({ content: update.content })
+        expect(current).toEqual({
+          content: update.content,
+          currentPath: '/path',
+        })
       );
     });
   });

--- a/web/src/app/modules/sugarloaf/components/smart/content/content.component.spec.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/content/content.component.spec.ts
@@ -17,6 +17,7 @@ import { SugarloafModule } from '../../../sugarloaf.module';
 class ContentServiceMock {
   current = new BehaviorSubject<ContentResponse>({
     content: { extensionComponent: null, viewComponents: [], title: [] },
+    currentPath: '',
   });
   defaultPath = new BehaviorSubject<string>('/path');
   setContentPath = (contentPath: string, params: Params) => {};

--- a/web/src/app/modules/sugarloaf/components/smart/content/content.component.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/content/content.component.ts
@@ -44,6 +44,7 @@ export class ContentComponent implements OnInit, OnDestroy {
   private previousParams: Params;
   private loadingSubscription: Subscription;
   public showSpinner = false;
+  currentPath = '';
 
   constructor(
     private router: Router,
@@ -92,6 +93,7 @@ export class ContentComponent implements OnInit, OnDestroy {
     force: boolean
   ) {
     const urlPath = segments.map(u => u.path).join('/');
+    this.currentPath = urlPath;
     const currentPath = urlPath || this.defaultPath;
     if (
       force ||
@@ -115,6 +117,13 @@ export class ContentComponent implements OnInit, OnDestroy {
   }
 
   private setContent = (contentResponse: ContentResponse) => {
+    if (
+      this.currentPath.length > 0 &&
+      contentResponse.currentPath !== this.currentPath
+    ) {
+      return; // ignore premature updates
+    }
+
     const views = contentResponse.content.viewComponents;
     if (!views || views.length === 0) {
       this.hasReceivedContent = false;


### PR DESCRIPTION
We now ignore premature UI updates that were happening before the frontend had data it needed for displaying the new view. This change also improves how we handle view changes between different namespaces and tweaks slightly the spinner timings.  
 
Signed-off-by: Milan Klanjsek <mklanjsek@pivotal.io>

**Which issue(s) this PR fixes**
- Fixes #1205
