### PR TITLE
Fixed Apply YAML modal issues

### DIFF
--- a/web/src/app/modules/shared/components/smart/editor/editor.component.scss
+++ b/web/src/app/modules/shared/components/smart/editor/editor.component.scss
@@ -1,6 +1,14 @@
 /* Copyright (c) 2020 the Octant contributors. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+:host-context(body) {
+  --editor-border-color: #d8e3e9;
+}
+
+// Color variables for Dark Theme.
+:host-context(body.dark) {
+  --editor-border-color: #324f62;
+}
 
 .editor-container {
   height: 90%;
@@ -10,8 +18,8 @@
 
 .editor {
   flex: 1;
-  height: 0;
   margin: 1.25em 0;
+  border: 1px solid var(--editor-border-color);
 }
 
 ng-monaco-editor {


### PR DESCRIPTION
This change fixes problem with editor sizing inside the modal popup on Safari browser. It also adds border around editor to improve layout, especially for the light theme.

Signed-off-by: Milan Klanjsek <mklanjsek@pivotal.io>

**Which issue(s) this PR fixes**
- Fixes #1382 

