### PR TITLE
Workaround for Clarity input control styling problem

### DIFF
--- a/web/src/app/modules/sugarloaf/components/smart/input-filter/input-filter.component.scss
+++ b/web/src/app/modules/sugarloaf/components/smart/input-filter/input-filter.component.scss
@@ -38,6 +38,10 @@
       & .clr-control-container {
         width: 100%;
 
+        .clr-input-wrapper {
+          max-width: initial;
+        }
+
         .clr-input-wrapper .clr-input {
           border-bottom-color: var(--input-border-color);
           color: white;

--- a/web/src/app/modules/sugarloaf/components/smart/quick-switcher/quick-switcher.component.scss
+++ b/web/src/app/modules/sugarloaf/components/smart/quick-switcher/quick-switcher.component.scss
@@ -15,6 +15,10 @@
     --destinationActive-bg-color: #324f62;
   }
 
+  ::ng-deep .clr-input-wrapper {
+    max-width: initial;
+  }
+
   .filter-input {
     padding: 1rem 0.5rem;
     font-size: 22px;

--- a/web/src/app/modules/sugarloaf/components/smart/quick-switcher/quick-switcher.component.scss
+++ b/web/src/app/modules/sugarloaf/components/smart/quick-switcher/quick-switcher.component.scss
@@ -64,7 +64,7 @@
     top: 4rem;
   }
 
-  ::ng-deep .modal-header {
+  ::ng-deep .modal-header--accessible {
     display: none;
   }
 


### PR DESCRIPTION
Latest Clarity release changed the css for input control and messed up Octant filter and Quick Switcher. This PR makes sure the input width is correct.
 
Signed-off-by: Milan Klanjsek <mklanjsek@pivotal.io>
