### PR TITLE
reduce flicker when components update

### DIFF
--- a/web/src/app/modules/shared/components/presentation/datagrid/datagrid.component.html
+++ b/web/src/app/modules/shared/components/presentation/datagrid/datagrid.component.html
@@ -1,10 +1,13 @@
-<div class="clr-row clr-align-items-center clr-justify-content-between" *ngIf="showTitle() || buttonGroup">
+<div
+  class="clr-row clr-align-items-center clr-justify-content-between"
+  *ngIf="showTitle() || buttonGroup"
+>
   <h4 class="clr-col-10" *ngIf="showTitle()">{{ title }}</h4>
-    <clr-dg-action-bar class="clr-col-2" *ngIf="buttonGroup">
-      <app-button-group class="btn-sm" [view]="buttonGroup"></app-button-group>
-    </clr-dg-action-bar>
+  <clr-dg-action-bar class="clr-col-2" *ngIf="buttonGroup">
+    <app-button-group class="btn-sm" [view]="buttonGroup"></app-button-group>
+  </clr-dg-action-bar>
 </div>
-<clr-datagrid [clrDgLoading]="loading$ | async">
+<clr-datagrid [clrDgLoading]="false">
   <clr-dg-placeholder>
     <ng-container *ngIf="placeholder?.length > 0; else emptyPlaceholder">
       {{ placeholder }}

--- a/web/src/app/modules/shared/components/presentation/datagrid/datagrid.component.ts
+++ b/web/src/app/modules/shared/components/presentation/datagrid/datagrid.component.ts
@@ -23,7 +23,7 @@ import { TimestampComparator } from '../../../../../util/timestamp-comparator';
 import { ViewService } from '../../../services/view/view.service';
 import { ActionService } from '../../../services/action/action.service';
 import { AbstractViewComponent } from '../../abstract-view/abstract-view.component';
-import { BehaviorSubject, merge, Observable, timer } from 'rxjs';
+import { BehaviorSubject, Observable } from 'rxjs';
 import { LoadingService } from '../../../services/loading/loading.service';
 import { ButtonGroupView } from '../../../models/content';
 

--- a/web/src/app/modules/shared/components/presentation/list/list.component.html
+++ b/web/src/app/modules/shared/components/presentation/list/list.component.html
@@ -1,5 +1,5 @@
 <app-breadcrumb [path]="title"> </app-breadcrumb>
-<ng-container *ngFor="let item of v?.config.items; trackBy: identifyItem">
+<ng-container *ngFor="let item of items; trackBy: identifyItem">
   <app-view-container
     [view]="item"
     (viewInit)="initDone()"

--- a/web/src/app/modules/shared/components/presentation/list/list.component.ts
+++ b/web/src/app/modules/shared/components/presentation/list/list.component.ts
@@ -1,7 +1,11 @@
 // Copyright (c) 2019 the Octant contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+} from '@angular/core';
 import {
   LinkView,
   ListView,
@@ -23,9 +27,14 @@ export class ListComponent extends AbstractViewComponent<ListView> {
 
   iconName: string;
 
+  items: View[];
+
+  private previous: string;
+
   constructor(
     private iconService: IconService,
-    private viewService: ViewService
+    private viewService: ViewService,
+    private cdr: ChangeDetectorRef
   ) {
     super();
   }
@@ -43,11 +52,15 @@ export class ListComponent extends AbstractViewComponent<ListView> {
         }))
       : [];
 
-    if (this.v.config.items) {
-      this.initialChildCount = this.v.config.items.length;
-      this.v.config.items.forEach(item => {
-        item.totalItems = this.v.config.items.length;
+    const cur = JSON.stringify(current);
+    if (current.config.items && cur !== this.previous) {
+      this.items = this.v.config.items;
+      this.initialChildCount = this.items.length;
+      this.items.forEach(item => {
+        item.totalItems = current.config.items.length;
       });
+      this.previous = cur;
+      this.cdr.markForCheck();
     }
   }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This change reduces flicker when components update by reusing existing resources and reducing the number of times static items change.

- In view-container:
  - Replace on changes hook with a setter that directly invokes loadView. 
  - In loadView use existing component ref if it exists and creates one if it does not.
- In list.component:
  - Update the change detection to look at the items directly. No changes could be updated since the ref to the array items is in did not change. 
  - Use an items property instead of referring to the view itself.
- In datagrid.component:
  - disable the loading indicator for datagrids until the loading timeout rxjs can be solved.

