### PR TITLE
Fix pv list generation when claimRef pvc cannot be found

### DIFF
--- a/changelogs/unreleased/1358-GuessWhoSamFoo
+++ b/changelogs/unreleased/1358-GuessWhoSamFoo
@@ -1,0 +1,1 @@
+Fixed pv list generation when claimRef pvc cannot be found

--- a/internal/objectstatus/objectstatus.go
+++ b/internal/objectstatus/objectstatus.go
@@ -37,6 +37,7 @@ var (
 		{apiVersion: "v1", kind: "Pod"}:                               pod,
 		{apiVersion: "v1", kind: "ReplicationController"}:             replicationController,
 		{apiVersion: "v1", kind: "Service"}:                           service,
+		{apiVersion: "v1", kind: "PersistentVolume"}:                  persistentVolume,
 		{apiVersion: "extensions/v1beta1", kind: "Ingress"}:           runIngressStatus,
 		{apiVersion: "apiregistration.k8s.io/v1", kind: "APIService"}: apiService,
 	}

--- a/internal/objectstatus/persistent_volume.go
+++ b/internal/objectstatus/persistent_volume.go
@@ -1,0 +1,52 @@
+/*
+Copyright (c) 2020 the Octant contributors. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package objectstatus
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+
+	"github.com/vmware-tanzu/octant/pkg/store"
+	"github.com/vmware-tanzu/octant/pkg/view/component"
+)
+
+func persistentVolume(ctx context.Context, object runtime.Object, o store.Store) (ObjectStatus, error) {
+	if object == nil {
+		return ObjectStatus{}, errors.Errorf("cronjob is nil")
+	}
+
+	pv := &corev1.PersistentVolume{}
+
+	if err := scheme.Scheme.Convert(object, pv, 0); err != nil {
+		return ObjectStatus{}, errors.Wrap(err, "convert object to v1 PersistentVolume")
+	}
+
+	if pv.Spec.ClaimRef != nil {
+		claim := pv.Spec.ClaimRef
+		pvc, err := o.Get(ctx, store.Key{
+			Kind:       claim.Kind,
+			Namespace:  claim.Namespace,
+			Name:       claim.Name,
+			APIVersion: claim.APIVersion,
+		})
+		if pvc == nil || err != nil {
+			claimWarning := fmt.Sprintf("PVC %s/%s cannot be found", claim.Namespace, claim.Name)
+			return ObjectStatus{
+				nodeStatus: component.NodeStatusWarning,
+				Details:    []component.Component{component.NewText(claimWarning)}}, nil
+		}
+	}
+
+	return ObjectStatus{
+		nodeStatus: component.NodeStatusOK,
+		Details:    []component.Component{component.NewText("v1 PersistentVolume is OK")},
+	}, nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR prevents a content response error if a persistent volume has a claimRef to a persistent volume claim that no longer exists (e.g. when the reclaim policy is `retain`). Moves attempt to `Get` into object status to show a warning instead. 

**Which issue(s) this PR fixes**
- Fixes #1249 

Signed-off-by: GuessWhoSamFoo <foos@vmware.com>
