### PR TITLE
Add no-op handler for loading action

### DIFF
--- a/internal/api/content_manager.go
+++ b/internal/api/content_manager.go
@@ -188,6 +188,10 @@ func (cm *ContentManager) Handlers() []octant.ClientRequestHandler {
 			RequestType: action.RequestSetNamespace,
 			Handler:     cm.SetNamespace,
 		},
+		{
+			RequestType: CheckLoading,
+			Handler:     cm.Loaded,
+		},
 	}
 }
 
@@ -231,6 +235,11 @@ func (cm *ContentManager) SetContentPath(state octant.State, payload action.Payl
 	cm.logger.With("content-path", contentPath).Debugf("setting content path")
 
 	state.SetContentPath(contentPath)
+	return nil
+}
+
+// Loaded is no-op once content is serving
+func (cm *ContentManager) Loaded(state octant.State, payload action.Payload) error {
 	return nil
 }
 

--- a/internal/api/content_manager_test.go
+++ b/internal/api/content_manager_test.go
@@ -34,6 +34,7 @@ func TestContentManager_Handlers(t *testing.T) {
 	AssertHandlers(t, manager, []string{
 		api.RequestSetContentPath,
 		action.RequestSetNamespace,
+		api.CheckLoading,
 	})
 }
 

--- a/pkg/plugin/api/api_test.go
+++ b/pkg/plugin/api/api_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -187,6 +188,8 @@ func TestAPI(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
 			defer controller.Finish()
+
+			viper.SetDefault("client-max-recv-msg-size", 1024*1024*16)
 
 			appObjectStore := storeFake.NewMockStore(controller)
 			pf := portForwardFake.NewMockPortForwarder(controller)


### PR DESCRIPTION
The uploader component must check if the backend is in loading state each time the component is created. This PR creates a no-op handler to prevent (`received websocket unknown message of type event.octant.dev/unknown with {message: "unknown request action.octant.dev/loading", payload: {…}}`) from spamming the console.

Signed-off-by: GuessWhoSamFoo <foos@vmware.com>
