### PR TITLE
Fix edit service to have sorted selectors

### DIFF
--- a/internal/printer/service.go
+++ b/internal/printer/service.go
@@ -8,6 +8,7 @@ package printer
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -334,6 +335,10 @@ func editServiceAction(ctx context.Context, service *corev1.Service, options Opt
 			seenSelectors[value] = true
 		}
 	}
+
+	sort.Slice(choices, func(i, j int) bool {
+		return choices[i].Value < choices[j].Value
+	})
 
 	form, err := component.CreateFormForObject(octant.ActionOverviewServiceEditor, service,
 		component.NewFormFieldSelect("Selectors", "selectors", choices, true))


### PR DESCRIPTION
Navigating into Service then editing the configuration shows a list of selectors that are not sorted from the backend and can appear in different order each content response.

Also moves the datagrid placeholder and column drawing outside of `setTimeout` to prevent flickering on component redraw.

Signed-off-by: GuessWhoSamFoo <foos@vmware.com>
