### PR TITLE
Create a bottom panel to show secondary content

### DIFF
--- a/web/src/app/modules/shared/components/smart/bottom-panel/bottom-panel.component.html
+++ b/web/src/app/modules/shared/components/smart/bottom-panel/bottom-panel.component.html
@@ -1,0 +1,20 @@
+<div
+  class="slider-container"
+  mwlResizable
+  [resizeCursors]="resizeCursors()"
+  [allowNegativeResizes]="true"
+  (resizing)="updateSliderPosition($event)"
+>
+  <div
+    class="gutter"
+    mwlResizeHandle
+    [resizeEdges]="resizeEdges"
+    [ngClass]="gutterClass()"
+  ></div>
+
+  <a class="slider-container--trigger" (click)="toggle()">
+    <clr-icon shape="angle-double" [@toggleState]="toggleState"></clr-icon>
+  </a>
+
+  <ng-content></ng-content>
+</div>

--- a/web/src/app/modules/shared/components/smart/bottom-panel/bottom-panel.component.scss
+++ b/web/src/app/modules/shared/components/smart/bottom-panel/bottom-panel.component.scss
@@ -1,0 +1,65 @@
+:host-context(body) {
+  --gutter-background-color: #eee;
+  --gutter-background-hover-color: #0079b8;
+  --app-background: #d4d4d4;
+}
+
+:host-context(body.dark) {
+  --gutter-background-color: #25333d;
+  --gutter-background-hover-color: #495a67;
+  --app-background: #121d22;
+}
+
+:host {
+  --slider-height: 1rem;
+
+  z-index: 777;
+  flex: 0 0 auto;
+  height: var(--slider-height);
+  overflow-y: scroll;
+
+  display: flex;
+  flex-direction: column;
+}
+
+mwlResizable {
+  box-sizing: border-box;
+}
+
+.slider-container {
+  flex: 1 1 auto;
+  overflow-y: hidden;
+  display: flex;
+  flex-direction: column;
+
+  &--trigger {
+    position: absolute;
+    right: 1rem;
+    margin: 0.125rem 0;
+    padding: 0 1px;
+
+    transition: all 0.5s ease-out;
+
+    &:hover {
+      background: var(--app-background);
+      border-radius: 30%;
+    }
+
+    &:visited, &:link {
+      color: #4aaed9;
+    }
+  }
+}
+
+
+.gutter {
+  width: 100%;
+  flex: 0 0 0.125rem;
+  background: var(--gutter-background-color);
+
+  &.open:hover {
+    background: var(--gutter-background-hover-color);
+    cursor: ns-resize;
+  }
+}
+

--- a/web/src/app/modules/shared/components/smart/bottom-panel/bottom-panel.component.spec.ts
+++ b/web/src/app/modules/shared/components/smart/bottom-panel/bottom-panel.component.spec.ts
@@ -1,0 +1,153 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import {
+  BottomPanelComponent,
+  minimizedHeight,
+  PanelState,
+  sliderHeightPropKey,
+} from './bottom-panel.component';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { ResizableModule, ResizeEvent } from 'angular-resizable-element';
+import { CssStyleDeclaration } from 'cytoscape';
+
+describe('BottomPanelComponent', () => {
+  let component: BottomPanelComponent;
+  let fixture: ComponentFixture<BottomPanelComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [BottomPanelComponent],
+      imports: [NoopAnimationsModule, ResizableModule],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(BottomPanelComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  describe('resizeCursors', () => {
+    describe('panel is open', () => {
+      beforeEach(() => {
+        component.open = true;
+      });
+
+      it('sets topOrBottom cursor to ns-resize', () => {
+        expect(component.resizeCursors().topOrBottom).toEqual('ns-resize');
+      });
+    });
+
+    describe('panel is closed', () => {
+      beforeEach(() => {
+        component.open = false;
+      });
+
+      it('sets topOrBottom cursor to default', () => {
+        expect(component.resizeCursors().topOrBottom).toEqual('default');
+      });
+    });
+  });
+
+  describe('updateSliderPosition', () => {
+    const event: ResizeEvent = {
+      rectangle: { bottom: 0, left: 0, right: 0, top: 777 },
+      edges: {},
+    };
+
+    beforeEach(() => {
+      spyOn(component, 'setHeight');
+      spyOn(component, 'parentHeight').and.returnValue('100vh');
+    });
+
+    describe('panel is closed', () => {
+      beforeEach(() => {
+        component.open = false;
+      });
+
+      it('does not update the slider position', () => {
+        component.updateSliderPosition(event);
+        expect(component.setHeight).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('panel is open', () => {
+      const expectedHeight = 'calc(100vh - 777px)';
+
+      beforeEach(() => {
+        component.open = true;
+        component.updateSliderPosition(event);
+      });
+
+      it('sets the height of the panel', () => {
+        expect(component.setHeight).toHaveBeenCalledWith(expectedHeight);
+      });
+
+      it('sets the previous open height for the panel', () => {
+        expect(component.previousOpenHeight).toEqual(expectedHeight);
+      });
+    });
+  });
+
+  describe('setHeight', () => {
+    it('sets the height of the panel', () => {
+      component.setHeight('777px');
+      const style = fixture.nativeElement.style as CssStyleDeclaration;
+      const value = style.getPropertyValue(sliderHeightPropKey);
+      expect(value).toEqual('777px');
+    });
+  });
+
+  describe('toggle', () => {
+    beforeEach(() => {
+      spyOn(component, 'setHeight');
+    });
+
+    describe('when panel is open', () => {
+      beforeEach(() => {
+        component.open = true;
+        component.toggle();
+      });
+
+      it('closes the panel', () => {
+        expect(component.open).toBeFalse();
+      });
+
+      it('sets the toggle state to closed', () => {
+        expect(component.toggleState).toEqual(PanelState.Closed);
+      });
+
+      it('sets the height to the minimized height', () => {
+        expect(component.setHeight).toHaveBeenCalledWith(minimizedHeight);
+      });
+    });
+
+    describe('when panel is closed', () => {
+      beforeEach(() => {
+        component.open = false;
+        component.toggle();
+      });
+
+      it('opens the panel', () => {
+        expect(component.open).toBeTrue();
+      });
+
+      it('sets the toggle state to open', () => {
+        expect(component.toggleState).toEqual(PanelState.Open);
+      });
+
+      it('sets the height to the minimized height', () => {
+        expect(component.setHeight).toHaveBeenCalledWith(
+          component.previousOpenHeight
+        );
+      });
+    });
+  });
+
+  describe('gutterClass', () => {
+    it('returns if the gutter class should be activated', () => {
+      component.open = false;
+      expect(component.gutterClass()).toEqual({ open: false });
+    });
+  });
+});

--- a/web/src/app/modules/shared/components/smart/bottom-panel/bottom-panel.component.ts
+++ b/web/src/app/modules/shared/components/smart/bottom-panel/bottom-panel.component.ts
@@ -1,0 +1,93 @@
+import { Component, ElementRef, OnInit } from '@angular/core';
+import { ResizeEvent } from 'angular-resizable-element';
+import {
+  animate,
+  state,
+  style,
+  transition,
+  trigger,
+} from '@angular/animations';
+
+export const minimizedHeight = '2rem';
+export const sliderHeightPropKey = '--slider-height';
+
+const transitionExpr = (from: string, to: string): string => `${from} => ${to}`;
+
+export enum PanelState {
+  Open = 'open',
+  Closed = 'closed',
+}
+
+@Component({
+  selector: 'app-bottom-panel',
+  templateUrl: './bottom-panel.component.html',
+  styleUrls: ['./bottom-panel.component.scss'],
+  animations: [
+    trigger('toggleState', [
+      state(PanelState.Closed, style({ transform: 'rotate(0)' })),
+      state(PanelState.Open, style({ transform: 'rotate(-180deg)' })),
+      transition(
+        transitionExpr(PanelState.Closed, PanelState.Open),
+        animate('500ms ease-out')
+      ),
+      transition(
+        transitionExpr(PanelState.Open, PanelState.Closed),
+        animate('500ms ease-in')
+      ),
+    ]),
+  ],
+})
+export class BottomPanelComponent implements OnInit {
+  open = false;
+  toggleState = PanelState.Closed;
+  previousOpenHeight = '50vh';
+  resizeEdges = { top: true };
+
+  constructor(private elRef: ElementRef) {}
+
+  ngOnInit() {
+    this.setHeight(minimizedHeight);
+  }
+
+  parentHeight() {
+    return this.elRef.nativeElement.parentNode.offsetHeight + 'px';
+  }
+
+  resizeCursors() {
+    return {
+      topLeft: 'nw-resize',
+      topRight: 'ne-resize',
+      bottomLeft: 'sw-resize',
+      bottomRight: 'se-resize',
+      leftOrRight: 'col-resize',
+      topOrBottom: this.open ? 'ns-resize' : 'default',
+    };
+  }
+
+  updateSliderPosition(event: ResizeEvent) {
+    if (!this.open) {
+      return;
+    }
+
+    const panelTop = event.rectangle.top;
+    const height = `calc(${this.parentHeight()} - ${panelTop}px)`;
+    this.setHeight(height);
+    this.previousOpenHeight = height;
+  }
+
+  setHeight(height: string) {
+    this.elRef.nativeElement.style.setProperty(sliderHeightPropKey, height);
+  }
+
+  toggle() {
+    this.open = !this.open;
+    this.toggleState = this.open ? PanelState.Open : PanelState.Closed;
+    this.setHeight(this.open ? this.previousOpenHeight : minimizedHeight);
+  }
+
+  gutterClass() {
+    return {
+      open: this.open,
+    };
+  }
+}

--- a/web/src/app/modules/shared/shared.module.ts
+++ b/web/src/app/modules/shared/shared.module.ts
@@ -76,6 +76,7 @@ import { dynamicComponents } from './dynamic-components';
 import { ViewContainerComponent } from './components/view/view-container.component';
 import { MissingComponentComponent } from './components/missing-component/missing-component.component';
 import { OctantTooltipComponent } from './components/presentation/octant-tooltip/octant-tooltip';
+import { BottomPanelComponent } from './components/smart/bottom-panel/bottom-panel.component';
 
 @NgModule({
   declarations: [
@@ -146,6 +147,7 @@ import { OctantTooltipComponent } from './components/presentation/octant-tooltip
     ViewContainerComponent,
     MissingComponentComponent,
     OctantTooltipComponent,
+    BottomPanelComponent,
   ],
   entryComponents: [
     AlertComponent,
@@ -282,6 +284,7 @@ import { OctantTooltipComponent } from './components/presentation/octant-tooltip
     ViewHostDirective,
     ViewContainerComponent,
     OctantTooltipComponent,
+    BottomPanelComponent,
   ],
 })
 export class SharedModule {}

--- a/web/src/app/modules/sugarloaf/components/smart/container/container.component.html
+++ b/web/src/app/modules/sugarloaf/components/smart/container/container.component.html
@@ -1,54 +1,57 @@
-<div class="main-container">
-  <div class="notifier">
-    <app-notifier></app-notifier>
-  </div>
-  <div class="uploader">
-    <app-uploader></app-uploader>
-  </div>
-  <header class="header header-6">
-    <div class="branding">
-      <a [routerLink]="['/']">
-        <clr-icon shape="octant-logo"></clr-icon>
-        <span class="title">Octant</span>
-      </a>
+<div class="octant-container">
+  <div class="main-container">
+    <div class="notifier">
+      <app-notifier></app-notifier>
     </div>
-    <div class="header-nav">
-      <div class="input-filter">
-        <app-input-filter></app-input-filter>
+    <div class="uploader">
+      <app-uploader></app-uploader>
+    </div>
+    <header class="header header-6">
+      <div class="branding">
+        <a [routerLink]="['/']">
+          <clr-icon shape="octant-logo"></clr-icon>
+          <span class="title">Octant</span>
+        </a>
+      </div>
+      <div class="header-nav">
+        <div class="input-filter">
+          <app-input-filter></app-input-filter>
+        </div>
+      </div>
+      <div class="header-actions">
+        <a
+          [routerLink]="['/configuration/apply']"
+          class="header-link"
+          title="Create or update resources"
+        >
+          <clr-icon shape="upload"></clr-icon>
+          <span>Apply YAML</span>
+        </a>
+        <div class="namespace-switcher header-centered">
+          <app-namespace></app-namespace>
+        </div>
+        <app-context-selector class="header-centered"></app-context-selector>
+        <app-helper class="header-centered"></app-helper>
+      </div>
+    </header>
+    <div class="content-container">
+      <div class="navigation">
+        <app-navigation></app-navigation>
+      </div>
+      <div class="content-area">
+        <router-outlet></router-outlet>
       </div>
     </div>
-    <div class="header-actions">
-      <a
-        [routerLink]="['/configuration/apply']"
-        class="header-link"
-        title="Create or update resources"
-      >
-        <clr-icon shape="upload"></clr-icon>
-        <span>Apply YAML</span>
-      </a>
-      <div class="namespace-switcher header-centered">
-        <app-namespace></app-namespace>
-      </div>
-      <app-context-selector class="header-centered"></app-context-selector>
-      <app-helper class="header-centered"></app-helper>
-    </div>
-  </header>
-  <div class="content-container">
-    <div class="navigation">
-      <app-navigation></app-navigation>
-    </div>
-    <div class="content-area">
-      <router-outlet></router-outlet>
-    </div>
   </div>
-  <div class="quick-switcher">
-    <app-quick-switcher></app-quick-switcher>
-  </div>
-  <div class="preferences">
-    <app-preferences
-      [(isOpen)]="preferencesOpened"
-      [preferences]="preferences"
-      (preferencesChanged)="preferencesChanged($event)"
-    ></app-preferences>
-  </div>
+  <app-bottom-panel *ngIf="isBottomPanelEnabled"></app-bottom-panel>
+</div>
+<div class="quick-switcher">
+  <app-quick-switcher></app-quick-switcher>
+</div>
+<div class="preferences">
+  <app-preferences
+    [(isOpen)]="preferencesOpened"
+    [preferences]="preferences"
+    (preferencesChanged)="preferencesChanged($event)"
+  ></app-preferences>
 </div>

--- a/web/src/app/modules/sugarloaf/components/smart/container/container.component.scss
+++ b/web/src/app/modules/sugarloaf/components/smart/container/container.component.scss
@@ -2,12 +2,32 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 @mixin electron-header {
   -webkit-app-region: drag;
   padding-left: var(--padding-left);
 }
 
+:host-context(body) {
+  --background-color: #fafafa;
+}
+
+:host-context(body.dark) {
+  --background-color: #1b2a32;
+}
+
+.octant-container {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  height: 100vh;
+  background-color: var(--background-color);
+}
+
 .main-container {
+  flex: 1 1 auto;
+  overflow-y: scroll;
+
   // Navigation's color variables for Light Theme.
 
   :host-context(body) {
@@ -98,3 +118,11 @@
     }
   }
 }
+
+.main-container {
+  .content-container {
+    flex: 1;
+    overflow-y: scroll;
+  }
+}
+

--- a/web/src/app/modules/sugarloaf/components/smart/container/container.component.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/container/container.component.ts
@@ -36,6 +36,10 @@ export class ContainerComponent implements OnInit, OnDestroy {
   preferencesOpened = false;
   preferences: Preferences;
 
+  // This is a feature flag for the app-wide bottom panel. It can be removed
+  // once the bottom panel is integrated.
+  isBottomPanelEnabled = false;
+
   constructor(
     private websocketService: WebsocketService,
     private iconService: IconService

--- a/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.scss
+++ b/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.scss
@@ -91,7 +91,7 @@
 
   .navigation-items-collapsed {
     flex-grow: 1;
-    overflow-y: hidden;
+    overflow-y: scroll;
   }
 
   .flyout-header {
@@ -160,3 +160,4 @@
     display: flex;
   }
 }
+

--- a/web/src/stories/other/bottom-panel.stories.ts
+++ b/web/src/stories/other/bottom-panel.stories.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2020 the Octant contributors. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { storiesOf } from '@storybook/angular';
+
+storiesOf('Other/Bottom Panel', module).add('Panel', () => {
+  return {
+    styles: [],
+
+    template: `
+    <div style="display: flex; flex-direction: column; height: 500px; background: hsl(198, 83%, 94%)">
+        <div style="flex: 1 1 auto; background: hsl(198, 0%, 98%); overflow-y: scroll">
+            <p *ngFor="let item of [].constructor(30); index as i">row {{i+1}}</p>
+        </div>
+        <app-bottom-panel>
+            bottom content
+        </app-bottom-panel>
+    </div>
+        `,
+  };
+});


### PR DESCRIPTION
**What this PR does / why we need it**:

This set of changes creates a bottom panel component to show secondary content. This change is meant to supersede the functionality provided in the SliderView component by introducing the following features:

- Only includes a bottom panel and not the contents of the bottom panel. This reduces coupling and allows the parent component to decide what is shown. 
- Allows for resizing the content without using the "ghost" method that was previously employed
- Is designed to live in the same container as other content rather than as an overlay. ie. It will push up content when it is activated. 

This change also includes:
- Temporarily makes the collapsed navigation view scrollable. 

**Special notes for your reviewer**:

The panel is included, but it is not activated. To see it working, set `isBottomPanelEnabled` to true in ContainerComponent and add some content to `app-bottom-panel` in the view.
