### PR TITLE
Fixed log component sizing issues

### DIFF
--- a/changelogs/1155-mklanjsek
+++ b/changelogs/1155-mklanjsek
@@ -1,0 +1,1 @@
+Fixed log component sizing issues

--- a/web/src/app/modules/shared/components/smart/logs/logs.component.scss
+++ b/web/src/app/modules/shared/components/smart/logs/logs.component.scss
@@ -3,7 +3,8 @@
  */
 
 .app-logs {
-  height: calc(100% - 140px);
+  display: flex;
+  flex-direction: column;
 
   .log-actions {
     display: flex;
@@ -67,7 +68,7 @@
     }
   }
   .container-logs {
-    height: 100%;
+    flex-grow: 1;
     border: 1px solid #ccc;
     border-radius: 4px;
 


### PR DESCRIPTION
Modified the css stiles for Logs component to make it behave better in plugin environments.

Signed-off-by: Milan Klanjsek <mklanjsek@pivotal.io>

**Which issue(s) this PR fixes**
- Fixes #1155 

**Special notes for your reviewer**:
The original issue was not so easy to reproduce - had to create a plugin with a logs view. 