### PR TITLE
Restore the collapsed left navigation functionality

### DIFF
--- a/web/src/app/modules/sugarloaf/components/smart/container/container.component.scss
+++ b/web/src/app/modules/sugarloaf/components/smart/container/container.component.scss
@@ -25,9 +25,6 @@
 }
 
 .main-container {
-  flex: 1 1 auto;
-  overflow-y: scroll;
-
   // Navigation's color variables for Light Theme.
 
   :host-context(body) {
@@ -116,13 +113,6 @@
       padding: 0;
       overflow: hidden;
     }
-  }
-}
-
-.main-container {
-  .content-container {
-    flex: 1;
-    overflow-y: scroll;
   }
 }
 

--- a/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.scss
+++ b/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.scss
@@ -91,7 +91,7 @@
 
   .navigation-items-collapsed {
     flex-grow: 1;
-    overflow-y: scroll;
+    overflow-y: hidden;
   }
 
   .flyout-header {


### PR DESCRIPTION
Changes introduced in #1341 inadvertently broke the left navigation in collapsed state. Namely, the flyout menu was positioned incorrectly and in some cases was not accessible after the scrollbar showed up. This change brings the old functionality back. 

The Navigation component simply does not support scrolling and that will be addressed during the navigation redesign (see #1353), but for the short term (0.16 release) we should keep that functionality the way it was.

Signed-off-by: Milan Klanjsek <mklanjsek@pivotal.io>

