### PR TITLE
Fix external link handling

### DIFF
--- a/web/src/app/modules/shared/components/presentation/link/link.component.html
+++ b/web/src/app/modules/shared/components/presentation/link/link.component.html
@@ -1,11 +1,8 @@
-<ng-template [ngIf]="isAbsolute" [ngIfElse]="relative">
-  <ng-container *ngIf="hasStatus">
-    <app-indicator [status]="view.config.status"></app-indicator>
-  </ng-container>
-  <a [routerLink]="ref">{{ value }}</a>
+<ng-template [ngIf]="isExternal" [ngIfElse]="internal">
+  <a href="{{ ref }}">{{ value }}</a>
 </ng-template>
 
-<ng-template #relative>
+<ng-template #internal>
   <ng-container *ngIf="hasStatus">
     <app-indicator
       [status]="view.config.status"

--- a/web/src/app/modules/shared/components/presentation/link/link.component.ts
+++ b/web/src/app/modules/shared/components/presentation/link/link.component.ts
@@ -6,7 +6,7 @@ import { Component } from '@angular/core';
 import { LinkView } from 'src/app/modules/shared/models/content';
 import { AbstractViewComponent } from '../../abstract-view/abstract-view.component';
 
-const isUrlAbsolute = url =>
+const isUrlExternal = url =>
   url?.indexOf('://') > 0 || url?.indexOf('//') === 0;
 
 @Component({
@@ -17,7 +17,7 @@ const isUrlAbsolute = url =>
 export class LinkComponent extends AbstractViewComponent<LinkView> {
   ref: string;
   value: string;
-  isAbsolute: boolean;
+  isExternal: boolean;
   hasStatus: boolean;
 
   constructor() {
@@ -28,7 +28,7 @@ export class LinkComponent extends AbstractViewComponent<LinkView> {
     const view = this.v;
     this.ref = view.config.ref;
     this.value = view.config.value;
-    this.isAbsolute = isUrlAbsolute(this.ref);
+    this.isExternal = isUrlExternal(this.ref);
 
     if (view.config.status) {
       this.hasStatus = true;


### PR DESCRIPTION
**What this PR does / why we need it**:

External links (previously absolute) are hrefs with a host component and
should not be handled as a router link. Links within Octant should not
contain a scheme or hostname.

**Special notes for your reviewer**:

Partially reverts https://github.com/vmware-tanzu/octant/commit/98f1eec99ba37ed6c4542131cb08da907881413f

**Release note**:
```
none
```
