### PR TITLE
Consolidated scss dependencies

### DIFF
--- a/web/angular.json
+++ b/web/angular.json
@@ -63,6 +63,11 @@
               "node_modules/@clr/ui/clr-ui-dark.min.css",
               "src/styles.scss"
             ],
+            "stylePreprocessorOptions": {
+              "includePaths": [
+                "src/sass/"
+              ]
+            },
             "scripts": [
               "node_modules/@webcomponents/custom-elements/custom-elements.min.js",
               "node_modules/@clr/icons/clr-icons.min.js"
@@ -103,7 +108,12 @@
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
             "browserTarget": "dash-frontend:build",
-            "disableHostCheck": true
+            "disableHostCheck": true,
+            "stylePreprocessorOptions": {
+              "includePaths": [
+                "src/sass/"
+              ]
+            }
           },
           "configurations": {
             "production": {
@@ -136,7 +146,12 @@
             "codeCoverageExclude": [
               "src/app/models/**/*",
               "src/environments/**/*"
-            ]
+            ],
+            "stylePreprocessorOptions": {
+              "includePaths": [
+                "src/sass/"
+              ]
+            }
           }
         },
         "lint": {

--- a/web/src/app/modules/shared/components/presentation/expression-selector/expression-selector.component.scss
+++ b/web/src/app/modules/shared/components/presentation/expression-selector/expression-selector.component.scss
@@ -2,8 +2,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-@import '../../../../../../sass/mixins';
-@import '../../../../../../sass/variables';
+@import '_mixins';
+@import '_variables';
 
 .selector--expression {
   @include pill(var(--selector-color));

--- a/web/src/app/modules/shared/components/presentation/expression-selector/expression-selector.component.scss
+++ b/web/src/app/modules/shared/components/presentation/expression-selector/expression-selector.component.scss
@@ -2,7 +2,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-@import '../../../../../../styles';
+@import '../../../../../../sass/mixins';
+@import '../../../../../../sass/variables';
 
 .selector--expression {
   @include pill(var(--selector-color));

--- a/web/src/app/modules/shared/components/presentation/labels/labels.component.scss
+++ b/web/src/app/modules/shared/components/presentation/labels/labels.component.scss
@@ -2,8 +2,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-@import '../../../../../../styles';
-
 .view-labels {
   display: flex;
   flex-direction: row;

--- a/web/src/app/modules/shared/components/presentation/octant-tooltip/octant-tooltip.scss
+++ b/web/src/app/modules/shared/components/presentation/octant-tooltip/octant-tooltip.scss
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-@import '../../../../../../sass/variables';
+@import '_variables';
 
 // work around clarity tooltip limitations
 .tooltip-content {

--- a/web/src/app/modules/shared/components/presentation/octant-tooltip/octant-tooltip.scss
+++ b/web/src/app/modules/shared/components/presentation/octant-tooltip/octant-tooltip.scss
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-@import '../../../../../../styles';
+@import '../../../../../../sass/variables';
 
 // work around clarity tooltip limitations
 .tooltip-content {

--- a/web/src/app/modules/shared/components/presentation/overflow-labels/overflow-labels.component.scss
+++ b/web/src/app/modules/shared/components/presentation/overflow-labels/overflow-labels.component.scss
@@ -2,8 +2,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-@import '../../../../../../styles';
-
 :host ::ng-deep .labels-wrapper {
   display: flex;
   align-items: center;

--- a/web/src/app/modules/shared/components/presentation/overflow-selectors/overflow-selectors.component.scss
+++ b/web/src/app/modules/shared/components/presentation/overflow-selectors/overflow-selectors.component.scss
@@ -2,8 +2,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-@import '../../../../../../styles';
-
 :host ::ng-deep .selectors-wrapper {
   display: flex;
   align-items: center;

--- a/web/src/app/modules/shared/components/smart/filters/filters.component.scss
+++ b/web/src/app/modules/shared/components/smart/filters/filters.component.scss
@@ -2,8 +2,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-@import '../../../../../../sass/mixins';
-@import '../../../../../../sass/variables';
+@import '_mixins';
+@import '_variables';
 
 .filters {
   display: flex;

--- a/web/src/app/modules/shared/components/smart/filters/filters.component.scss
+++ b/web/src/app/modules/shared/components/smart/filters/filters.component.scss
@@ -2,7 +2,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-@import '../../../../../../styles';
+@import '../../../../../../sass/mixins';
+@import '../../../../../../sass/variables';
 
 .filters {
   display: flex;

--- a/web/src/app/modules/sugarloaf/components/smart/input-filter/input-filter.component.scss
+++ b/web/src/app/modules/sugarloaf/components/smart/input-filter/input-filter.component.scss
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-@import '../../../../../../styles';
+@import '../../../../../../sass/variables';
 
 .input-filter {
   // Dropdown's color variables for Light Theme.

--- a/web/src/app/modules/sugarloaf/components/smart/input-filter/input-filter.component.scss
+++ b/web/src/app/modules/sugarloaf/components/smart/input-filter/input-filter.component.scss
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-@import '../../../../../../sass/variables';
+@import '_variables';
 
 .input-filter {
   // Dropdown's color variables for Light Theme.


### PR DESCRIPTION
Consolidated the scss dependencies to eliminate the budget related build warnings. 

We used to directly include the global `styles.scss` file in 7 of our component scss files and that was creating the output that was larger than budgeted.  Changed it, so now we include only what's necessary to reduce the scss footprint. 

Signed-off-by: Milan Klanjsek <mklanjsek@pivotal.io>

**Which issue(s) this PR fixes**
- Fixes #1338 
