### PR TITLE
Fix syntax highlighting in YAML tab

### DIFF
--- a/changelogs/unreleased/1436-GuessWhoSamFoo
+++ b/changelogs/unreleased/1436-GuessWhoSamFoo
@@ -1,0 +1,1 @@
+Fixed syntax highlighting in YAML tab

--- a/internal/modules/overview/yamlviewer/yamlviewer.go
+++ b/internal/modules/overview/yamlviewer/yamlviewer.go
@@ -41,6 +41,7 @@ func new(object runtime.Object) (*yamlViewer, error) {
 // ToComponent converts the YAMLViewer to a component.
 func (yv *yamlViewer) ToComponent() (*component.Editor, error) {
 	y := component.NewEditor(component.TitleFromString("YAML"), "", false)
+	y.Config.Language = "yaml"
 	if err := y.SetValueFromObject(yv.object); err != nil {
 		return nil, errors.Wrap(err, "add YAML data")
 	}

--- a/internal/modules/overview/yamlviewer/yamlviewer_test.go
+++ b/internal/modules/overview/yamlviewer/yamlviewer_test.go
@@ -24,6 +24,7 @@ func Test_ToComponent(t *testing.T) {
 
 	data := "---\nmetadata:\n  creationTimestamp: null\nspec:\n  containers: null\nstatus: {}\n"
 	expected := component.NewEditor(component.TitleFromString("YAML"), data, false)
+	expected.Config.Language = "yaml"
 	require.NoError(t, expected.SetValueFromObject(object))
 
 	testutil.AssertJSONEqual(t, expected, got)

--- a/pkg/view/component/editor.go
+++ b/pkg/view/component/editor.go
@@ -26,6 +26,7 @@ type Editor struct {
 // EditorConfig is configuration for Editor.
 type EditorConfig struct {
 	Value        string            `json:"value"`
+	Language     string            `json:"language"`
 	ReadOnly     bool              `json:"readOnly"`
 	Metadata     map[string]string `json:"metadata"`
 	SubmitAction string            `json:"submitAction,omitempty"`


### PR DESCRIPTION
During the transition to dynamic component editing, the options were overwritten from `view.config` instead of always yaml by default. This PR adds the missing language struct field and allows the syntax language configurable from the backend.

**Which issue(s) this PR fixes**
- Fixes #1421 

Signed-off-by: GuessWhoSamFoo <foos@vmware.com>
