### PR TITLE
Add full label selector to store#Key struct

### DIFF
--- a/changelogs/unreleased/1201-ipsi
+++ b/changelogs/unreleased/1201-ipsi
@@ -1,0 +1,1 @@
+Expose full selector capabilities through `Key` object

--- a/internal/objectstore/dynamic_cache.go
+++ b/internal/objectstore/dynamic_cache.go
@@ -8,7 +8,6 @@ package objectstore
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"sync"
@@ -29,6 +28,8 @@ import (
 	kcache "k8s.io/client-go/tools/cache"
 	kretry "k8s.io/client-go/util/retry"
 	sigyaml "sigs.k8s.io/yaml"
+
+	"github.com/pkg/errors"
 
 	"github.com/vmware-tanzu/octant/internal/cluster"
 	"github.com/vmware-tanzu/octant/internal/log"
@@ -278,9 +279,22 @@ func (dc *DynamicCache) listFromInformer(ctx context.Context, key store.Key) (*u
 		l = informer.Lister().ByNamespace(key.Namespace)
 	}
 
+	if key.Selector != nil && key.RequirementsSelector != nil {
+		return nil, false, fmt.Errorf("must provide only one of Key.Selector and Key.RequirementsSelector")
+	}
+
 	var selector = kLabels.Everything()
 	if key.Selector != nil {
 		selector = key.Selector.AsSelector()
+	} else if key.RequirementsSelector != nil {
+		selector = kLabels.NewSelector()
+		for _, r := range *key.RequirementsSelector {
+			requirement, err := kLabels.NewRequirement(r.Key, r.Operator, r.StrValues)
+			if err != nil {
+				return nil, false, errors.Wrap(err, "unable to convert requirement to k8s requirement")
+			}
+			selector = selector.Add(*requirement)
+		}
 	}
 
 	objects, err := l.List(selector)

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -11,6 +11,8 @@ import (
 	"fmt"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/selection"
+
 	"github.com/hashicorp/go-multierror"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -49,11 +51,19 @@ type Store interface {
 
 // Key is a key for the object store.
 type Key struct {
-	Namespace  string      `json:"namespace"`
-	APIVersion string      `json:"apiVersion"`
-	Kind       string      `json:"kind"`
-	Name       string      `json:"name"`
-	Selector   *labels.Set `json:"selector"`
+	Namespace            string         `json:"namespace"`
+	APIVersion           string         `json:"apiVersion"`
+	Kind                 string         `json:"kind"`
+	Name                 string         `json:"name"`
+	Selector             *labels.Set    `json:"selector"`
+	RequirementsSelector *[]Requirement `json:"requirementsSelector"`
+}
+
+// See vendor/k8s.io/apimachinery/pkg/labels/selector.go:120
+type Requirement struct {
+	Key       string             `json:"key"`
+	Operator  selection.Operator `json:"operator"`
+	StrValues []string           `json:"strValues"`
 }
 
 // Validate validates the key.

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -103,7 +103,7 @@ func (k Key) String() string {
 
 	if k.LabelSelector != nil {
 		sb.WriteString(", LabelSelector='")
-		k.labelSelectorString(sb)
+		k.labelSelectorString(&sb)
 		sb.WriteString("'")
 	}
 
@@ -112,7 +112,7 @@ func (k Key) String() string {
 	return sb.String()
 }
 
-func (k Key) labelSelectorString(sb strings.Builder) {
+func (k Key) labelSelectorString(sb *strings.Builder) {
 	if k.LabelSelector.MatchLabels != nil {
 		sb.WriteString("MatchLabels=")
 		data := make([]string, len(k.LabelSelector.MatchLabels))

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -3,6 +3,8 @@ package store
 import (
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -81,6 +83,62 @@ func TestKey_Validate(t *testing.T) {
 			key: Key{
 				APIVersion: "apiVersion",
 				Name:       "name",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Exists operator with values",
+			key: Key{
+				APIVersion: "apiVersion",
+				Name:       "name",
+				Kind:       "kind",
+				LabelSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{Key: "foo", Operator: metav1.LabelSelectorOpExists, Values: []string{"foo1"}},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "DoesNotExist operator with values",
+			key: Key{
+				APIVersion: "apiVersion",
+				Name:       "name",
+				Kind:       "kind",
+				LabelSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{Key: "foo", Operator: metav1.LabelSelectorOpDoesNotExist, Values: []string{"foo1"}},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "In operator without values",
+			key: Key{
+				APIVersion: "apiVersion",
+				Name:       "name",
+				Kind:       "kind",
+				LabelSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{Key: "foo", Operator: metav1.LabelSelectorOpIn},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "NotIn operator without values",
+			key: Key{
+				APIVersion: "apiVersion",
+				Name:       "name",
+				Kind:       "kind",
+				LabelSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{Key: "foo", Operator: metav1.LabelSelectorOpNotIn},
+					},
+				},
 			},
 			wantErr: true,
 		},


### PR DESCRIPTION
Support using all types of label matching in selector, such as exists,
contains, not-exists, etc.


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**
- Fixes #1201

**Special notes for your reviewer**:

**Release note**:
```
* Expose full selector capabilities through `Key` object
```
