### PR TITLE
Add validator and action payload for stepper

### DIFF
--- a/changelogs/unreleased/1300-GuessWhoSamFoo
+++ b/changelogs/unreleased/1300-GuessWhoSamFoo
@@ -1,0 +1,1 @@
+Added validator and action payload for stepper

--- a/pkg/view/component/form_test.go
+++ b/pkg/view/component/form_test.go
@@ -18,6 +18,7 @@ func TestFormFieldCheckBox_UnmarshalJSON(t *testing.T) {
 	}
 
 	expected := NewFormFieldCheckBox("label", "name", choices)
+	expected.AddValidator("error", []string{})
 
 	data, err := json.Marshal(&expected)
 	require.NoError(t, err)
@@ -37,6 +38,7 @@ func TestFormFieldRadio_UnmarshalJSON(t *testing.T) {
 	}
 
 	expected := NewFormFieldRadio("label", "name", choices)
+	expected.AddValidator("error", []string{})
 
 	data, err := json.Marshal(&expected)
 	require.NoError(t, err)
@@ -50,6 +52,7 @@ func TestFormFieldRadio_UnmarshalJSON(t *testing.T) {
 
 func TestFormFieldText_UnmarshalJSON(t *testing.T) {
 	expected := NewFormFieldText("label", "name", "text")
+	expected.AddValidator("placeholder", "error", []string{})
 
 	data, err := json.Marshal(&expected)
 	require.NoError(t, err)
@@ -63,6 +66,7 @@ func TestFormFieldText_UnmarshalJSON(t *testing.T) {
 
 func TestFormFieldPassword_UnmarshalJSON(t *testing.T) {
 	expected := NewFormFieldPassword("label", "name", "text")
+	expected.AddValidator("placeholder", "error", []string{})
 
 	data, err := json.Marshal(&expected)
 	require.NoError(t, err)
@@ -76,6 +80,7 @@ func TestFormFieldPassword_UnmarshalJSON(t *testing.T) {
 
 func TestFormFieldNumber_UnmarshalJSON(t *testing.T) {
 	expected := NewFormFieldNumber("label", "name", "999")
+	expected.AddValidator("error", []string{})
 
 	data, err := json.Marshal(&expected)
 	require.NoError(t, err)
@@ -95,6 +100,7 @@ func TestFormFieldSelect_UnmarshalJSON(t *testing.T) {
 	}
 
 	expected := NewFormFieldSelect("label", "name", choices, true)
+	expected.AddValidator("error", []string{})
 
 	data, err := json.Marshal(&expected)
 	require.NoError(t, err)
@@ -108,6 +114,7 @@ func TestFormFieldSelect_UnmarshalJSON(t *testing.T) {
 
 func TestFormFieldTextarea_UnmarshalJSON(t *testing.T) {
 	expected := NewFormFieldTextarea("label", "name", "999")
+	expected.AddValidator("placeholder", "error", []string{})
 
 	data, err := json.Marshal(&expected)
 	require.NoError(t, err)
@@ -121,6 +128,7 @@ func TestFormFieldTextarea_UnmarshalJSON(t *testing.T) {
 
 func TestFormFieldHidden_UnmarshalJSON(t *testing.T) {
 	expected := NewFormFieldHidden("label", "name")
+	expected.AddValidator("placeholder", "error", []string{})
 
 	data, err := json.Marshal(&expected)
 	require.NoError(t, err)

--- a/pkg/view/component/stepper.go
+++ b/pkg/view/component/stepper.go
@@ -15,12 +15,35 @@ type Stepper struct {
 	Config StepperConfig `json:"config"`
 }
 
+// NewStepper creates a stepper component
+func NewStepper(title string, actionName string, steps ...StepConfig) *Stepper {
+	s := append([]StepConfig(nil), steps...)
+	return &Stepper{
+		Base: newBase(TypeStepper, TitleFromString(title)),
+		Config: StepperConfig{
+			Steps:  s,
+			Action: actionName,
+		},
+	}
+}
+
 type stepperMarshal Stepper
 
 func (t *Stepper) MarshalJSON() ([]byte, error) {
 	m := stepperMarshal(*t)
 	m.Metadata.Type = TypeStepper
 	return json.Marshal(&m)
+}
+
+// AddStep adds a step to a stepper
+func (t *Stepper) AddStep(name string, form Form, title string, description string) {
+	step := StepConfig{
+		Name:        name,
+		Form:        form,
+		Title:       title,
+		Description: description,
+	}
+	t.Config.Steps = append(t.Config.Steps, step)
 }
 
 type StepperConfig struct {

--- a/pkg/view/component/stepper_test.go
+++ b/pkg/view/component/stepper_test.go
@@ -11,8 +11,10 @@ import (
 )
 
 func Test_stepper_Marshal(t *testing.T) {
+	fft := NewFormFieldText("test", "test", "test")
+	fft.AddValidator("placeholder", "error message", []string{"required"})
 	form := Form{}
-	form.Fields = append(form.Fields, NewFormFieldText("test", "test", "test"))
+	form.Fields = append(form.Fields, fft)
 
 	tests := []struct {
 		name         string

--- a/pkg/view/component/testdata/stepper.json
+++ b/pkg/view/component/testdata/stepper.json
@@ -18,6 +18,11 @@
         "form": {
           "fields": [
             {
+              "error": "error message",
+              "placeholder": "placeholder",
+              "validators": [
+                "required"
+              ],
               "type": "text",
               "label": "test",
               "name": "test",
@@ -34,6 +39,11 @@
         "form": {
           "fields": [
             {
+              "error": "error message",
+              "placeholder": "placeholder",
+              "validators": [
+                "required"
+              ],
               "type": "text",
               "label": "test",
               "name": "test",


### PR DESCRIPTION
Validator and placeholder:
![Screenshot_20200826_200716](https://user-images.githubusercontent.com/10288252/91379565-d70a9000-e7d7-11ea-9e97-4306c657d205.png)


```
		fft := component.NewFormFieldText("textFormLabel", "textFormName", "")
		fft.AddValidator("placeholder", "this is an error", []string{"required"})

		form := component.Form{
			Fields: []component.FormField{
				fft,
			},
		}

		stepper := component.NewStepper("Test", "testAction")
		stepper.AddStep("Step1", form, "title1", "description1")
		stepper.AddStep("Step2", form, "title2", "description2")
```

Example message on submit with inputs of "test" and "test2" for "Step1" and "Step2" respectively:
```{"type":"action.octant.dev/performAction","payload":{"action":"testAction","formGroup":{"Step1":{"textFormName":"test"},"Step2":{"textFormName":"test2"}}}}```

**Which issue(s) this PR fixes**
- Fixes #1291 
