### PR TITLE
Update quick switcher UI; add namespace to search

### DIFF
--- a/changelogs/unreleased/1381-GuessWhoSamFoo
+++ b/changelogs/unreleased/1381-GuessWhoSamFoo
@@ -1,0 +1,1 @@
+Updated quick switcher UI and added namespace to search

--- a/web/src/app/modules/sugarloaf/components/smart/quick-switcher/quick-switcher.component.html
+++ b/web/src/app/modules/sugarloaf/components/smart/quick-switcher/quick-switcher.component.html
@@ -17,6 +17,11 @@
       (ngModelChange)="onInputChange($event)"
     />
     <table class="table table-noborder destinations">
+      <thead *ngIf="searchingNamespace">
+        <tr>
+          <th>Searching Namespaces</th>
+        </tr>
+      </thead>
       <tbody>
         <tr
           *ngFor="
@@ -27,10 +32,15 @@
           (mouseover)="activeIndex = index"
           (click)="onEnter($event)"
           [class.destination-active]="index == activeIndex"
+          [attr.aria-label]="destination.title"
         >
           <td>{{ destination.title }}</td>
+          <td>{{ destination.type }}</td>
         </tr>
       </tbody>
     </table>
+  </div>
+  <div class="modal-footer">
+    <pre>{{ helperText}}<code>!</code></pre>
   </div>
 </clr-modal>

--- a/web/src/app/modules/sugarloaf/components/smart/quick-switcher/quick-switcher.component.scss
+++ b/web/src/app/modules/sugarloaf/components/smart/quick-switcher/quick-switcher.component.scss
@@ -17,14 +17,37 @@
 
   .filter-input {
     padding: 1rem 0.5rem;
+    font-size: 22px;
   }
 
-  td {
-    padding-left: 11px !important;
-  }
-
-  .destinations td {
+  th {
     text-align: left;
+    font-size: 10px;
+    border: 0;
+    text-transform: uppercase;
+  }
+
+  tbody {
+    display: block;
+    overflow: auto;
+    max-height: 60vh;
+    cursor: pointer;
+  }
+
+  tr {
+    padding-left: 11px !important;
+    display: table;
+    width: 100%;
+  }
+
+  .destinations td:first-child {
+    text-align: left;
+    font-weight: 500;
+  }
+
+  .destinations td:last-child {
+    text-align: right;
+    opacity: 0.6;
   }
 
   ::ng-deep .clr-input,
@@ -41,17 +64,25 @@
     display: none;
   }
 
-  ::ng-deep .modal-body,
-  ::ng-deep .modal-content {
-    padding: 0;
-  }
-
   .destination-active {
     background-color: var(--destinationActive-bg-color);
     color: var(--destinationActive-color);
   }
 
-  .destination-active:hover {
-    cursor: pointer;
+  .modal-footer {
+    padding-top: 10px;
+    justify-content: flex-start;
+    font-size: x-small;
+
+    pre {
+      border: none;
+      margin: 0;
+    }
+
+    code {
+      background-color: var(--destinationActive-bg-color);
+      padding: 2px;
+      block-size: auto;
+    }
   }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/10288252/93806966-d3afcc00-fbfe-11ea-94d9-e3219ff1bf66.png)

This PR improves the quick switcher by:
 - Allowing the user to see current search input while scrolling through results
 - Using case insensitive search (e.g. `Deployment` would yield no results)
 - Moving resource groupings to the right so results are easier to read
 - Adding experimental support for namespace search via starting with `!`

Signed-off-by: GuessWhoSamFoo <foos@vmware.com>

