### PR TITLE
Move breadcrumb/title generation to tab component

### DIFF
--- a/changelogs/unreleased/1445-GuessWhoSamFoo
+++ b/changelogs/unreleased/1445-GuessWhoSamFoo
@@ -1,0 +1,1 @@
+Moved breadcrumb/title generation to tab component

--- a/web/src/app/modules/shared/components/presentation/list/list.component.html
+++ b/web/src/app/modules/shared/components/presentation/list/list.component.html
@@ -1,4 +1,3 @@
-<app-breadcrumb [path]="title"> </app-breadcrumb>
 <ng-container *ngFor="let item of items; trackBy: identifyItem">
   <app-view-container
     [view]="item"

--- a/web/src/app/modules/shared/components/presentation/list/list.component.ts
+++ b/web/src/app/modules/shared/components/presentation/list/list.component.ts
@@ -45,12 +45,6 @@ export class ListComponent extends AbstractViewComponent<ListView> {
 
   update() {
     const current = this.v;
-    this.title = current.metadata.title
-      ? current.metadata.title.map((item: LinkView) => ({
-          title: item.config.value,
-          url: item.config.ref,
-        }))
-      : [];
 
     const cur = JSON.stringify(current);
     if (current.config.items && cur !== this.previous) {

--- a/web/src/app/modules/shared/components/presentation/tabs/tabs.component.html
+++ b/web/src/app/modules/shared/components/presentation/tabs/tabs.component.html
@@ -8,7 +8,7 @@
     </div>
   </div>
 </div>
-<clr-tabs *ngIf="tabs.length > 0">
+<clr-tabs *ngIf="tabs.length > 1; else noTabs">
   <clr-tab *ngFor="let tab of tabs; trackBy: identifyTab">
     <div clrTabLink class="tab-button">
       <button clrTabLink class="tab-button" (click)="clickTab(tab.accessor)">
@@ -27,3 +27,6 @@
     </ng-template>
   </clr-tab>
 </clr-tabs>
+<ng-template #noTabs>
+  <app-view-container [view]="view"></app-view-container>
+</ng-template>

--- a/web/src/app/modules/shared/components/presentation/tabs/tabs.component.ts
+++ b/web/src/app/modules/shared/components/presentation/tabs/tabs.component.ts
@@ -11,6 +11,7 @@ import {
 import { ActivatedRoute, Router } from '@angular/router';
 import {
   ButtonGroupView,
+  LinkView,
   PathItem,
   View,
 } from 'src/app/modules/shared/models/content';
@@ -43,6 +44,7 @@ export class TabsComponent implements OnChanges, OnInit {
   activeTab: string;
   activeTabIndex: number;
   closingTab: boolean;
+  view: View;
 
   constructor(
     private router: Router,
@@ -72,6 +74,18 @@ export class TabsComponent implements OnChanges, OnInit {
           accessor: view.metadata.accessor,
         };
       });
+
+      if (views.length === 1) {
+        this.view = views[0];
+        if (this.title == null) {
+          this.title = this.view.metadata.title
+            ? this.view.metadata.title.map((item: LinkView) => ({
+                title: item.config.value,
+                url: item.config.ref,
+              }))
+            : [];
+        }
+      }
 
       if (this.extView && this.tabs.length > 0) {
         this.sliderService.activeTab.subscribe(index => {

--- a/web/src/app/modules/sugarloaf/components/smart/content/content.component.html
+++ b/web/src/app/modules/sugarloaf/components/smart/content/content.component.html
@@ -5,19 +5,11 @@
   [class.loading-content]="!hasReceivedContent"
 >
   <ng-container *ngIf="hasReceivedContent && !showSpinner; else loading">
-    <ng-container
-      *ngIf="hasTabs; then withTabs; else withoutTabs"
-    ></ng-container>
-    <ng-template #withTabs>
       <app-object-tabs
         [buttonGroup]="buttonGroup"
         [title]="title"
         [views]="views"
       ></app-object-tabs>
-    </ng-template>
-    <ng-template #withoutTabs>
-      <app-view-container [view]="singleView"></app-view-container>
-    </ng-template>
   </ng-container>
 
   <ng-template #loading>

--- a/web/src/app/modules/sugarloaf/components/smart/content/content.component.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/content/content.component.ts
@@ -116,7 +116,6 @@ export class ContentComponent implements OnInit, OnDestroy {
 
   private resetView() {
     this.title = null;
-    this.singleView = null;
     this.views = null;
   }
 
@@ -137,17 +136,11 @@ export class ContentComponent implements OnInit, OnDestroy {
     this.buttonGroup = contentResponse.content.buttonGroup;
 
     this.extView = contentResponse.content.extensionComponent;
-    this.hasTabs = views.length > 1;
-    if (this.hasTabs) {
-      this.views = views;
-      this.title = contentResponse.content.title.map((item: LinkView) => ({
-        title: item.config.value,
-        url: item.config.ref,
-      }));
-    } else if (views.length === 1) {
-      this.views = null;
-      this.singleView = views[0];
-    }
+    this.views = views;
+    this.title = contentResponse.content.title?.map((item: LinkView) => ({
+      title: item.config.value,
+      url: item.config.ref,
+    }));
 
     this.hasReceivedContent = true;
   };


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding a header/breadcrumb was confusing because `app-breadcrumb` was declared in two places that toggled on/off depending on the component configuration (in this case, list and tabs). Instead of creating a separate code path for cases with a single tab, this PR consolidates that into `tabs.component.ts`.

Plugins using a single component in content response now looks like:
![image](https://user-images.githubusercontent.com/10288252/94968319-8ad8fc80-04b5-11eb-82b1-d69599fe26dd.png)

**Which issue(s) this PR fixes**
- Fixes #1430 

Signed-off-by: GuessWhoSamFoo <foos@vmware.com>
