### PR TITLE
Decouple ThemeService from Monaco

### DIFF
--- a/web/src/app/components/smart/home/home.component.spec.ts
+++ b/web/src/app/components/smart/home/home.component.spec.ts
@@ -1,36 +1,28 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { HomeComponent } from './home.component';
-import {
-  MonacoEditorComponent,
-  MonacoProviderService,
-  MonacoEditorConfig,
-} from 'ng-monaco-editor';
-import { themeServiceStub } from 'src/app/testing/theme-service-stub';
-import { ThemeService } from 'src/app/modules/sugarloaf/components/smart/theme-switch/theme-switch.service';
+import { initServiceStub } from 'src/app/testing/init-service-stub';
+import { InitService } from 'src/app/modules/shared/services/init/init.service';
 
 describe('HomeComponent', () => {
   let component: HomeComponent;
   let fixture: ComponentFixture<HomeComponent>;
-  let themeService: ThemeService;
+  let initService: InitService;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       providers: [
         {
-          provide: ThemeService,
-          useValue: themeServiceStub,
+          provide: InitService,
+          useValue: initServiceStub,
         },
-        MonacoProviderService,
-        MonacoEditorComponent,
-        MonacoEditorConfig,
       ],
       declarations: [HomeComponent],
     }).compileComponents();
   }));
 
   beforeEach(() => {
-    themeService = TestBed.inject(ThemeService);
+    initService = TestBed.inject(InitService);
 
     fixture = TestBed.createComponent(HomeComponent);
     component = fixture.componentInstance;
@@ -41,11 +33,10 @@ describe('HomeComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should load light theme when component mounts', () => {
-    spyOn(themeService, 'loadTheme').and.returnValue(Promise.resolve());
+  it('should initialize when component mounts', () => {
+    spyOn(initService, 'init');
     component.ngOnInit();
 
-    expect(themeService.isLightThemeEnabled()).toBeTruthy();
-    expect(themeService.loadTheme).toHaveBeenCalled();
+    expect(initService.init).toHaveBeenCalled();
   });
 });

--- a/web/src/app/components/smart/home/home.component.ts
+++ b/web/src/app/components/smart/home/home.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, Renderer2 } from '@angular/core';
-import { ThemeService } from 'src/app/modules/sugarloaf/components/smart/theme-switch/theme-switch.service';
+import { InitService } from '../../../modules/shared/services/init/init.service';
 import { ElectronService } from '../../../modules/shared/services/electron/electron.service';
 
 @Component({
@@ -10,14 +10,12 @@ import { ElectronService } from '../../../modules/shared/services/electron/elect
 export class HomeComponent implements OnInit {
   constructor(
     private renderer: Renderer2,
-    private themeService: ThemeService,
+    private initService: InitService,
     private electronService: ElectronService
   ) {}
 
   ngOnInit() {
-    this.themeService.loadTheme().catch(e => {
-      console.error('Unable to load theme:', e);
-    });
+    this.initService.init();
 
     if (this.electronService.isElectron()) {
       this.renderer.addClass(document.body, 'electron');

--- a/web/src/app/modules/denali/components/smart/home/home.component.ts
+++ b/web/src/app/modules/denali/components/smart/home/home.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, Renderer2 } from '@angular/core';
 import {
   darkTheme,
   ThemeService,
-} from '../../../../sugarloaf/components/smart/theme-switch/theme-switch.service';
+} from '../../../../shared/services/theme/theme.service';
 import { MonacoProviderService } from 'ng-monaco-editor';
 
 @Component({

--- a/web/src/app/modules/shared/services/init/init.service.spec.ts
+++ b/web/src/app/modules/shared/services/init/init.service.spec.ts
@@ -1,6 +1,6 @@
 import { inject, TestBed } from '@angular/core/testing';
 import { InitService } from './init.service';
-import { ThemeService } from '../../../sugarloaf/components/smart/theme-switch/theme-switch.service';
+import { ThemeService } from '../theme/theme.service';
 import { MonacoEditorConfig, MonacoProviderService } from 'ng-monaco-editor';
 
 describe('InitService', () => {

--- a/web/src/app/modules/shared/services/init/init.service.ts
+++ b/web/src/app/modules/shared/services/init/init.service.ts
@@ -1,13 +1,30 @@
 import { Injectable } from '@angular/core';
-import { ThemeService } from '../../../sugarloaf/components/smart/theme-switch/theme-switch.service';
+import { ThemeService } from '../theme/theme.service';
+import { MonacoProviderService } from 'ng-monaco-editor';
 
-@Injectable()
+@Injectable({
+  providedIn: 'root',
+})
 export class InitService {
-  constructor(private themeService: ThemeService) {}
+  private syncMonacoTheme: () => void;
+
+  constructor(
+    private themeService: ThemeService,
+    private monacoService: MonacoProviderService
+  ) {
+    // we want a new instance of the handler for each component instance
+    this.syncMonacoTheme = () => {
+      const theme = this.themeService.isLightThemeEnabled() ? 'vs' : 'vs-dark';
+      this.monacoService.changeTheme(theme);
+    };
+  }
 
   init(): void {
-    this.themeService.loadTheme().catch(e => {
-      console.error('Unable to load theme:', e);
-    });
+    this.themeService.loadTheme();
+    // TODO remove this once we are able to define the theme before loading monaco
+    this.monacoService.initMonaco().then(this.syncMonacoTheme);
+
+    this.themeService.onChange(this.syncMonacoTheme);
+    this.syncMonacoTheme();
   }
 }

--- a/web/src/app/modules/shared/services/theme/theme.service.spec.ts
+++ b/web/src/app/modules/shared/services/theme/theme.service.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 import { inject, TestBed } from '@angular/core/testing';
-import { ThemeService } from './theme-switch.service';
+import { ThemeService } from './theme.service';
 import { DOCUMENT } from '@angular/common';
 import { MonacoEditorConfig, MonacoProviderService } from 'ng-monaco-editor';
 

--- a/web/src/app/modules/sugarloaf/components/smart/theme-switch/theme-switch-button.component.spec.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/theme-switch/theme-switch-button.component.spec.ts
@@ -3,29 +3,24 @@
 //
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { ThemeSwitchButtonComponent } from './theme-switch-button.component';
-import { ThemeService } from './theme-switch.service';
+import { ThemeService } from '../../../../shared/services/theme/theme.service';
 import { themeServiceStub } from 'src/app/testing/theme-service-stub';
 import { By } from '@angular/platform-browser';
-import { MonacoEditorConfig, MonacoProviderService } from 'ng-monaco-editor';
 
 describe('ThemeSwitchButtonComponent', () => {
   let component: ThemeSwitchButtonComponent;
   let fixture: ComponentFixture<ThemeSwitchButtonComponent>;
-  let monacoService: MonacoProviderService;
+  let themeService: ThemeService;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ThemeSwitchButtonComponent],
-      providers: [
-        { provide: ThemeService, useValue: themeServiceStub },
-        MonacoEditorConfig,
-        MonacoProviderService,
-      ],
+      providers: [{ provide: ThemeService, useValue: themeServiceStub }],
     }).compileComponents();
   }));
 
   beforeEach(() => {
-    monacoService = TestBed.inject(MonacoProviderService);
+    themeService = TestBed.inject(ThemeService);
 
     fixture = TestBed.createComponent(ThemeSwitchButtonComponent);
     component = fixture.componentInstance;
@@ -35,18 +30,12 @@ describe('ThemeSwitchButtonComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should switch theme', async () => {
-    spyOn(monacoService, 'initMonaco').and.returnValue(Promise.resolve());
+  it('should switch theme', () => {
+    spyOn(themeService, 'switchTheme');
 
-    await component.switchTheme();
+    component.switchTheme();
 
-    expect(localStorage.getItem('theme')).toBe('dark');
-    expect(component.lightThemeEnabled).toBe(false);
-
-    await component.switchTheme();
-
-    expect(localStorage.getItem('theme')).toBe('light');
-    expect(component.lightThemeEnabled).toBe(true);
+    expect(themeService.switchTheme).toHaveBeenCalled();
   });
 
   it('should render the right button', () => {

--- a/web/src/app/modules/sugarloaf/components/smart/theme-switch/theme-switch-button.component.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/theme-switch/theme-switch-button.component.ts
@@ -1,34 +1,38 @@
 // Copyright (c) 2019 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
-import { Component, Input, OnInit } from '@angular/core';
-import { ThemeService } from './theme-switch.service';
+import { Component, Input, OnInit, OnDestroy } from '@angular/core';
+import { ThemeService } from '../../../../shared/services/theme/theme.service';
 
 @Component({
   selector: 'app-theme-switch-button',
   templateUrl: './theme-switch-button.component.html',
   styleUrls: ['./theme-switch-button.component.scss'],
-  providers: [ThemeService],
 })
-export class ThemeSwitchButtonComponent implements OnInit {
+export class ThemeSwitchButtonComponent implements OnInit, OnDestroy {
   @Input() public collapsed: boolean;
 
   lightThemeEnabled: boolean;
 
-  constructor(private themeService: ThemeService) {}
+  private onThemeChange: () => void;
 
-  ngOnInit() {
-    this.lightThemeEnabled = this.themeService.isLightThemeEnabled();
+  constructor(private themeService: ThemeService) {
+    // we want a new instance of the handler for each component instance
+    this.onThemeChange = () => {
+      this.lightThemeEnabled = this.themeService.isLightThemeEnabled();
+    };
+    this.onThemeChange();
   }
 
-  switchTheme(): Promise<any> {
-    return this.themeService
-      .switchTheme()
-      .then(() => {
-        this.lightThemeEnabled = this.themeService.isLightThemeEnabled();
-      })
-      .catch(e => {
-        console.error('Unable to switch theme:', e);
-      });
+  ngOnInit() {
+    this.themeService.onChange(this.onThemeChange);
+  }
+
+  ngOnDestroy() {
+    this.themeService.offChange(this.onThemeChange);
+  }
+
+  switchTheme(): void {
+    this.themeService.switchTheme();
   }
 }

--- a/web/src/app/testing/init-service-stub.ts
+++ b/web/src/app/testing/init-service-stub.ts
@@ -1,0 +1,8 @@
+// Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+import { InitService } from '../modules/shared/services/init/init.service';
+
+export const initServiceStub: Partial<InitService> = {
+  init: () => void 0,
+};

--- a/web/src/app/testing/theme-service-stub.ts
+++ b/web/src/app/testing/theme-service-stub.ts
@@ -1,10 +1,13 @@
 // Copyright (c) 2019 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
-import { ThemeService } from '../modules/sugarloaf/components/smart/theme-switch/theme-switch.service';
+import { ThemeService } from '../modules/shared/services/theme/theme.service';
 
 export const themeServiceStub: Partial<ThemeService> = {
   loadCSS: () => void 0,
-  loadTheme: () => Promise.resolve(),
+  loadTheme: () => void 0,
   isLightThemeEnabled: () => true,
+  onChange: () => void 0,
+  offChange: () => void 0,
+  switchTheme: () => void 0,
 };


### PR DESCRIPTION
**What this PR does / why we need it**:

The ThemeService is now fully decoupled from Monaco. Consumers of Monaco
do not need to take any special steps for the editor to get the correct
theme. More importantly, loading the ThemeService will no longer also
load Monaco.

The ThemeService publishes change events for any interested consumer
when the loaded theme changes.

**Special notes for your reviewer**:

I can't find a hook in ng-monaco-editor that will allow us to define/update
the desired theme for the editor be Monaco is initialized, so we still eagerly
initialize the editor in the InitService.

**Release note**:
```
none
```
