### PR TITLE
Fixed multiple plugin tabs overwriting

### DIFF
--- a/changelogs/unreleased/1446-GuessWhoSamFoo
+++ b/changelogs/unreleased/1446-GuessWhoSamFoo
@@ -1,0 +1,1 @@
+Fixed multiple plugin tabs overwriting

--- a/internal/describer/tab_generator.go
+++ b/internal/describer/tab_generator.go
@@ -181,6 +181,7 @@ func pluginTabsFactory(
 	}
 
 	for _, tab := range tabs {
+		tab := tab
 		list = append(list, Tab{
 			Name: tab.Name,
 			Factory: func(ctx context.Context, object runtime.Object, options Options) (component.Component, error) {

--- a/pkg/plugin/javascript.go
+++ b/pkg/plugin/javascript.go
@@ -383,6 +383,7 @@ func (t *jsPlugin) PrintTab(ctx context.Context, object runtime.Object) (TabResp
 	cTab := &component.Tab{}
 	if name, ok := contents["name"]; ok {
 		cTab.Contents = *component.NewFlexLayout(name.(string))
+		cTab.Name = name.(string)
 	}
 
 	if contents, ok := contents["contents"]; ok {


### PR DESCRIPTION
**What this PR does / why we need it**:
This was a regression from #691 that was not caught when switching to a generator pattern for tabs. A test is added to ensure multiple tabs do not overwrite.

Tabs added from JS were missing names which could cause then to appear in a random order as tabs are sorted by name. https://github.com/vmware-tanzu/octant/blob/7adc72b353d3f3bd849319a425d87bd97431d0fa/pkg/plugin/manager.go#L753-L755

**Which issue(s) this PR fixes**
- Fixes #1426 

Signed-off-by: GuessWhoSamFoo <foos@vmware.com>
