### PR TITLE
Fix since creation option in log viewer

### DIFF
--- a/pkg/action/payload.go
+++ b/pkg/action/payload.go
@@ -74,6 +74,24 @@ func (p Payload) Uint16(key string) (uint16, error) {
 	return uint16(i), nil
 }
 
+// Int64 returns a int64 from the payload.
+func (p Payload) Int64(key string) (int64, error) {
+	i, found, err := unstructured.NestedFloat64(p, key)
+	if err != nil {
+		return 0, err
+	}
+
+	if !found {
+		return 0, errors.Errorf("payload does not contain %q", key)
+	}
+
+	if i > math.MaxInt64 || i < math.MinInt64 {
+		return 0, errors.Errorf("value %v is not a valid int64", i)
+	}
+
+	return int64(i), nil
+}
+
 // String returns a string from the payload.
 func (p Payload) String(key string) (string, error) {
 	s, ok := p[key].(string)

--- a/pkg/action/payload_test.go
+++ b/pkg/action/payload_test.go
@@ -6,6 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 package action
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -229,6 +230,61 @@ func TestPayload_Uint16(t *testing.T) {
 			got, err := test.payload.Uint16(test.key)
 			if test.isErr {
 				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			assert.Equal(t, test.expected, got)
+		})
+	}
+}
+
+func TestPayload_Int64(t *testing.T) {
+	tests := []struct {
+		name     string
+		payload  Payload
+		key      string
+		isErr    bool
+		expected int64
+	}{
+		{
+			name:     "source is int",
+			payload:  Payload{"int64": float64(7)},
+			key:      "int64",
+			expected: int64(7),
+		},
+		{
+			name:    "source overflows",
+			payload: Payload{"int64": float64(1 << 64)},
+			key:     "int64",
+			isErr:   true,
+		},
+		{
+			name:    "source overflows",
+			payload: Payload{"int64": float64(-1 << 64)},
+			key:     "int64",
+			isErr:   true,
+		},
+		{
+			name:    "value is not int",
+			payload: Payload{"int64": true},
+			key:     "int64",
+			isErr:   true,
+		},
+		{
+			name:    "key does not exist",
+			payload: Payload{},
+			key:     "invalid",
+			isErr:   true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := test.payload.Int64(test.key)
+			if test.isErr {
+				require.Error(t, err)
+				fmt.Println(got, err)
 				return
 			}
 			require.NoError(t, err)

--- a/pkg/view/component/logs.go
+++ b/pkg/view/component/logs.go
@@ -16,7 +16,7 @@ var defaultDurations = []Since{
 	{"1 hour", 3600},
 	{"3 hours", 10800},
 	{"5 hours", 18000},
-	{"Creation", 1<<63 - 1},
+	{"Creation", -1},
 }
 
 type Since struct {

--- a/web/src/app/modules/shared/components/smart/logs/logs.component.html
+++ b/web/src/app/modules/shared/components/smart/logs/logs.component.html
@@ -12,25 +12,25 @@
           *ngFor="let container of v?.config.containers"
           value="{{ container }}"
         >
-          {{ container === '' ? '[all containers]' : container }}</option
-        >
+          {{ container === '' ? '[all containers]' : container }}
+        </option>
       </select>
     </clr-select-container>
     <clr-select-container class="container-select">
       <label>Since</label>
       <select
-              clrSelect
-              name="options"
-              [value]="selectedSince"
-              (change)="onSinceChange($event.target.value)"
+        clrSelect
+        name="options"
+        [value]="selectedSince"
+        (change)="onSinceChange($event.target.value)"
       >
         <option
-                *ngFor="let duration of v?.config.durations"
-                label="{{ duration.label }}"
-                value="{{ duration.seconds }}"
+          *ngFor="let duration of v?.config.durations"
+          label="{{ duration.label }}"
+          value="{{ duration.seconds }}"
         >
-          {{ container === '' ? '[all containers]' : container }}</option
-        >
+          {{ container === '' ? '[all containers]' : container }}
+        </option>
       </select>
     </clr-select-container>
     <div class="clr-filter">
@@ -93,9 +93,7 @@
   </div>
   <div class="container-logs">
     <div class="container-logs-bg" #scrollTarget (scroll)="onScroll($event)">
-      <ng-container *ngIf="containerLogs?.length < 1">
-        No logs
-      </ng-container>
+      <ng-container *ngIf="containerLogs?.length < 1"> No logs </ng-container>
       <div
         class="container-log code language-bash"
         *ngFor="let log of filterFunction(containerLogs); trackBy: identifyLog"

--- a/web/src/app/modules/shared/components/smart/logs/logs.component.ts
+++ b/web/src/app/modules/shared/components/smart/logs/logs.component.ts
@@ -77,8 +77,8 @@ export class LogsComponent
     }
   }
 
-  onSinceChange(sinceSelection: number): void {
-    this.selectedSince = sinceSelection;
+  onSinceChange(selectedSince: string): void {
+    this.selectedSince = +selectedSince;
     this.stopStreamIfStarted();
     this.startStream();
   }


### PR DESCRIPTION
Signed-off-by: Wayne Witzel III <wayne@riotousliving.com>

Fixes a bug in master where the `Creation` option in the Log selector was not working.

This was due to a JavaScript number rounding issue since this number exceeded Number.MAX_SAFE_INTEGER
![image](https://user-images.githubusercontent.com/27317/94172826-fc370080-fe60-11ea-9a8e-0cb4cf936695.png)


This was solved by setting the since time to `-1` and using a negative number to trigger looking up the pod creation time and using that to initialize the log streamer.