### PR TITLE
Use table component when loading summary page

### DIFF
--- a/web/src/app/modules/shared/components/presentation/summary/summary.component.html
+++ b/web/src/app/modules/shared/components/presentation/summary/summary.component.html
@@ -28,7 +28,12 @@
         <tr *ngFor="let item of v?.config.sections; trackBy: identifyItem">
           <td class="left">{{ item.header }}</td>
           <td class="left">
-            <app-view-container [view]="item.content"></app-view-container>
+            <app-view-table *ngIf="item.content?.metadata?.type === 'table'; else dynamic"
+              [view]="item.content"
+            ></app-view-table>
+            <ng-template #dynamic>
+              <app-view-container [view]="item.content"></app-view-container>
+            </ng-template>
           </td>
         </tr>
       </tbody>

--- a/web/src/app/modules/shared/components/smart/helper/helper.component.html
+++ b/web/src/app/modules/shared/components/smart/helper/helper.component.html
@@ -26,7 +26,11 @@
   </clr-dropdown>
 </div>
 
-<clr-modal [(clrModalOpen)]="isBuildModalOpen" [clrModalStaticBackdrop]="false">
+<clr-modal
+  [(clrModalOpen)]="isBuildModalOpen"
+  [clrModalStaticBackdrop]="false"
+  [clrModalSkipAnimation]="true"
+>
   <h3 class="modal-title">Build Information</h3>
   <div class="modal-body">
     <table class="table table-vertical table-noborder">
@@ -60,6 +64,7 @@
 <clr-modal
   [(clrModalOpen)]="isShortcutModalOpen"
   [clrModalStaticBackdrop]="false"
+  [clrModalSkipAnimation]="true"
 >
   <h3 class="modal-title">Keyboard Shortcuts</h3>
   <div class="modal-body">

--- a/web/src/app/modules/sugarloaf/components/smart/apply-yaml/apply-yaml.component.scss
+++ b/web/src/app/modules/sugarloaf/components/smart/apply-yaml/apply-yaml.component.scss
@@ -3,6 +3,8 @@
  */
 
 .modal-body {
+  overflow-y: hidden;
+
   ::ng-deep ng-monaco-editor {
     height: calc(60vh - 100px);
   }

--- a/web/src/app/modules/sugarloaf/components/smart/quick-switcher/quick-switcher.component.scss
+++ b/web/src/app/modules/sugarloaf/components/smart/quick-switcher/quick-switcher.component.scss
@@ -69,6 +69,10 @@
     color: var(--destinationActive-color);
   }
 
+  .modal-body {
+    overflow-y: hidden;
+  }
+
   .modal-footer {
     padding-top: 10px;
     justify-content: flex-start;


### PR DESCRIPTION
**What this PR does / why we need it**:
Octant calls a component of type `table` and `datagrid` interchangeably. The table component is used as a specialized case in the summary component in place of a datagrid.

In #1242, the dynamic loader is used in favor of the switch statement which accidentally dropped usage of `app-view-table`.

Also removes some modal animations for responsiveness and CSS fixes.

**Which issue(s) this PR fixes**
- Fixes #1366 

Signed-off-by: GuessWhoSamFoo <foos@vmware.com>