### PR TITLE
Unmarshal ResourceViewer Nodes with details

### DIFF
--- a/pkg/view/component/testdata/config_resource_viewer.json
+++ b/pkg/view/component/testdata/config_resource_viewer.json
@@ -24,7 +24,13 @@
       "name": "my-nginx",
       "apiVersion": "v1",
       "kind": "Service",
-      "status": "ok"
+      "status": "ok",
+      "details": [
+        {
+          "metadata": { "type": "text" },
+          "config": { "value": "my-nginx" }
+        }
+      ]
     },
     "71c2b4eb-2949-11e9-b356-42010a8000e5": {
       "name": "nginx-deployment",

--- a/pkg/view/component/unmarshal_test.go
+++ b/pkg/view/component/unmarshal_test.go
@@ -307,6 +307,9 @@ func Test_unmarshal(t *testing.T) {
 							APIVersion: "v1",
 							Kind:       "Service",
 							Status:     "ok",
+							Details: []Component{
+								NewText("my-nginx"),
+							},
 						},
 						"71c2b4eb-2949-11e9-b356-42010a8000e5": Node{
 							Name:       "nginx-deployment",


### PR DESCRIPTION
**What this PR does / why we need it**:

We need to unmarshal each ResourceViewer Node to convert it's details
from the Component interface back to a specific type.

**Special notes for your reviewer**:

Without this plugins are unable to define details for the selected node in the resource viewer.

**Release note**:
```
n/a
```
