### PR TITLE
Explicitly allow common js dependencies

### DIFF
--- a/web/angular.json
+++ b/web/angular.json
@@ -17,6 +17,21 @@
         "build": {
           "builder": "@angular-devkit/build-angular:browser",
           "options": {
+            "allowedCommonJsDependencies": [
+              "ansi_up",
+              "css-element-queries",
+              "cytoscape",
+              "cytoscape-cose-bilkent",
+              "cytoscape-dagre",
+              "d3-graphviz",
+              "lodash",
+              "lodash/chunk",
+              "lodash/findIndex",
+              "lodash/forEach",
+              "lodash/pullAt",
+              "lodash/remove",
+              "lodash/uniqueId"
+            ],
             "aot": true,
             "outputPath": "dist/dash-frontend",
             "index": "src/index.html",


### PR DESCRIPTION
This change explictly lists common js modules which octant uses.

In browser, user may have seen

```
WARNING in
/Users/bryan/Development/projects/octant/web/src/app/modules/shared/notifier/notifier.service.ts
depends on 'lodash/findIndex'. CommonJS or AMD dependencies can cause
optimization bailouts.
For more info see:
https://angular.io/guide/build#configuring-commonjs-dependencies
```

