### PR TITLE
Change redirect path when switching namespaces to be more intuitive

### DIFF
--- a/changelogs/unreleased/1461-GuessWhoSamFoo
+++ b/changelogs/unreleased/1461-GuessWhoSamFoo
@@ -1,0 +1,1 @@
+Changed redirect path when switching namespaces to be more intuitive

--- a/web/src/app/modules/shared/services/navigation/navigation.service.spec.ts
+++ b/web/src/app/modules/shared/services/navigation/navigation.service.spec.ts
@@ -14,6 +14,7 @@ import { WebsocketServiceMock } from '../websocket/mock';
 import { Navigation } from '../../../sugarloaf/models/navigation';
 import { ContentService } from '../content/content.service';
 import { NAVIGATION_MOCK_DATA } from './navigation.test.data';
+import { BehaviorSubject } from 'rxjs';
 import { take } from 'rxjs/operators';
 
 describe('NavigationService', () => {
@@ -101,5 +102,47 @@ describe('NavigationService', () => {
           .toEqual('/' + path)
       );
     }
+
+    const routerLinkCases = [
+      { url: '/', namespace: 'test', result: '/' },
+      {
+        url: '/workloads/namespace/default',
+        namespace: 'test',
+        result: '/workloads/namespace/test',
+      },
+      {
+        url: '/cluster-overview',
+        namespace: 'test',
+        result: '/cluster-overview',
+      },
+      { url: '/plugin/path', namespace: 'test', result: '/plugin/path' },
+      {
+        url: '/overview/namespace/default',
+        namespace: 'test',
+        result: '/overview/namespace/test',
+      },
+      {
+        url: '/overview/namespace/default/workloads/deployments',
+        namespace: 'test',
+        result: '/overview/namespace/test/workloads/deployments',
+      },
+      {
+        url:
+          '/overview/namespace/default/workloads/deployments/nginx-deployment',
+        namespace: 'test',
+        result: '/overview/namespace/test',
+      },
+    ];
+
+    routerLinkCases.forEach((test, index) => {
+      it(`generates correct routerLink based on url ${test.url}`, inject(
+        [NavigationService],
+        (svc: NavigationService) => {
+          svc.activeUrl = new BehaviorSubject<string>(test.url);
+          const result = svc.redirect(test.namespace);
+          expect(test.result).toEqual(result);
+        }
+      ));
+    });
   });
 });

--- a/web/src/app/modules/shared/services/navigation/navigation.service.ts
+++ b/web/src/app/modules/shared/services/navigation/navigation.service.ts
@@ -11,7 +11,6 @@ import { ContentService } from '../content/content.service';
 import { NavigationEnd, Router, RouterEvent } from '@angular/router';
 import { filter } from 'rxjs/operators';
 import { LoadingService } from '../loading/loading.service';
-import { NamespaceService } from '../namespace/namespace.service';
 
 const emptyNavigation: Navigation = {
   sections: [],
@@ -91,5 +90,31 @@ export class NavigationService {
       }
     }
     return -1;
+  }
+
+  redirect(namespace: string): string {
+    let routerLink = '';
+    const paths = this.activeUrl.value.split('/');
+    const module = paths[1];
+
+    switch (module) {
+      case 'workloads': {
+        routerLink = '/workloads/namespace/' + namespace;
+        break;
+      }
+      case 'overview': {
+        if (paths.length > 6) {
+          routerLink = '/overview/namespace/' + namespace;
+        } else {
+          paths[3] = namespace;
+          routerLink = paths.join('/');
+        }
+        break;
+      }
+      default: {
+        routerLink = this.activeUrl.value;
+      }
+    }
+    return routerLink;
   }
 }

--- a/web/src/app/modules/sugarloaf/components/smart/namespace/namespace.component.html
+++ b/web/src/app/modules/sugarloaf/components/smart/namespace/namespace.component.html
@@ -21,7 +21,7 @@
             [ngClass]="namespaceClass(namespace)"
             clrDropdownItem
             (click)="selectNamespace(namespace)"
-            [routerLink]="'/overview/namespace/' + namespace"
+            [routerLink]="routerLinkPath(namespace)"
           >
             {{ namespace }}
           </button>

--- a/web/src/app/modules/sugarloaf/components/smart/namespace/namespace.component.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/namespace/namespace.component.ts
@@ -123,4 +123,8 @@ export class NamespaceComponent implements OnInit, OnDestroy {
 
     return false;
   }
+
+  private routerLinkPath(namespace: string): string {
+    return this.navigationService.redirect(namespace);
+  }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR creates smarter routerLinks for the namespace switcher based on the current URL. It will keep the user in the same place on the navigation tree when switching namespaces unless viewing an object.

xref #1387 

**Which issue(s) this PR fixes**
- Fixes #1429 

Signed-off-by: GuessWhoSamFoo <foos@vmware.com>
