### PR TITLE
Fix electron build

### DIFF
--- a/build.go
+++ b/build.go
@@ -232,21 +232,13 @@ func newCmd(command string, env map[string]string, args ...string) *exec.Cmd {
 }
 
 func buildElectronDev() {
-	listCmd := newCmd("go", nil,
-		"list", "-m", "-f", "{{.Dir}}", "github.com/asticode/go-astilectron-bundler")
-
-	abPath, err := listCmd.Output()
-	if err != nil {
-		log.Fatalf("unable to find astilectron-bundler: %w", err)
-	}
-	abPath = bytes.TrimSpace(abPath)
-
 	runCmdIn(
 		filepath.Join("cmd", "octant-electron"),
 		"go",
 		nil,
 		"run",
-		filepath.Join(string(abPath), "astilectron-bundler"),
+		"github.com/asticode/go-astilectron-bundler/astilectron-bundler",
+		"-o", filepath.Join("..", "..", "build"),
 	)
 }
 

--- a/hacks/tools.go
+++ b/hacks/tools.go
@@ -1,0 +1,12 @@
+// +build tools
+
+/*
+Copyright (c) 2020 the Octant contributors. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package tools
+
+import (
+	_ "github.com/asticode/go-astilectron-bundler/astilectron-bundler"
+)

--- a/vendor/github.com/asticode/go-astilectron-bundler/astilectron-bundler/ldflags.go
+++ b/vendor/github.com/asticode/go-astilectron-bundler/astilectron-bundler/ldflags.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// LDFlags represents ldflags
+type LDFlags map[string][]string
+
+// String returns the ldflags as a string
+func (l LDFlags) String() string {
+	var o []string
+	keys := make([]string, 0, len(l))
+	for k := range l {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		ss := l[k]
+		if len(ss) == 0 {
+			o = append(o, "-"+k)
+			continue
+		}
+		for _, s := range ss {
+			o = append(o, fmt.Sprintf(`-%s %s`, k, s))
+		}
+	}
+	return strings.Join(o, " ")
+}
+
+// Set allows setting the values for use by flag
+func (l LDFlags) Set(s string) error {
+	segments := strings.SplitN(s, ":", 2)
+	flag := segments[0]
+
+	val := l[flag]
+	if len(segments) == 2 {
+		val = strings.Split(segments[1], ",")
+	}
+	l[flag] = append(l[flag], val...)
+
+	return nil
+}

--- a/vendor/github.com/asticode/go-astilectron-bundler/astilectron-bundler/main.go
+++ b/vendor/github.com/asticode/go-astilectron-bundler/astilectron-bundler/main.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/asticode/go-astikit"
+	astibundler "github.com/asticode/go-astilectron-bundler"
+)
+
+var ldflags = LDFlags{}
+
+// Flags
+var (
+	astilectronPath   = flag.String("a", "", "the astilectron path")
+	configurationPath = flag.String("c", "", "the configuration path")
+	darwin            = flag.Bool("d", false, "if set, will add darwin/amd64 to the environments")
+	linux             = flag.Bool("l", false, "if set, will add linux/amd64 to the environments")
+	outputPath        = flag.String("o", "", "the output path")
+	windows           = flag.Bool("w", false, "if set, will add windows/amd64 to the environments")
+)
+
+func init() {
+	flag.Var(ldflags, "ldflags", "extra values to concatenate onto -ldflags, eg X:main.Version=1.0.7")
+}
+
+func main() {
+	// Parse flags
+	cmd := astikit.FlagCmd()
+	flag.Parse()
+
+	// Create logger
+	l := log.New(log.Writer(), log.Prefix(), log.Flags())
+
+	// Get configuration path
+	var cp = *configurationPath
+	var err error
+	if len(cp) == 0 {
+		// Get working directory path
+		var wd string
+		if wd, err = os.Getwd(); err != nil {
+			l.Fatal(fmt.Errorf("os.Getwd failed: %w", err))
+		}
+
+		// Set configuration path
+		cp = filepath.Join(wd, "bundler.json")
+	}
+
+	// Open file
+	var f *os.File
+	if f, err = os.Open(cp); err != nil {
+		l.Fatal(fmt.Errorf("opening file %s failed: %w", cp, err))
+	}
+	defer f.Close()
+
+	// Unmarshal
+	var c *astibundler.Configuration
+	if err = json.NewDecoder(f).Decode(&c); err != nil {
+		l.Fatal(fmt.Errorf("unmarshaling configuration failed: %w", err))
+	}
+
+	// Astilectron path
+	if len(*astilectronPath) > 0 {
+		c.AstilectronPath = *astilectronPath
+	}
+
+	// Output path
+	if len(*outputPath) > 0 {
+		c.OutputPath = *outputPath
+	}
+
+	// Environments
+	if *darwin {
+		c.Environments = append(c.Environments, astibundler.ConfigurationEnvironment{Arch: runtime.GOARCH, OS: "darwin"})
+	}
+	if *linux {
+		c.Environments = append(c.Environments, astibundler.ConfigurationEnvironment{Arch: runtime.GOARCH, OS: "linux"})
+	}
+	if *windows {
+		c.Environments = append(c.Environments, astibundler.ConfigurationEnvironment{Arch: runtime.GOARCH, OS: "windows"})
+	}
+	if len(c.Environments) == 0 {
+		c.Environments = []astibundler.ConfigurationEnvironment{{Arch: runtime.GOARCH, OS: runtime.GOOS}}
+	}
+
+	// Flags
+	if c.LDFlags == nil {
+		c.LDFlags = astibundler.LDFlags(make(map[string][]string))
+	}
+	c.LDFlags.Merge(astibundler.LDFlags(ldflags))
+
+	// Build bundler
+	var b *astibundler.Bundler
+	if b, err = astibundler.New(c, l); err != nil {
+		l.Fatal(fmt.Errorf("building bundler failed: %w", err))
+	}
+
+	// Handle signals
+	b.HandleSignals()
+
+	// Switch on cmd
+	switch cmd {
+	case "bd":
+		// Bind Data
+		for _, env := range c.Environments {
+			if err = b.BindData(env.OS, env.Arch); err != nil {
+				l.Fatal(fmt.Errorf("binding data failed for %s/%s: %w", env.OS, env.Arch, err))
+			}
+		}
+	case "cc":
+		// Clear cache
+		if err = b.ClearCache(); err != nil {
+			l.Fatal(fmt.Errorf("clearing cache failed: %w", err))
+		}
+	default:
+		// Bundle
+		if err = b.Bundle(); err != nil {
+			l.Fatal(fmt.Errorf("bundling failed: %w", err))
+		}
+	}
+}

--- a/vendor/github.com/hashicorp/go-plugin/go.mod
+++ b/vendor/github.com/hashicorp/go-plugin/go.mod
@@ -1,7 +1,5 @@
 module github.com/hashicorp/go-plugin
 
-go 1.15
-
 require (
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
 	github.com/golang/protobuf v1.2.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -36,6 +36,7 @@ github.com/asticode/go-astilectron
 # github.com/asticode/go-astilectron-bundler v0.5.2
 ## explicit
 github.com/asticode/go-astilectron-bundler
+github.com/asticode/go-astilectron-bundler/astilectron-bundler
 # github.com/asticode/go-bindata v1.0.0
 github.com/asticode/go-bindata
 # github.com/daaku/go.zipexe v1.0.0


### PR DESCRIPTION
**What this PR does / why we need it**:

Restores `go run build.go build-electron-dev`

**Special notes for your reviewer**:

- makes sure astilectron-bundler is vendored
- move build output into `./build`

**Release note**:
```
none
```
