### PR TITLE
Create an Octant log sink for zap messages

### DIFF
--- a/internal/log/sink.go
+++ b/internal/log/sink.go
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2020 the Octant contributors. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package log
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/util/rand"
+)
+
+// Message is an Octant log message.
+type Message struct {
+	// Date is the seconds since epoch.
+	Date int64
+	// LogLevel is the log level.
+	LogLevel string
+	// Location is the source location.
+	Location string
+	// Text is the actual message.
+	Text string
+	// JSON is the JSON payload.
+	JSON string
+}
+
+// ListenCancelFunc is a function for canceling a sink listener.
+type ListenCancelFunc func()
+
+// OctantSinkOption is an option for configuring OctantSink.
+type OctantSinkOption func(o *OctantSink)
+
+// OctantSink is an Octant log sink for zap. It creates a method that
+// allows multiple loggers to listen to message.
+type OctantSink struct {
+	listeners map[string]chan Message
+	converter func(b []byte) (Message, error)
+
+	mu sync.RWMutex
+}
+
+var _ zap.Sink = &OctantSink{}
+
+// NewOctantSink creates an instance of OctantSink.
+func NewOctantSink(options ...OctantSinkOption) *OctantSink {
+	o := &OctantSink{
+		listeners: map[string]chan Message{},
+		converter: ConvertBytesToMessage,
+	}
+
+	for _, option := range options {
+		option(o)
+	}
+
+	return o
+}
+
+// Write converts the message to a Message and sends it to all listeners.
+// The message format is IS8061 date[\t]level[\t]location[\t]text[\t]optional payload[\n]
+func (o *OctantSink) Write(p []byte) (n int, err error) {
+	m, err := o.converter(p)
+	if err != nil {
+		return 0, fmt.Errorf("convert bytes to message: %w", err)
+	}
+
+	o.send(m)
+
+	return len(p), nil
+}
+
+func (o *OctantSink) send(m Message) {
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+
+	for _, ch := range o.listeners {
+		ch <- m
+	}
+}
+
+// Sync is a no-op as.
+func (o *OctantSink) Sync() error {
+	return nil
+}
+
+// Close closes the sink and its listeners.
+func (o *OctantSink) Close() error {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	for k, ch := range o.listeners {
+		close(ch)
+		delete(o.listeners, k)
+	}
+
+	return nil
+}
+
+// Listen creates a channel for listening for messages and cancel func.
+func (o *OctantSink) Listen() (<-chan Message, ListenCancelFunc) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	id := rand.String(6)
+	ch := make(chan Message, 1000)
+	o.listeners[id] = ch
+
+	return ch, func() {
+		o.mu.Lock()
+		defer o.mu.Unlock()
+
+		close(ch)
+
+		delete(o.listeners, id)
+	}
+}
+
+// ConvertBytesToMessage converts a zap message string to a Message instance.
+func ConvertBytesToMessage(b []byte) (Message, error) {
+	parts := strings.Split(strings.TrimSpace(string(b)), "\t")
+	pLen := len(parts)
+
+	if pLen < 4 || pLen > 5 {
+		return Message{}, errors.New("unknown log message format")
+	}
+
+	t, err := time.Parse("2006-01-02T15:04:05.000Z0700", parts[0])
+	if err != nil {
+		return Message{}, fmt.Errorf("invalid log timestamp: %w", err)
+	}
+
+	m := Message{
+		Date:     t.Unix(),
+		LogLevel: parts[1],
+		Location: parts[2],
+		Text:     parts[3],
+	}
+
+	if pLen > 4 {
+		m.JSON = parts[4]
+	}
+
+	return m, nil
+}

--- a/internal/log/sink_test.go
+++ b/internal/log/sink_test.go
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2020 the Octant contributors. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package log
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/vmware-tanzu/octant/internal/testutil"
+)
+
+func TestOctantSink(t *testing.T) {
+	validConvert := func(b []byte) (Message, error) {
+		return Message{}, nil
+	}
+
+	invalidConvert := func(b []byte) (Message, error) {
+		return Message{}, errors.New("invalid")
+	}
+
+	type ctorArgs struct {
+		options []OctantSinkOption
+	}
+	type args struct {
+		message string
+	}
+	tests := []struct {
+		name     string
+		ctorArgs ctorArgs
+		args     args
+		wantErr  bool
+	}{
+		{
+			name: "conversion is success",
+			ctorArgs: ctorArgs{
+				options: []OctantSinkOption{
+					func(o *OctantSink) {
+						o.converter = validConvert
+					},
+				},
+			},
+		},
+		{
+			name: "conversion fails",
+			ctorArgs: ctorArgs{
+				options: []OctantSinkOption{
+					func(o *OctantSink) {
+						o.converter = invalidConvert
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewOctantSink(tt.ctorArgs.options...)
+
+			defer func() {
+				_ = s.Close()
+			}()
+
+			ch, cancel := s.Listen()
+			defer cancel()
+
+			done := make(chan bool, 1)
+
+			n, err := s.Write([]byte(tt.args.message))
+			testutil.RequireErrorOrNot(t, tt.wantErr, err, func() {
+				go func() {
+					<-ch
+					done <- true
+				}()
+				<-done
+				require.Len(t, tt.args.message, n)
+			})
+		})
+	}
+}
+
+func TestConvertBytesToMessage(t *testing.T) {
+	type args struct {
+		bytes []byte
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    Message
+		wantErr bool
+	}{
+		{
+			name: "in general with JSON",
+			args: args{
+				bytes: []byte(strings.Join([]string{
+					"2020-09-03T14:39:51.115-0400",
+					"INFO",
+					"file.go:50",
+					"message",
+					`{"foo": "bar"}`,
+				}, "\t") + "\n"),
+			},
+			want: Message{
+				Date:     1599158391,
+				LogLevel: "INFO",
+				Location: "file.go:50",
+				Text:     "message",
+				JSON:     `{"foo": "bar"}`,
+			},
+		},
+		{
+			name: "in general without JSON",
+			args: args{
+				bytes: []byte(strings.Join([]string{
+					"2020-09-03T14:39:51.115-0400",
+					"INFO",
+					"file.go:50",
+					"message",
+				}, "\t") + "\n"),
+			},
+			want: Message{
+				Date:     1599158391,
+				LogLevel: "INFO",
+				Location: "file.go:50",
+				Text:     "message",
+			},
+		},
+		{
+			name: "invalid format (too short)",
+			args: args{
+				bytes: []byte(strings.Join([]string{
+					"message",
+				}, "\t") + "\n"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid format (too long)",
+			args: args{
+				bytes: []byte(strings.Join([]string{
+					"message",
+					"message",
+					"message",
+					"message",
+					"message",
+					"message",
+				}, "\t") + "\n"),
+			},
+			wantErr: true,
+		}, {
+			name: "invalid timestamp (not ISO8601)",
+			args: args{
+				bytes: []byte(strings.Join([]string{
+					"2020-09-03T14:39:51.115-0400invalid",
+					"INFO",
+					"file.go:50",
+					"message",
+				}, "\t") + "\n"),
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ConvertBytesToMessage(tt.args.bytes)
+			testutil.RequireErrorOrNot(t, tt.wantErr, err, func() {
+				require.Equal(t, tt.want, got)
+			})
+		})
+	}
+}


### PR DESCRIPTION
This change creates an Octant zap log sink. It will allow Octant to process log messages.
