### PR TITLE
Link namespace dropdown to overview pages

### DIFF
--- a/internal/api/navigation_manager.go
+++ b/internal/api/navigation_manager.go
@@ -165,7 +165,7 @@ func NavigationGenerator(ctx context.Context, state octant.State, config Navigat
 	return sections, nil
 }
 
-// CreateNavigationEvent creates a namespaces event.
+// CreateNavigationEvent creates a navigation event.
 func CreateNavigationEvent(sections []navigation.Navigation, defaultPath string) oevent.Event {
 	return oevent.Event{
 		Type: oevent.EventTypeNavigation,

--- a/web/src/app/modules/shared/components/presentation/code/code.component.html
+++ b/web/src/app/modules/shared/components/presentation/code/code.component.html
@@ -5,7 +5,7 @@
     title="Copy to clipboard"
     (click)="copyToClipboard(value)"
   >
-    <clr-icon shape="copy-to-clipboard" size="32"></clr-icon>
+    <clr-icon shape="copy-to-clipboard" size="28"></clr-icon>
   </button>
 </div>
 <pre>

--- a/web/src/app/modules/shared/components/presentation/code/code.component.scss
+++ b/web/src/app/modules/shared/components/presentation/code/code.component.scss
@@ -4,6 +4,10 @@
 
 .code-button-wrapper {
   position: absolute;
-  margin-top: 20px;
+  margin-top: 10px;
   right: 30px;
+}
+
+pre {
+  min-height: 40px;
 }

--- a/web/src/app/modules/shared/components/smart/editor/editor.component.ts
+++ b/web/src/app/modules/shared/components/smart/editor/editor.component.ts
@@ -48,6 +48,9 @@ export class EditorComponent extends AbstractViewComponent<EditorView> {
     private actionService: ActionService
   ) {
     super();
+
+    this.uri =
+      'file:text-' + Math.random().toString(36).substring(2, 15) + '.yaml';
   }
 
   update() {
@@ -59,8 +62,6 @@ export class EditorComponent extends AbstractViewComponent<EditorView> {
       this.pristineValue = view.config.value;
       this.options.readOnly = view.config.readOnly;
       this.options.language = view.config.language;
-      this.uri =
-        'file:text-' + Math.random().toString(36).substring(2, 15) + '.yaml';
     }
 
     this.submitAction = view.config.submitAction || this.submitAction;

--- a/web/src/app/modules/shared/services/content/content.service.ts
+++ b/web/src/app/modules/shared/services/content/content.service.ts
@@ -35,7 +35,6 @@ const emptyContentResponse: ContentResponse = {
   providedIn: 'root',
 })
 export class ContentService {
-  defaultPath = new BehaviorSubject<string>('');
   current = new BehaviorSubject<ContentResponse>(emptyContentResponse);
   viewScrollPos = new BehaviorSubject<number>(0);
   debouncedScrollPos = new BehaviorSubject<number>(0);

--- a/web/src/app/modules/shared/services/namespace/namespace.service.ts
+++ b/web/src/app/modules/shared/services/namespace/namespace.service.ts
@@ -41,9 +41,11 @@ export class NamespaceService {
     });
 
     this.activeNamespace.subscribe(namespace => {
-      websocketService.sendMessage('action.octant.dev/setNamespace', {
-        namespace,
-      });
+      if (namespace.length > 0) {
+        websocketService.sendMessage('action.octant.dev/setNamespace', {
+          namespace,
+        });
+      }
     });
 
     this.notifierSession = this.notifierService.createSession();

--- a/web/src/app/modules/shared/services/navigation/navigation.service.spec.ts
+++ b/web/src/app/modules/shared/services/navigation/navigation.service.spec.ts
@@ -50,9 +50,6 @@ describe('NavigationService', () => {
 
         backendService.triggerHandler('event.octant.dev/navigation', update);
         svc.current.subscribe(current => expect(current).toEqual(update));
-        contentService.defaultPath.subscribe(defaultPath =>
-          expect(defaultPath).toEqual(update.defaultPath)
-        );
       }
     ));
 

--- a/web/src/app/modules/shared/services/navigation/navigation.service.ts
+++ b/web/src/app/modules/shared/services/navigation/navigation.service.ts
@@ -11,6 +11,7 @@ import { ContentService } from '../content/content.service';
 import { NavigationEnd, Router, RouterEvent } from '@angular/router';
 import { filter } from 'rxjs/operators';
 import { LoadingService } from '../loading/loading.service';
+import { NamespaceService } from '../namespace/namespace.service';
 
 const emptyNavigation: Navigation = {
   sections: [],
@@ -40,8 +41,6 @@ export class NavigationService {
     websocketService.registerHandler('event.octant.dev/navigation', data => {
       const update = data as Navigation;
       this.current.next(update);
-
-      contentService.defaultPath.next(update.defaultPath);
       this.updateLastSelection();
     });
 

--- a/web/src/app/modules/sugarloaf/components/smart/apply-yaml/apply-yaml.component.html
+++ b/web/src/app/modules/sugarloaf/components/smart/apply-yaml/apply-yaml.component.html
@@ -3,7 +3,13 @@
   <span>Apply YAML</span>
 </div>
 
-<clr-modal [(clrModalOpen)]="isOpen" [clrModalSize]="'xl'" [clrModalClosable]="true" [clrModalStaticBackdrop]="false">
+<clr-modal
+  [(clrModalOpen)]="isOpen"
+  [clrModalSize]="'xl'"
+  [clrModalClosable]="true"
+  [clrModalStaticBackdrop]="false"
+  [clrModalSkipAnimation]="true"
+>
   <h3 class="modal-title">Apply YAML</h3>
   <div class="modal-body">
       <app-view-editor [view]="editorView"></app-view-editor>

--- a/web/src/app/modules/sugarloaf/components/smart/namespace/namespace.component.html
+++ b/web/src/app/modules/sugarloaf/components/smart/namespace/namespace.component.html
@@ -1,5 +1,5 @@
 <div class="app-namespace-selector">
-  <ng-template [ngIf]="showDropdown()" [ngIfElse]="hideDropdown">
+  <ng-template [ngIf]="showDropdown" [ngIfElse]="hideDropdown">
     <clr-dropdown class="dropdown-top" [clrCloseMenuOnItemClick]="true">
       <button type="button" class="dropdown-button" clrDropdownTrigger>
         <clr-icon shape="namespace"></clr-icon>
@@ -21,6 +21,7 @@
             [ngClass]="namespaceClass(namespace)"
             clrDropdownItem
             (click)="selectNamespace(namespace)"
+            [routerLink]="'/overview/namespace/' + namespace"
           >
             {{ namespace }}
           </button>

--- a/web/src/app/modules/sugarloaf/components/smart/namespace/namespace.component.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/namespace/namespace.component.ts
@@ -2,7 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  OnDestroy,
+  OnInit,
+} from '@angular/core';
 import { NamespaceService } from 'src/app/modules/shared/services/namespace/namespace.service';
 import trackByIdentity from 'src/app/util/trackBy/trackByIdentity';
 import { Subscription } from 'rxjs';
@@ -12,6 +18,7 @@ import { NavigationService } from '../../../../shared/services/navigation/naviga
   selector: 'app-namespace',
   templateUrl: './namespace.component.html',
   styleUrls: ['./namespace.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class NamespaceComponent implements OnInit, OnDestroy {
   namespaces: string[];
@@ -23,36 +30,46 @@ export class NamespaceComponent implements OnInit, OnDestroy {
   };
   lastSelection: number;
   activeUrl: string;
+  showDropdown: boolean;
 
   private namespaceSubscription: Subscription;
 
   constructor(
     private namespaceService: NamespaceService,
-    private navigationService: NavigationService
+    private navigationService: NavigationService,
+    private cdr: ChangeDetectorRef
   ) {}
 
   ngOnInit() {
     this.namespaceSubscription = this.namespaceService.activeNamespace.subscribe(
       (namespace: string) => {
         this.currentNamespace = namespace;
+        this.cdr.detectChanges();
       }
     );
 
     this.namespaceSubscription = this.namespaceService.availableNamespaces.subscribe(
       (namespaces: string[]) => {
         this.namespaces = namespaces;
+        this.cdr.detectChanges();
       }
     );
 
-    this.navigationService.current.subscribe(
-      navigation => (this.navigation = navigation)
-    );
+    this.navigationService.current.subscribe(navigation => {
+      this.navigation = navigation;
+      this.cdr.detectChanges();
+    });
 
-    this.navigationService.lastSelection.subscribe(
-      selection => (this.lastSelection = selection)
-    );
+    this.navigationService.activeUrl.subscribe(url => {
+      this.activeUrl = url;
+      this.cdr.detectChanges();
+    });
 
-    this.navigationService.activeUrl.subscribe(url => (this.activeUrl = url));
+    this.navigationService.lastSelection.subscribe(selection => {
+      this.lastSelection = selection;
+      this.showDropdown = this.hasDropdown();
+      this.cdr.detectChanges();
+    });
   }
 
   ngOnDestroy(): void {
@@ -68,7 +85,7 @@ export class NamespaceComponent implements OnInit, OnDestroy {
     this.namespaceService.setNamespace(namespace);
   }
 
-  showDropdown() {
+  hasDropdown(): boolean {
     if (this.lastSelection && this.navigation.sections[this.lastSelection]) {
       const url = this.navigation.sections[this.lastSelection].path;
       return !this.isClusterSpecific(url);
@@ -76,27 +93,32 @@ export class NamespaceComponent implements OnInit, OnDestroy {
     return true;
   }
 
-  private namespaceFromUrl(): string {
-    const paths = this.activeUrl.split('/');
-    const len = paths.length;
-    if (len > 1 && paths[len - 2] === 'namespaces') {
-      const hashIndex = paths[len - 1].indexOf('#');
-      return hashIndex > 0
-        ? paths[len - 1].substring(0, hashIndex)
-        : paths[len - 1];
+  private namespaceFromUrl(url: string): string {
+    if (url) {
+      const paths = url.split('/');
+      const len = paths.length;
+      if (len > 1 && paths[len - 2] === 'namespaces') {
+        const hashIndex = paths[len - 1].indexOf('#');
+        return hashIndex > 0
+          ? paths[len - 1].substring(0, hashIndex)
+          : paths[len - 1];
+      }
     }
     return '';
   }
 
   private isClusterSpecific(url: string) {
-    const ns = this.namespaceFromUrl();
+    const ns = this.namespaceFromUrl(url);
     if (ns.length > 0) {
       this.selectNamespace(ns);
       return false;
     }
 
     if (url.includes('cluster-overview')) {
-      return !this.activeUrl.endsWith(this.currentNamespace);
+      return (
+        this.currentNamespace.length === 0 ||
+        !url.endsWith(this.currentNamespace)
+      );
     }
 
     return false;


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR links the user back to the overview page when changing namespaces via dropdown.

It also changes the namespace component to use onPush change detection, and removes `showDropdown()` from template for better performance.

Minor tacked on fixes:
 - Fix CSS for copy button where `pre` tag content is less than 2 lines causing alignment issues.
![image](https://user-images.githubusercontent.com/10288252/94040045-51014b00-fd7d-11ea-8e47-d2a8cd834642.png)

 - Move editor URI generation to constructor (https://github.com/vmware-tanzu/octant/pull/1367#discussion_r492353364)

**Which issue(s) this PR fixes**
- Fixes #1387 

Signed-off-by: GuessWhoSamFoo <foos@vmware.com>
