### PR TITLE
Add support for selectors in js dashboard client list

### DIFF
--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -127,11 +127,16 @@ func Time() time.Time {
 	return time.Unix(1547211430, 0)
 }
 
-// RequireErrorOrNot or not is a helper that requires an error or not.
-func RequireErrorOrNot(t *testing.T, wantErr bool, err error) {
+// RequireErrorOrNot or not is a helper that requires an error or not. If functions are
+// present, execute them if there was no error.
+func RequireErrorOrNot(t *testing.T, wantErr bool, err error, fns ...func()) {
 	if wantErr {
 		require.Error(t, err)
 		return
 	}
 	require.NoError(t, err)
+
+	for _, fn := range fns {
+		fn()
+	}
 }

--- a/pkg/action/payload.go
+++ b/pkg/action/payload.go
@@ -6,6 +6,8 @@ SPDX-License-Identifier: Apache-2.0
 package action
 
 import (
+	"encoding/json"
+	"fmt"
 	"math"
 	"strconv"
 
@@ -149,4 +151,14 @@ func (p Payload) Float64(key string) (float64, error) {
 	default:
 		return 0, errors.Errorf("unable to handle type %T for %q; got %#v", p[key], key, v)
 	}
+}
+
+// Raw returns a key as bytes.
+func (p Payload) Raw(key string) ([]byte, error) {
+	v, ok := p[key]
+	if !ok {
+		return nil, fmt.Errorf("payload does not contain %q", key)
+	}
+
+	return json.Marshal(v)
 }

--- a/pkg/action/payload_test.go
+++ b/pkg/action/payload_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/vmware-tanzu/octant/internal/testutil"
 )
 
 func TestCreatePayload(t *testing.T) {
@@ -232,6 +234,47 @@ func TestPayload_Uint16(t *testing.T) {
 			require.NoError(t, err)
 
 			assert.Equal(t, test.expected, got)
+		})
+	}
+}
+
+func TestPayload_Raw(t *testing.T) {
+	type args struct {
+		key string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		payload Payload
+		wantErr bool
+		want    []byte
+	}{
+		{
+			name: "key exists",
+			args: args{
+				key: "key",
+			},
+			payload: Payload{
+				"key": "value",
+			},
+			want: []byte(`"value"`),
+		},
+		{
+			name: "key does not exist",
+			args: args{
+				key: "key",
+			},
+			payload: Payload{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.payload.Raw(tt.args.key)
+			testutil.RequireErrorOrNot(t, tt.wantErr, err, func() {
+				require.Equal(t, tt.want, got)
+			})
 		})
 	}
 }

--- a/pkg/plugin/javascript/dashboard_list.go
+++ b/pkg/plugin/javascript/dashboard_list.go
@@ -7,6 +7,7 @@ package javascript
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/dop251/goja"
 
@@ -38,11 +39,18 @@ func (d *DashboardList) Name() string {
 // list is unsuccessful, it will throw a javascript exception.
 func (d *DashboardList) Call(ctx context.Context, vm *goja.Runtime) func(c goja.FunctionCall) goja.Value {
 	return func(c goja.FunctionCall) goja.Value {
+		m := map[string]interface{}{}
+
 		var key store.Key
 		obj := c.Argument(0).ToObject(vm)
 
-		// This will never error since &key is a pointer to a type.
-		_ = vm.ExportTo(obj, &key)
+		// This will never error since &m is a pointer to a type.
+		_ = vm.ExportTo(obj, &m)
+
+		key, err := store.KeyFromPayload(m)
+		if err != nil {
+			panicMessage(vm, fmt.Errorf("key is invalid: %w", err), "")
+		}
 
 		u, _, err := d.storage.ObjectStore().List(ctx, key)
 		if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

When the js key is converted to an octant key, the selector information was elided. This change adds support for key `selectors` and `labelSelectors`.

In support of this change, a new Raw function was added to Payload.

Also, the RequireErrorOrNot test utility was updated to accept an optional list of functions to run when an error was not encountered. With this change, you can write simpler error checking code:

```go
// old
got, err := someCode()
if tt.wantErr {
  require.Error(t, err)
  return
}
require.NoError(t, err)
runCheck(got)

// new
got, err := someCode()
testutil.RequireErrorOrNot(t, tt.wantErr, err, func() {
  runCheck(got)
})
```

**Release note**:
```
JS plugin dashboard client list supports selectors
```
