### PR TITLE
Fix for the Schema validation serve issue

### DIFF
--- a/web/angular.json
+++ b/web/angular.json
@@ -108,12 +108,7 @@
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
             "browserTarget": "dash-frontend:build",
-            "disableHostCheck": true,
-            "stylePreprocessorOptions": {
-              "includePaths": [
-                "src/sass/"
-              ]
-            }
+            "disableHostCheck": true
           },
           "configurations": {
             "production": {


### PR DESCRIPTION
Change in PR #1357 was too aggressive and unnecessarily added the `stylePreprocessorOptions` option inside the `serve` section of angular.json files. This change takes it out to make sure the serve warks again.

Signed-off-by: Milan Klanjsek <mklanjsek@pivotal.io>
