### PR TITLE
Fixing safari height bug (#1268)

### DIFF
--- a/changelogs/unreleased/1313-alexbarbato
+++ b/changelogs/unreleased/1313-alexbarbato
@@ -1,0 +1,1 @@
+Fixing safari height bug in the header so all browsers render the header the same.

--- a/web/src/app/modules/sugarloaf/components/smart/container/container.component.scss
+++ b/web/src/app/modules/sugarloaf/components/smart/container/container.component.scss
@@ -47,6 +47,7 @@
     background: var(--navigation-background-color);
     flex-wrap: wrap;
     height: auto;
+    flex-basis: auto;
 
     .header-nav {
       padding-left: 1rem;


### PR DESCRIPTION
**What this PR does / why we need it**:
Safari doesn't expand header as screen shrinks.

**Which issue(s) this PR fixes**
- Fixes #1268

**Special notes for your reviewer**:
Not in love with this fix as its kind of hack due to the dependencies on clarity. 

There is an inherit dependency that the height of flex items within the container don't change. Granted, with this fix at least the change would look the same on all browsers.

**Release note**:
```
Fixing safari height bug in the header so all browsers render the header the same.
```
