### PR TITLE
Remove height from FlexLayoutSection

### DIFF
--- a/changelogs/unreleased/1237-GuessWhoSamFoo
+++ b/changelogs/unreleased/1237-GuessWhoSamFoo
@@ -1,0 +1,1 @@
+Removed height from FlexLayoutSection

--- a/internal/modules/workloads/detail_describer.go
+++ b/internal/modules/workloads/detail_describer.go
@@ -99,10 +99,8 @@ _%s_
 			View:  component.NewMarkdownText(workloadName),
 		},
 		{
-			Width:  component.WidthQuarter,
-			Height: "6em",
-			Margin: "0 0 2em 0",
-			View:   summary.Summary,
+			Width: component.WidthQuarter,
+			View:  summary.Summary,
 		},
 	}
 

--- a/pkg/view/component/donut_chart.go
+++ b/pkg/view/component/donut_chart.go
@@ -10,8 +10,8 @@ import "encoding/json"
 type DonutChartSize int
 
 const (
-	DonutChartSizeSmall  DonutChartSize = 21
-	DonutChartSizeMedium DonutChartSize = 42
+	DonutChartSizeSmall  DonutChartSize = 50
+	DonutChartSizeMedium DonutChartSize = 100
 )
 
 type DonutChartLabels struct {

--- a/pkg/view/component/flexlayout.go
+++ b/pkg/view/component/flexlayout.go
@@ -23,10 +23,8 @@ const (
 
 // FlexLayoutItem is an item in a flex layout.
 type FlexLayoutItem struct {
-	Width  int       `json:"width,omitempty"`
-	Height string    `json:"height,omitempty"`
-	Margin string    `json:"margin,omitempty"`
-	View   Component `json:"view,omitempty"`
+	Width int       `json:"width,omitempty"`
+	View  Component `json:"view,omitempty"`
 }
 
 func (fli *FlexLayoutItem) UnmarshalJSON(data []byte) error {

--- a/pkg/view/component/testdata/config_donutchart.json
+++ b/pkg/view/component/testdata/config_donutchart.json
@@ -9,5 +9,5 @@
         "plural": "tests",
         "singular": "test"
     },
-    "size": 21
+    "size": 50
 }

--- a/web/src/app/modules/shared/components/presentation/donut-chart/donut-chart.component.html
+++ b/web/src/app/modules/shared/components/presentation/donut-chart/donut-chart.component.html
@@ -1,4 +1,4 @@
-<svg [attr.viewBox]="viewBox()" class="donut" height="100%" width="100%">
+<svg [attr.viewBox]="viewBox()" class="donut" [attr.height]="scale" [attr.width]="scale">
   <circle
     [attr.cx]="center()"
     [attr.cy]="center()"

--- a/web/src/app/modules/shared/components/presentation/donut-chart/donut-chart.component.ts
+++ b/web/src/app/modules/shared/components/presentation/donut-chart/donut-chart.component.ts
@@ -19,6 +19,7 @@ export interface SegmentDescriptor {
 })
 export class DonutChartComponent implements OnInit {
   v: DonutChartView;
+  scale: string;
 
   @Input() set view(v: View) {
     this.v = v as DonutChartView;
@@ -32,7 +33,11 @@ export class DonutChartComponent implements OnInit {
 
   constructor() {}
 
-  ngOnInit() {}
+  ngOnInit() {
+    if (this.v?.config?.size) {
+      this.scale = String(this.v.config.size) + '%';
+    }
+  }
 
   trackByDescriptor(index: number, item: SegmentDescriptor) {
     if (!item) {

--- a/web/src/app/modules/shared/components/presentation/flexlayout/flexlayout.component.html
+++ b/web/src/app/modules/shared/components/presentation/flexlayout/flexlayout.component.html
@@ -14,7 +14,6 @@
   >
     <div
       *ngFor="let item of section; trackBy: identifySection"
-      [ngStyle]="sectionStyle(item)"
       class="clr-col-md-{{ item.width / 2 }} content-card-parent"
     >
       <app-content-switcher [view]="item.view"></app-content-switcher>

--- a/web/src/app/modules/shared/components/presentation/flexlayout/flexlayout.component.ts
+++ b/web/src/app/modules/shared/components/presentation/flexlayout/flexlayout.component.ts
@@ -34,14 +34,4 @@ export class FlexlayoutComponent {
   sections: FlexLayoutItem[][];
 
   identifySection = trackByIndex;
-
-  sectionStyle(item: FlexLayoutItem) {
-    return ['height', 'margin'].reduce((previousValue, currentValue) => {
-      if (!item[currentValue]) {
-        return previousValue;
-      }
-
-      return { ...previousValue, [currentValue]: item[currentValue] };
-    }, {});
-  }
 }

--- a/web/src/app/modules/shared/models/content.ts
+++ b/web/src/app/modules/shared/models/content.ts
@@ -97,7 +97,6 @@ export interface GraphvizView extends View {
 
 export interface FlexLayoutItem {
   width: number;
-  height: number;
   view: View;
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes height and margin from FlexLayoutSection. It had only once use case where donut charts were resized for the detail view over a resource viewer. Instead, this takes the donut chart size which was previously unused and passes those values as height/width dimensions for the resulting svg instead.

We should also see modest performance gains as `sectionStyle` will no longer run each second.

**Which issue(s) this PR fixes**
- Fixes #1156 

