### PR TITLE
use 127.0.0.1 for default DashService address

### DIFF
--- a/changelogs/unreleased/1438-joshrosso
+++ b/changelogs/unreleased/1438-joshrosso
@@ -1,0 +1,1 @@
+Default internal DashService API to 127.0.0.1 rather than localhost (DNS lookup)

--- a/pkg/plugin/api/api.go
+++ b/pkg/plugin/api/api.go
@@ -32,11 +32,13 @@ type grpcAPI struct {
 	listener net.Listener
 }
 
+const dashServiceAddress = "127.0.0.1:0"
+
 var _ API = (*grpcAPI)(nil)
 
 // New creates a new API instance for DashService.
 func New(service Service) (API, error) {
-	listener, err := net.Listen("tcp", "localhost:0")
+	listener, err := net.Listen("tcp", dashServiceAddress)
 	if err != nil {
 		return nil, errors.Wrap(err, "create listener")
 	}


### PR DESCRIPTION
Signed-off-by: joshrosso <rossoj@vmware.com>


**What this PR does / why we need it**:
This PR ensures the DashService API default to `127.0.0.1` rather than doing a DNS lookup against `localhost`.

**Which issue(s) this PR fixes**
- Fixes https://github.com/vmware-tanzu/octant/issues/1437

**Special notes for your reviewer**:
This fixes the issue and now is consistent with the listener address default:
https://github.com/vmware-tanzu/octant/blob/18f17d46b9000c4c1b413118ba7eb393e8d47837/internal/api/api.go#L32-L34
