### PR TITLE
Fixed unreferenced configmap in container to crash summary tab

### DIFF
--- a/internal/printer/container.go
+++ b/internal/printer/container.go
@@ -406,21 +406,16 @@ func describeEnvRows(ctx context.Context, namespace string, vars []corev1.EnvVar
 			}
 
 			u, err := objectStore.Get(ctx, key)
-			if err != nil {
-				return nil, err
-			}
-
-			if u != nil {
+			if u == nil || err != nil {
+				row["Value"] = component.NewText("<none>")
+				row["Source"] = component.NewText(fmt.Sprintf("%s:%s", ref.Name, ref.Key))
+			} else {
 				configMap := &corev1.ConfigMap{}
 				if err := kubernetes.FromUnstructured(u, configMap); err != nil {
 					return nil, err
 				}
-
 				row["Value"] = component.NewText(configMap.Data[ref.Key])
 				row["Source"] = source
-			} else {
-				row["Value"] = component.NewText("<none>")
-				row["Source"] = component.NewText(fmt.Sprintf("%s:%s", ref.Name, ref.Key))
 			}
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Prevents something like below from crashing the summary tab:

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: kuard-env
  labels:
    app: kuard
spec:
  replicas: 1
  selector:
    matchLabels:
      app: kuard
  template:
    metadata:
      labels:
        app: kuard
    spec:
      containers:
        - name: kuard
          image: gcr.io/kuar-demo/kuard-amd64:1
          ports:
          - containerPort: 8080
            name: http
            protocol: TCP
          env:
            - name: LOG_LEVEL
              valueFrom:
                configMapKeyRef:
                  name: env-config
                  key: log_level
                  optional: true
```

**Which issue(s) this PR fixes**
n/a

Signed-off-by: GuessWhoSamFoo <foos@vmware.com>