### PR TITLE
Normalize prettier line endings

### DIFF
--- a/pkg/view/tsgen/tsgen_test.go
+++ b/pkg/view/tsgen/tsgen_test.go
@@ -96,7 +96,9 @@ func TestTSGen_ComponentConfig(t *testing.T) {
 }
 
 func clean(b []byte) string {
-	return strings.TrimSpace(string(b))
+	// normalize Windows line endings
+	str := strings.ReplaceAll(string(b), "\r\n", "\n")
+	return strings.TrimSpace(str)
 }
 
 func assertTemplate(t *testing.T, wantFile string, got []byte) {


### PR DESCRIPTION
Always use line feed as the end of line separator. This will restore
test compatibility on Windows.

Refs #1235

**Release note**:
```
none
```
