### PR TITLE
Custom unmarshaler for LinkConfig's StatusDetail

### DIFF
--- a/pkg/view/component/link.go
+++ b/pkg/view/component/link.go
@@ -26,6 +26,32 @@ type LinkConfig struct {
 	StatusDetail Component  `json:"statusDetail,omitempty"`
 }
 
+func (lc *LinkConfig) UnmarshalJSON(data []byte) error {
+	x := struct {
+		Text         string       `json:"value,omitempty"`
+		Ref          string       `json:"ref,omitempty"`
+		Status       TextStatus   `json:"status,omitempty"`
+		StatusDetail *TypedObject `json:"statusDetail,omitempty"`
+	}{}
+
+	if err := json.Unmarshal(data, &x); err != nil {
+		return err
+	}
+
+	lc.Text = x.Text
+	lc.Ref = x.Ref
+	lc.Status = x.Status
+	if x.StatusDetail != nil {
+		sd, err := x.StatusDetail.ToComponent()
+		if err != nil {
+			return err
+		}
+		lc.StatusDetail = sd
+	}
+
+	return nil
+}
+
 type LinkOption func(l *Link)
 
 // NewLink creates a link component

--- a/pkg/view/component/testdata/config_link_status.json
+++ b/pkg/view/component/testdata/config_link_status.json
@@ -1,0 +1,1 @@
+{ "value": "text", "ref": "ref", "status": 1, "statusDetail": { "config": { "value": "Ready" }, "metadata": { "type": "text" } } }

--- a/pkg/view/component/unmarshal_test.go
+++ b/pkg/view/component/unmarshal_test.go
@@ -203,6 +203,25 @@ func Test_unmarshal(t *testing.T) {
 			},
 		},
 		{
+			name:       "link with status",
+			configFile: "config_link_status.json",
+			objectType: "link",
+			expected: &Link{
+				Config: LinkConfig{
+					Text:   "text",
+					Ref:    "ref",
+					Status: TextStatusOK,
+					StatusDetail: &Text{
+						Config: TextConfig{
+							Text: "Ready",
+						},
+						Base: newBase(TypeText, nil),
+					},
+				},
+				Base: newBase(TypeLink, nil),
+			},
+		},
+		{
 			name:       "list",
 			configFile: "config_list.json",
 			objectType: "list",


### PR DESCRIPTION
**What this PR does / why we need it**:

The LinkConfig's StatusDetail is defined as the Component interface,
so we need to unmarshal specific component structs based on the type of
the data being unmarshaled.

**Release note**:
```
none
```
