### PR TITLE
default provided namespaces to initial namespace when empty

### DIFF
--- a/changelogs/unreleased/838-wwitzel3
+++ b/changelogs/unreleased/838-wwitzel3
@@ -1,0 +1,1 @@
+default provided namespaces to initial namespace when empty

--- a/internal/cluster/namespace.go
+++ b/internal/cluster/namespace.go
@@ -91,10 +91,16 @@ func namespaces(dc dynamic.Interface) ([]corev1.Namespace, error) {
 	return nsList.Items, nil
 }
 
+// InitialNamespace returns the initial namespace for Octant
 func (n *namespaceClient) InitialNamespace() string {
 	return n.initialNamespace
 }
 
+// ProvidedNamespaces returns the list of namespaces provided.
+// If no namespaces  are provided, it will default to returning the InitialNamespace
 func (n *namespaceClient) ProvidedNamespaces() []string {
+	if len(n.providedNamespaces) == 0 {
+		n.providedNamespaces = []string{n.initialNamespace}
+	}
 	return n.providedNamespaces
 }

--- a/internal/cluster/namespace_test.go
+++ b/internal/cluster/namespace_test.go
@@ -18,8 +18,6 @@ import (
 func Test_namespaceClient_Names(t *testing.T) {
 	scheme := runtime.NewScheme()
 
-	// NOTE: this should be reverted to the k8s.io/client-go/dynamic/fake when bug fix is
-	// merged upstream
 	dc := dynamicfake.NewSimpleDynamicClient(scheme,
 		newUnstructured("v1", "Namespace", "", "default"),
 		newUnstructured("v1", "Namespace", "", "app-1"),
@@ -32,6 +30,19 @@ func Test_namespaceClient_Names(t *testing.T) {
 
 	expected := []string{"app-1", "default"}
 	assert.Equal(t, expected, got)
+}
+
+func Test_namespaceClient_providedNamespaces(t *testing.T) {
+	providedNamespaces := []string{"default", "user-1"}
+
+	scheme := runtime.NewScheme()
+	dc := dynamicfake.NewSimpleDynamicClient(scheme)
+	nc := newNamespaceClient(dc, nil, "default", providedNamespaces)
+
+	assert.Equal(t, providedNamespaces, nc.ProvidedNamespaces())
+
+	nc = newNamespaceClient(dc, nil, "default", []string{})
+	assert.Equal(t, nc.ProvidedNamespaces(), []string{"default"})
 }
 
 func Test_namespaceClient_InitialNamespace(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Wayne Witzel III <wayne@riotousliving.com>


This solves the issue of the namespace not found warning being displayed when an initial namespace is provided and the client does not have permissions to list namespaces.

Since Octant merges the provided namespace list with the API namespace list and de-dupe entries, defaulting the provided namespace list to the initial namespace when empty prevents this warning from being dislpayed.

**Which issue(s) this PR fixes**
- Fixes #838 
