### PR TITLE
fix: bump grpc max receive message size

### DIFF
--- a/internal/commands/dash.go
+++ b/internal/commands/dash.go
@@ -154,6 +154,7 @@ func newOctantCmd(version string, gitCommit string, buildTime string) *cobra.Com
 	octantCmd.Flags().StringSlice("namespace-list", []string{}, "a list of namespaces to use on start")
 	octantCmd.Flags().StringP("plugin-path", "", "", "plugin path")
 	octantCmd.Flags().BoolP("verbose", "v", false, "turn on debug logging")
+	octantCmd.Flags().IntP("client-max-recv-msg-size", "", 1024*1024*16, "client max receiver message size")
 
 	octantCmd.Flags().StringP("accepted-hosts", "", "", "accepted hosts list [DEV]")
 	octantCmd.Flags().Float32P("client-qps", "", 200, "maximum QPS for client [DEV]")

--- a/pkg/plugin/api/api.go
+++ b/pkg/plugin/api/api.go
@@ -9,6 +9,8 @@ import (
 	"context"
 	"net"
 
+	"github.com/spf13/viper"
+
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 
@@ -53,7 +55,10 @@ func (a *grpcAPI) Start(ctx context.Context) error {
 		service: a.Service,
 	}
 
-	s := grpc.NewServer()
+	s := grpc.NewServer(
+		grpc.MaxRecvMsgSize(viper.GetInt("client-max-recv-msg-size")),
+	)
+
 	proto.RegisterDashboardServer(s, dashboardServer)
 
 	logger.Debugf("dashboard plugin api is starting")


### PR DESCRIPTION
Signed-off-by: Zixuan Liu <nodeces@gmail.com>


**What this PR does / why we need it**:

This change is increase grpc max receive message size (4MB to 16 MB), and support set grpc max receive message size from `OCTANT_CLIENT_MAX_RECV_MSG_SIZE` environment variables.

**Which issue(s) this PR fixes**
- Fixes https://github.com/vmware-tanzu/octant/issues/924

**Special notes for your reviewer**:

**Release note**:
```
Increase grpc max receive message size (4MB to 16 MB), and support set grpc max receive message size from `OCTANT_CLIENT_MAX_RECV_MSG_SIZE` environment variables
```
