### PR TITLE
fix: add configure GRPC message size to API Client

### DIFF
--- a/changelogs/unreleased/1324-nodece
+++ b/changelogs/unreleased/1324-nodece
@@ -1,0 +1,1 @@
+Add configure GRPC message size to API Client

--- a/pkg/plugin/api/client.go
+++ b/pkg/plugin/api/client.go
@@ -8,6 +8,8 @@ package api
 import (
 	"context"
 
+	"github.com/spf13/viper"
+
 	"google.golang.org/grpc"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
@@ -59,7 +61,10 @@ func NewClient(address string, options ...ClientOption) (*Client, error) {
 
 	if client.DashboardConnection == nil {
 		// NOTE: is it possible to make this secure? Is it even important?
-		conn, err := grpc.Dial(address, grpc.WithInsecure())
+		conn, err := grpc.Dial(address,
+			grpc.WithInsecure(),
+			grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(viper.GetInt("client-max-recv-msg-size"))),
+		)
 		if err != nil {
 			return nil, err
 


### PR DESCRIPTION
Signed-off-by: Zixuan Liu <nodeces@gmail.com>

same PR: https://github.com/vmware-tanzu/octant/pull/1231