### PR TITLE
Fix metadata property appending for TS gen

### DIFF
--- a/pkg/view/tsgen/testdata/link-config.ts
+++ b/pkg/view/tsgen/testdata/link-config.ts
@@ -49,7 +49,7 @@ export class LinkFactory implements ComponentFactory<LinkConfig> {
     return {
       metadata: {
         type: 'link',
-        ...(this.factoryMetadata && { metadata: this.factoryMetadata }),
+        ...this.factoryMetadata,
       },
       config: {
         value: this.value,

--- a/pkg/view/tsgen/ts-support/type-config.ts.tmpl
+++ b/pkg/view/tsgen/ts-support/type-config.ts.tmpl
@@ -48,7 +48,7 @@ export class {{.Name}}Factory implements ComponentFactory<{{.Name}}Config> {
     return {
       metadata: {
         type: '{{.Type}}',
-        ...(this.factoryMetadata && { metadata: this.factoryMetadata}),
+        ...this.factoryMetadata,
       },
       config: {
 {{range .RequiredFields}}        {{.Name}}: this.{{.Name}},


### PR DESCRIPTION
Signed-off-by: Wayne Witzel III <wayne@riotousliving.com>


This was causing the title to be embedded as `{ metadata: metadata: title ...}` and corrects that behavior to `{ metadata: title ...}`