### PR TITLE
Vertical Navigation redesign

### DIFF
--- a/changelogs/unreleased/1353-mklanjsek
+++ b/changelogs/unreleased/1353-mklanjsek
@@ -1,0 +1,1 @@
+Left Navigation redesign

--- a/internal/api/navigation_manager.go
+++ b/internal/api/navigation_manager.go
@@ -146,6 +146,8 @@ func NavigationGenerator(ctx context.Context, state octant.State, config Navigat
 			if err != nil {
 				return fmt.Errorf("unable to generate navigation for module %s: %v", m.Name(), err)
 			}
+			navList[0].Module = m.Name()
+			navList[0].Description = m.Description()
 
 			mu.Lock()
 			defer mu.Unlock()

--- a/internal/api/navigation_manager_test.go
+++ b/internal/api/navigation_manager_test.go
@@ -63,6 +63,7 @@ func TestNavigationGenerator(t *testing.T) {
 				m := moduleFake.NewMockModule(controller)
 				m.EXPECT().ContentPath().Return("/module")
 				m.EXPECT().Name().Return("module").AnyTimes()
+				m.EXPECT().Description().Return("description").AnyTimes()
 				m.EXPECT().
 					Navigation(gomock.Any(), "default", "/module").
 					Return([]navigation.Navigation{
@@ -81,7 +82,7 @@ func TestNavigationGenerator(t *testing.T) {
 				return dashConfig, state
 			},
 			expected: []navigation.Navigation{
-				{Title: "module"},
+				{Title: "module", Module: "module", Description: "description"},
 			},
 		},
 	}

--- a/internal/module/fake/mock_module.go
+++ b/internal/module/fake/mock_module.go
@@ -98,6 +98,20 @@ func (mr *MockModuleMockRecorder) ContentPath() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContentPath", reflect.TypeOf((*MockModule)(nil).ContentPath))
 }
 
+// Description mocks base method
+func (m *MockModule) Description() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Description")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Description indicates an expected call of Description
+func (mr *MockModuleMockRecorder) Description() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Description", reflect.TypeOf((*MockModule)(nil).Description))
+}
+
 // Generators mocks base method
 func (m *MockModule) Generators() []octant.Generator {
 	m.ctrl.T.Helper()

--- a/internal/module/module.go
+++ b/internal/module/module.go
@@ -28,6 +28,8 @@ type ContentOptions struct {
 type Module interface {
 	// Name is the name of the module.
 	Name() string
+	// Description
+	Description() string
 	// ClientRequestHandlers are handlers for handling client requests.
 	ClientRequestHandlers() []octant.ClientRequestHandler
 	// Content generates content for a path.

--- a/internal/module/module.go
+++ b/internal/module/module.go
@@ -28,7 +28,7 @@ type ContentOptions struct {
 type Module interface {
 	// Name is the name of the module.
 	Name() string
-	// Description
+	// Description is a description for this module
 	Description() string
 	// ClientRequestHandlers are handlers for handling client requests.
 	ClientRequestHandlers() []octant.ClientRequestHandler

--- a/internal/modules/applications/module.go
+++ b/internal/modules/applications/module.go
@@ -59,6 +59,11 @@ func (m Module) Name() string {
 	return "applications"
 }
 
+// Description is the description of the module.
+func (m Module) Description() string {
+	return "Applications module description comes here"
+}
+
 // ClientRequestHandlers are client handlers for the module.
 func (m Module) ClientRequestHandlers() []octant.ClientRequestHandler {
 	return nil

--- a/internal/modules/clusteroverview/clusteroverview.go
+++ b/internal/modules/clusteroverview/clusteroverview.go
@@ -117,6 +117,10 @@ func (co *ClusterOverview) Name() string {
 	return "cluster-overview"
 }
 
+func (co *ClusterOverview) Description() string {
+	return "Cluster module is used to display all cluster related resources"
+}
+
 func (co *ClusterOverview) ClientRequestHandlers() []octant.ClientRequestHandler {
 	return nil
 }
@@ -200,7 +204,7 @@ func (co *ClusterOverview) Navigation(ctx context.Context, _ string, root string
 			"Port Forwards":               nil,
 		},
 		IconMap: map[string]string{
-			"Cluster Overview":            icon.Overview,
+			"Cluster Overview":            icon.Cluster,
 			"Namespaces":                  icon.Namespaces,
 			"Custom Resources":            icon.CustomResources,
 			"Custom Resource Definitions": icon.CustomResourceDefinition,

--- a/internal/modules/configuration/configuration.go
+++ b/internal/modules/configuration/configuration.go
@@ -57,6 +57,11 @@ func (Configuration) Name() string {
 	return "configuration"
 }
 
+func (Configuration) Description() string {
+	return `Plugins module displays all registered plugins and their properties.
+		To find list of known plugins go to https://github.com/topics/octant-plugin`
+}
+
 func (c Configuration) ClientRequestHandlers() []octant.ClientRequestHandler {
 	return nil
 }
@@ -96,7 +101,7 @@ func (c *Configuration) Navigation(ctx context.Context, namespace, root string) 
 	return []navigation.Navigation{
 		{
 			Module:   "Configuration",
-			Title:    "Plugin",
+			Title:    "Plugins",
 			Path:     path.Join(c.ContentPath(), "plugins"),
 			IconName: icon.ConfigurationPlugin,
 		},

--- a/internal/modules/localcontent/localcontent.go
+++ b/internal/modules/localcontent/localcontent.go
@@ -45,6 +45,10 @@ func (l *LocalContent) Name() string {
 	return "local"
 }
 
+func (l *LocalContent) Description() string {
+	return "This is the local module description"
+}
+
 func (l *LocalContent) ClientRequestHandlers() []octant.ClientRequestHandler {
 	return nil
 }

--- a/internal/modules/overview/overview.go
+++ b/internal/modules/overview/overview.go
@@ -181,6 +181,11 @@ func (co *Overview) Name() string {
 	return "overview"
 }
 
+// Description returns module description.
+func (co *Overview) Description() string {
+	return "Namespace module shows all resources related to currently selected namespace\nUse dropdown at the top to change the selected namespace"
+}
+
 func (co *Overview) ClientRequestHandlers() []octant.ClientRequestHandler {
 	return nil
 }

--- a/internal/modules/workloads/module.go
+++ b/internal/modules/workloads/module.go
@@ -71,6 +71,11 @@ func (m *Module) Name() string {
 	return "workloads"
 }
 
+// Description returns the module description.
+func (m *Module) Description() string {
+	return "Application module displays all known applications and their status"
+}
+
 // ClientRequestHandlers returns nil.
 func (m *Module) ClientRequestHandlers() []octant.ClientRequestHandler {
 	return nil

--- a/pkg/icon/icon.go
+++ b/pkg/icon/icon.go
@@ -14,6 +14,7 @@ const (
 	ConfigAndStorage          = "storage"
 	RBAC                      = "assign-user"
 	Events                    = "event"
+	Cluster                   = "cluster"
 
 	Namespaces      = "namespace"
 	ApiServer       = "hard-disk"

--- a/pkg/navigation/navigation.go
+++ b/pkg/navigation/navigation.go
@@ -50,6 +50,7 @@ func SetLoading(isLoading bool) Option {
 // Navigation is a set of navigation entries.
 type Navigation struct {
 	Module   string       `json:"module,omitempty"`
+	Description string     `json:"description,omitempty"`
 	Title    string       `json:"title,omitempty"`
 	Path     string       `json:"path,omitempty"`
 	Children []Navigation `json:"children,omitempty"`

--- a/pkg/navigation/navigation.go
+++ b/pkg/navigation/navigation.go
@@ -49,13 +49,13 @@ func SetLoading(isLoading bool) Option {
 
 // Navigation is a set of navigation entries.
 type Navigation struct {
-	Module   string       `json:"module,omitempty"`
-	Description string     `json:"description,omitempty"`
-	Title    string       `json:"title,omitempty"`
-	Path     string       `json:"path,omitempty"`
-	Children []Navigation `json:"children,omitempty"`
-	IconName string       `json:"iconName,omitempty"`
-	Loading  bool         `json:"isLoading"`
+	Module      string       `json:"module,omitempty"`
+	Description string       `json:"description,omitempty"`
+	Title       string       `json:"title,omitempty"`
+	Path        string       `json:"path,omitempty"`
+	Children    []Navigation `json:"children,omitempty"`
+	IconName    string       `json:"iconName,omitempty"`
+	Loading     bool         `json:"isLoading"`
 }
 
 // New creates a Navigation.

--- a/pkg/plugin/module_proxy.go
+++ b/pkg/plugin/module_proxy.go
@@ -41,6 +41,11 @@ func (m *ModuleProxy) Name() string {
 	return m.Metadata.Name
 }
 
+// Description returns the module's description.
+func (m *ModuleProxy) Description() string {
+	return m.Metadata.Description
+}
+
 func (m *ModuleProxy) ClientRequestHandlers() []octant.ClientRequestHandler {
 	return nil
 }

--- a/web/src/app/modules/shared/components/presentation/content-filter/content-filter.component.ts
+++ b/web/src/app/modules/shared/components/presentation/content-filter/content-filter.component.ts
@@ -26,8 +26,10 @@ export class ContentFilterComponent
   }
 
   ngOnInit(): void {
-    this.filter.selected.forEach(value => (this.checkboxes[value] = true));
-    this.cd.detectChanges();
+    if (this.filter.selected) {
+      this.filter.selected.forEach(value => (this.checkboxes[value] = true));
+      this.cd.detectChanges();
+    }
   }
 
   accepts(row: TableRow): boolean {

--- a/web/src/app/modules/shared/components/smart/helper/helper.component.html
+++ b/web/src/app/modules/shared/components/smart/helper/helper.component.html
@@ -169,7 +169,7 @@
         >
           <clr-stack-label>Toggle Theme</clr-stack-label>
           <clr-stack-content>
-            <span class="label">Ctrl<span class="badge">T</span></span>
+            <span class="label">Ctrl Shift<span class="badge">T</span></span>
           </clr-stack-content>
         </clr-stack-block>
         <clr-stack-block
@@ -179,7 +179,7 @@
         >
           <clr-stack-label>Toggle Navigation</clr-stack-label>
           <clr-stack-content>
-            <span class="label">Ctrl<span class="badge">N</span></span>
+            <span class="label">Ctrl Shift<span class="badge">N</span></span>
           </clr-stack-content>
         </clr-stack-block>
         <clr-stack-block
@@ -189,7 +189,7 @@
         >
           <clr-stack-label>Show/Hide Labels</clr-stack-label>
           <clr-stack-content>
-            <span class="label">Ctrl<span class="badge">L</span></span>
+            <span class="label">Ctrl Shift<span class="badge">L</span></span>
           </clr-stack-content>
         </clr-stack-block>
       </clr-stack-block>

--- a/web/src/app/modules/shared/components/smart/helper/helper.component.html
+++ b/web/src/app/modules/shared/components/smart/helper/helper.component.html
@@ -179,7 +179,7 @@
         >
           <clr-stack-label>Toggle Navigation</clr-stack-label>
           <clr-stack-content>
-            <span class="label">Ctrl Shift<span class="badge">N</span></span>
+            <span class="label">Ctrl<span class="badge">b</span></span>
           </clr-stack-content>
         </clr-stack-block>
         <clr-stack-block

--- a/web/src/app/modules/shared/components/smart/helper/helper.component.html
+++ b/web/src/app/modules/shared/components/smart/helper/helper.component.html
@@ -162,6 +162,36 @@
           <span class="label">Ctrl<span class="badge">Y</span></span>
         </clr-stack-content>
       </clr-stack-block>
+        <clr-stack-block
+          [clrStackViewLevel]="2"
+          [clrStackViewSetsize]="0"
+          [clrStackViewPosinset]="1"
+        >
+          <clr-stack-label>Toggle Theme</clr-stack-label>
+          <clr-stack-content>
+            <span class="label">Ctrl<span class="badge">T</span></span>
+          </clr-stack-content>
+        </clr-stack-block>
+        <clr-stack-block
+          [clrStackViewLevel]="2"
+          [clrStackViewSetsize]="0"
+          [clrStackViewPosinset]="1"
+        >
+          <clr-stack-label>Toggle Navigation</clr-stack-label>
+          <clr-stack-content>
+            <span class="label">Ctrl<span class="badge">N</span></span>
+          </clr-stack-content>
+        </clr-stack-block>
+        <clr-stack-block
+          [clrStackViewLevel]="2"
+          [clrStackViewSetsize]="0"
+          [clrStackViewPosinset]="1"
+        >
+          <clr-stack-label>Show/Hide Labels</clr-stack-label>
+          <clr-stack-content>
+            <span class="label">Ctrl<span class="badge">L</span></span>
+          </clr-stack-content>
+        </clr-stack-block>
       </clr-stack-block>
       <clr-stack-block
         [clrSbExpandable]="false"

--- a/web/src/app/modules/shared/services/navigation/navigation.service.spec.ts
+++ b/web/src/app/modules/shared/services/navigation/navigation.service.spec.ts
@@ -76,6 +76,11 @@ describe('NavigationService', () => {
           if (section.children) {
             section.children.map(child => {
               verifySelection(child.path, svc, index, 'child');
+              if (child.children) {
+                child.children.map(grandchild => {
+                  verifySelection(grandchild.path, svc, index, 'grandchild');
+                });
+              }
             });
           }
         });

--- a/web/src/app/modules/shared/services/navigation/navigation.service.spec.ts
+++ b/web/src/app/modules/shared/services/navigation/navigation.service.spec.ts
@@ -13,7 +13,10 @@ import {
 import { WebsocketServiceMock } from '../../../../data/services/websocket/mock';
 import { Navigation } from '../../../sugarloaf/models/navigation';
 import { ContentService } from '../content/content.service';
-import { NAVIGATION_MOCK_DATA } from './navigation.test.data';
+import {
+  expectedSelection,
+  NAVIGATION_MOCK_DATA,
+} from './navigation.test.data';
 import { BehaviorSubject } from 'rxjs';
 import { take } from 'rxjs/operators';
 
@@ -77,7 +80,7 @@ describe('NavigationService', () => {
           }
         });
         svc.activeUrl.unsubscribe();
-        svc.lastSelection.unsubscribe();
+        svc.selectedItem.unsubscribe();
       }
     ));
 
@@ -90,10 +93,19 @@ describe('NavigationService', () => {
       svc.activeUrl.next('/' + path);
       svc.updateLastSelection();
 
-      svc.lastSelection.pipe(take(1)).subscribe(selection => {
-        expect(selection)
-          .withContext(`navigation selected ${descriptor} index ${index}`)
-          .toEqual(index);
+      svc.selectedItem.pipe(take(1)).subscribe(selection => {
+        const expected = expectedSelection[path];
+
+        expect(selection.index)
+          .withContext(
+            `navigation selected ${descriptor} index ${index} ${path}`
+          )
+          .toEqual(expected.index);
+        expect(selection.module)
+          .withContext(
+            `navigation selected ${descriptor} module ${index} ${path}`
+          )
+          .toEqual(expected.module);
       });
 
       svc.activeUrl.pipe(take(1)).subscribe(url =>

--- a/web/src/app/modules/shared/services/navigation/navigation.service.ts
+++ b/web/src/app/modules/shared/services/navigation/navigation.service.ts
@@ -59,7 +59,12 @@ export class NavigationService {
       this.current.next(update);
       this.createModules(update.sections);
       if (update.defaultPath) {
-        this.activeUrl.next(update.defaultPath);
+        const newUrl = update.defaultPath.startsWith('/')
+          ? update.defaultPath
+          : '/' + update.defaultPath;
+        if (newUrl !== this.activeUrl.value) {
+          this.activeUrl.next(newUrl);
+        }
       }
       this.updateLastSelection();
     });

--- a/web/src/app/modules/shared/services/navigation/navigation.test.data.ts
+++ b/web/src/app/modules/shared/services/navigation/navigation.test.data.ts
@@ -202,6 +202,24 @@ export const NAVIGATION_MOCK_DATA: NavigationChild[] = [
         isLoading: false,
       },
       {
+        title: 'resource1',
+        path: 'cluster-overview/custom-resources/resource1',
+        children: [
+          {
+            title: 'First',
+            path: 'cluster-overview/custom-resources/resource1/v1alpha',
+            isLoading: false,
+          },
+          {
+            title: 'Second',
+            path: 'cluster-overview/custom-resources/resource1/v1/more/info',
+            isLoading: false,
+          },
+        ],
+        iconName: 'crd',
+        isLoading: false,
+      },
+      {
         title:
           'antreacontrollerinfos.clusterinformation.antrea.tanzu.vmware.com',
         path:
@@ -368,6 +386,15 @@ export const expectedSelection = {
   'cluster-overview': { module: 2, index: 0 },
   'cluster-overview/namespaces': { module: 2, index: 1 },
   'cluster-overview/custom-resources': { module: 2, index: 2 },
+  'cluster-overview/custom-resources/resource1': { module: 2, index: 2 },
+  'cluster-overview/custom-resources/resource1/v1alpha': {
+    module: 2,
+    index: 2,
+  },
+  'cluster-overview/custom-resources/resource1/v1/more/info': {
+    module: 2,
+    index: 2,
+  },
   'cluster-overview/custom-resources/antreacontrollerinfos.clusterinformation.antrea.tanzu.vmware.com': {
     module: 2,
     index: 2,
@@ -379,9 +406,10 @@ export const expectedSelection = {
   'cluster-overview/storage': { module: 2, index: 5 },
   'cluster-overview/storage/persistent-volumes': { module: 2, index: 5 },
   'cluster-overview/port-forward': { module: 2, index: 6 },
-  'configuration/plugins': { module: 3, index: 0 },
-  'argo-ui': { module: 4, index: 0 },
-  'plugin-name': { module: 5, index: 0 },
-  'plugin-name/nested-once': { module: 5, index: 1 },
-  openstack: { module: 6, index: 0 },
+  'configuration/plugins': { module: 6, index: 0 },
+  'argo-ui': { module: 3, index: 0 },
+  'plugin-name': { module: 4, index: 0 },
+  'plugin-name/nested-once': { module: 4, index: 1 },
+  'plugin-name/nested-once/nested-twice': { module: 4, index: 1 },
+  openstack: { module: 5, index: 0 },
 };

--- a/web/src/app/modules/shared/services/navigation/navigation.test.data.ts
+++ b/web/src/app/modules/shared/services/navigation/navigation.test.data.ts
@@ -6,12 +6,14 @@ import { NavigationChild } from '../../../sugarloaf/models/navigation';
 
 export const NAVIGATION_MOCK_DATA: NavigationChild[] = [
   {
+    module: 'workloads',
     title: 'Applications',
     path: 'workloads/namespace/default',
     iconName: 'application',
     isLoading: false,
   },
   {
+    module: 'overview',
     title: 'Namespace Overview',
     path: 'overview/namespace/default',
     iconName: 'dashboard',
@@ -272,12 +274,14 @@ export const NAVIGATION_MOCK_DATA: NavigationChild[] = [
     isLoading: false,
   },
   {
+    module: 'argo-ui',
     title: 'Argo UI',
     path: 'argo-ui',
     iconName: 'cloud',
     isLoading: false,
   },
   {
+    module: 'sample-plugin',
     title: 'Sample Plugin',
     path: 'plugin-name',
     children: [
@@ -300,9 +304,84 @@ export const NAVIGATION_MOCK_DATA: NavigationChild[] = [
     isLoading: false,
   },
   {
+    module: 'open-stack',
     title: 'OpenStack',
     path: 'openstack',
     iconName: 'cloud',
     isLoading: false,
   },
 ];
+
+export const expectedSelection = {
+  'workloads/namespace/default': { module: 0, index: 0 },
+  'overview/namespace/default': { module: 1, index: 0 },
+  'overview/namespace/default/workloads': { module: 1, index: 1 },
+  'overview/namespace/default/workloads/cron-jobs': { module: 1, index: 1 },
+  'overview/namespace/default/workloads/daemon-sets': { module: 1, index: 1 },
+  'overview/namespace/default/workloads/deployments': { module: 1, index: 1 },
+  'overview/namespace/default/workloads/jobs': { module: 1, index: 1 },
+  'overview/namespace/default/workloads/pods': { module: 1, index: 1 },
+  'overview/namespace/default/workloads/replica-sets': { module: 1, index: 1 },
+  'overview/namespace/default/workloads/replication-controllers': {
+    module: 1,
+    index: 1,
+  },
+  'overview/namespace/default/workloads/stateful-sets': { module: 1, index: 1 },
+  'overview/namespace/default/discovery-and-load-balancing': {
+    module: 1,
+    index: 2,
+  },
+  'overview/namespace/default/discovery-and-load-balancing/horizontal-pod-autoscalers': {
+    module: 1,
+    index: 2,
+  },
+  'overview/namespace/default/discovery-and-load-balancing/ingresses': {
+    module: 1,
+    index: 2,
+  },
+  'overview/namespace/default/discovery-and-load-balancing/services': {
+    module: 1,
+    index: 2,
+  },
+  'overview/namespace/default/config-and-storage': { module: 1, index: 3 },
+  'overview/namespace/default/config-and-storage/config-maps': {
+    module: 1,
+    index: 3,
+  },
+  'overview/namespace/default/config-and-storage/persistent-volume-claims': {
+    module: 1,
+    index: 3,
+  },
+  'overview/namespace/default/config-and-storage/secrets': {
+    module: 1,
+    index: 3,
+  },
+  'overview/namespace/default/config-and-storage/service-accounts': {
+    module: 1,
+    index: 3,
+  },
+  'overview/namespace/default/custom-resources': { module: 1, index: 4 },
+  'overview/namespace/default/rbac': { module: 1, index: 5 },
+  'overview/namespace/default/rbac/roles': { module: 1, index: 5 },
+  'overview/namespace/default/rbac/role-bindings': { module: 1, index: 5 },
+  'overview/namespace/default/events': { module: 1, index: 6 },
+  'cluster-overview': { module: 2, index: 0 },
+  'cluster-overview/namespaces': { module: 2, index: 1 },
+  'cluster-overview/custom-resources': { module: 2, index: 2 },
+  'cluster-overview/custom-resources/antreacontrollerinfos.clusterinformation.antrea.tanzu.vmware.com': {
+    module: 2,
+    index: 2,
+  },
+  'cluster-overview/rbac': { module: 2, index: 3 },
+  'cluster-overview/rbac/cluster-roles': { module: 2, index: 3 },
+  'cluster-overview/rbac/cluster-role-bindings': { module: 2, index: 3 },
+  'cluster-overview/nodes': { module: 2, index: 4 },
+  'cluster-overview/storage': { module: 2, index: 5 },
+  'cluster-overview/storage/persistent-volumes': { module: 2, index: 5 },
+  'cluster-overview/port-forward': { module: 2, index: 6 },
+  'configuration/plugins': { module: 3, index: 0 },
+  'argo-ui': { module: 4, index: 0 },
+  'plugin-name': { module: 5, index: 0 },
+  'plugin-name/nested-once': { module: 5, index: 1 },
+  openstack: { module: 6, index: 0 },
+};

--- a/web/src/app/modules/sugarloaf/components/smart/container/container.component.html
+++ b/web/src/app/modules/sugarloaf/components/smart/container/container.component.html
@@ -13,7 +13,8 @@
           <span class="title">Octant</span>
         </a>
       </div>
-      <div class="header-nav">
+        <!-- Navigation items -->
+        <div class="header-nav">
         <div class="input-filter">
           <app-input-filter></app-input-filter>
         </div>

--- a/web/src/app/modules/sugarloaf/components/smart/container/container.component.scss
+++ b/web/src/app/modules/sugarloaf/components/smart/container/container.component.scss
@@ -24,6 +24,13 @@
   background-color: var(--background-color);
 }
 
+:host ::ng-deep .navigation-top {
+  height: 100%;
+  clr-vertical-nav {
+    padding-top: 0px;
+  }
+}
+
 .main-container {
   // Navigation's color variables for Light Theme.
 
@@ -101,4 +108,5 @@
     }
   }
 }
+
 

--- a/web/src/app/modules/sugarloaf/components/smart/container/container.component.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/container/container.component.ts
@@ -9,6 +9,7 @@ import { Navigation } from '../../../models/navigation';
 import { WebsocketService } from '../../../../../data/services/websocket/websocket.service';
 import { IconService } from '../../../../shared/services/icon/icon.service';
 import { Preferences } from '../../../../shared/models/preference';
+import { NavigationService } from '../../../../shared/services/navigation/navigation.service';
 
 // tslint:disable-next-line
 declare namespace astilectron {
@@ -42,6 +43,7 @@ export class ContainerComponent implements OnInit, OnDestroy {
 
   constructor(
     private websocketService: WebsocketService,
+    private navigationService: NavigationService,
     private iconService: IconService
   ) {
     iconService.load({

--- a/web/src/app/modules/sugarloaf/components/smart/namespace/namespace.component.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/namespace/namespace.component.ts
@@ -12,7 +12,11 @@ import {
 import { NamespaceService } from 'src/app/modules/shared/services/namespace/namespace.service';
 import trackByIdentity from 'src/app/util/trackBy/trackByIdentity';
 import { Subscription } from 'rxjs';
-import { NavigationService } from '../../../../shared/services/navigation/navigation.service';
+import {
+  Module,
+  NavigationService,
+  Selection,
+} from '../../../../shared/services/navigation/navigation.service';
 
 @Component({
   selector: 'app-namespace',
@@ -24,11 +28,8 @@ export class NamespaceComponent implements OnInit, OnDestroy {
   namespaces: string[];
   currentNamespace = '';
   trackByIdentity = trackByIdentity;
-  navigation = {
-    sections: [],
-    defaultPath: '',
-  };
-  lastSelection: number;
+  modules: Module[] = [];
+  selectedItem: Selection;
   activeUrl: string;
   showDropdown: boolean;
 
@@ -55,19 +56,22 @@ export class NamespaceComponent implements OnInit, OnDestroy {
       }
     );
 
-    this.navigationService.current.subscribe(navigation => {
-      this.navigation = navigation;
-      this.cdr.detectChanges();
-    });
+    this.navigationService.modules.subscribe(
+      modules => {
+        this.modules = modules;
+        this.cdr.detectChanges();
+      }
+    );
 
+    this.navigationService.selectedItem.subscribe(
+      selection => {
+        this.selectedItem = selection;
+        this.showDropdown = this.hasDropdown();
+        this.cdr.detectChanges();
+      }
+    );
     this.navigationService.activeUrl.subscribe(url => {
       this.activeUrl = url;
-      this.cdr.detectChanges();
-    });
-
-    this.navigationService.lastSelection.subscribe(selection => {
-      this.lastSelection = selection;
-      this.showDropdown = this.hasDropdown();
       this.cdr.detectChanges();
     });
   }
@@ -87,43 +91,11 @@ export class NamespaceComponent implements OnInit, OnDestroy {
     this.namespaceService.setNamespace(namespace);
   }
 
-  hasDropdown(): boolean {
-    if (this.lastSelection && this.navigation.sections[this.lastSelection]) {
-      const url = this.navigation.sections[this.lastSelection].path;
-      return !this.isClusterSpecific(url);
+  hasDropdown() {
+    if (this.selectedItem && this.modules[this.selectedItem.module]) {
+      return this.modules[this.selectedItem.module].name !== 'cluster-overview';
     }
     return true;
-  }
-
-  private namespaceFromUrl(url: string): string {
-    if (url) {
-      const paths = url.split('/');
-      const len = paths.length;
-      if (len > 1 && paths[len - 2] === 'namespaces') {
-        const hashIndex = paths[len - 1].indexOf('#');
-        return hashIndex > 0
-          ? paths[len - 1].substring(0, hashIndex)
-          : paths[len - 1];
-      }
-    }
-    return '';
-  }
-
-  private isClusterSpecific(url: string) {
-    const ns = this.namespaceFromUrl(url);
-    if (ns.length > 0) {
-      this.selectNamespace(ns);
-      return false;
-    }
-
-    if (url.includes('cluster-overview')) {
-      return (
-        this.currentNamespace.length === 0 ||
-        !url.endsWith(this.currentNamespace)
-      );
-    }
-
-    return false;
   }
 
   private routerLinkPath(namespace: string): string {

--- a/web/src/app/modules/sugarloaf/components/smart/namespace/namespace.component.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/namespace/namespace.component.ts
@@ -56,20 +56,16 @@ export class NamespaceComponent implements OnInit, OnDestroy {
       }
     );
 
-    this.navigationService.modules.subscribe(
-      modules => {
-        this.modules = modules;
-        this.cdr.detectChanges();
-      }
-    );
+    this.navigationService.modules.subscribe(modules => {
+      this.modules = modules;
+      this.cdr.detectChanges();
+    });
 
-    this.navigationService.selectedItem.subscribe(
-      selection => {
-        this.selectedItem = selection;
-        this.showDropdown = this.hasDropdown();
-        this.cdr.detectChanges();
-      }
-    );
+    this.navigationService.selectedItem.subscribe(selection => {
+      this.selectedItem = selection;
+      this.showDropdown = this.hasDropdown();
+      this.cdr.detectChanges();
+    });
     this.navigationService.activeUrl.subscribe(url => {
       this.activeUrl = url;
       this.cdr.detectChanges();

--- a/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.html
+++ b/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.html
@@ -46,7 +46,7 @@
     }">
     <ng-container
       *ngFor="
-        let section of getSelectedSections();
+        let section of currentModule?.children;
         let i = index;
         trackBy: identifyNavigationItem
       "
@@ -92,7 +92,7 @@
             >
               <a
                 [routerLink]="formatPath(category.path)"
-                [routerLinkActiveOptions]="{ exact: true }"
+                [routerLinkActiveOptions]="{ exact: false }"
                 routerLinkActive="active"
                 class="flyout-item nav-link"
                 (click)="setNavState(false, i)"
@@ -136,7 +136,7 @@
                 <a
                   clrVerticalNavLink
                   [routerLink]="formatPath(category.path)"
-                  [routerLinkActiveOptions]="{ exact: true }"
+                  [routerLinkActiveOptions]="{ exact: false }"
                   routerLinkActive="active"
                 >
                   <clr-icon
@@ -155,7 +155,7 @@
             clrVerticalNavLink
             (click)="closePopups(i)"
             [routerLink]="formatPath(section.path)"
-            [routerLinkActiveOptions]="{ exact: true }"
+            [routerLinkActiveOptions]="{ exact: i==0 }"
             routerLinkActive="active"
           >
             <clr-icon *ngIf="section.iconName"
@@ -177,11 +177,11 @@
           <div class="clr-col-12">
             <div class="card">
               <div class="card-header">
-                {{ getModuleTitle() }}
+                {{ currentModule?.title }}
               </div>
               <div class="card-block">
                 <div class="card-text">
-                {{ getModuleDescription() }}
+                {{ currentModule?.description }}
                 </div>
               </div>
             </div>

--- a/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.html
+++ b/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.html
@@ -1,39 +1,69 @@
-<clr-vertical-nav
-  [clrVerticalNavCollapsible]="true"
+<div class="navigation-top"
+  [ngClass]="{
+      'navigation-top-collapsed': collapsed,
+      'navigation-top-collapsed-labels': collapsed&&showLabels
+    }">
+  <clr-vertical-nav
+  [clrVerticalNavCollapsible]="false"
   [(clrVerticalNavCollapsed)]="collapsed"
   (clrVerticalNavCollapsedChange)="updateNavCollapsed($event)"
 >
-  <!-- Navigation items -->
+  <div class="navigation-main">
+    <clr-tabs clrLayout="vertical"
+      [ngClass]="{
+        'module-tabs': !showLabels,
+        'module-tabs-labels': showLabels
+      }">
+    >
+      <clr-tab *ngFor="let tab of modules; let i = index; trackBy: identifyTab">
+        <div clrTabLink (click)="setModule(i)" class="btn-icon"
+          [ngClass]="{
+            'button-tool': !showLabels,
+            'button-tool-labels': showLabels
+          }">
+            <div *ngIf="showLabels" class="button-wrapper">
+              <clr-icon class="icon-nav" [attr.shape]="tab.icon"></clr-icon>
+              <div class="button-text-wrapper">
+                <div class="button-text">{{tab.title}}</div>
+              </div>
+            </div>
+          <app-octant-tooltip *ngIf="!showLabels" [tooltipText]="tab.title">
+            <clr-icon class="icon-nav" [attr.shape]="tab.icon"></clr-icon>
+          </app-octant-tooltip>
+        </div>
+        <ng-template *clrIfActive="i === this.selectedItem.module">
+          <clr-tab-content>
+            <div></div>
+          </clr-tab-content>
+        </ng-template>
+      </clr-tab>
+      </clr-tabs>
+    <!-- Navigation items -->
   <div
     [ngClass]="{
       'navigation-items-collapsed': collapsed,
       'navigation-items': !collapsed
-    }"
-  >
+    }">
     <ng-container
       *ngFor="
-        let section of navigation.sections;
+        let section of getSelectedSections();
         let i = index;
         trackBy: identifyNavigationItem
       "
     >
       <!-- Collapsed Navigation -->
       <ng-container *ngIf="collapsed; else expanded">
-        <ng-template [ngIf]="section.module">
-          <div class="nav-divider"></div>
-        </ng-template>
-
         <a
           clrVerticalNavLink
           (click)="openPopup(i)"
-          [ngClass]="{ 'item-selected': i == this.lastSelection }"
+          [ngClass]="{ 'item-selected': i == this.selectedItem.index }"
           [routerLinkActiveOptions]="{ exact: !section.children?.length }"
           [routerLink]="formatPath(section.path)"
           routerLinkActive="active"
-          (mouseover)="flyoutIndex = i; lastSelection = i"
+          (mouseover)="flyoutIndex = i; selectedItem.index = i"
         >
           <clr-icon
-            [attr.shape]="section.iconName | default: 'home'"
+            [attr.shape]="section.iconName | default: 'play'"
             clrVerticalNavIcon
           ></clr-icon>
         </a>
@@ -41,8 +71,8 @@
         <div
           class="flyout nav-group-children"
           [ngClass]="{ 'flyout-empty': !section.children?.length }"
-          (mouseleave)="flyoutIndex = -1; lastSelection = -1"
-          (document:mouseleave)="flyoutIndex = -1; lastSelection = -1"
+          (mouseleave)="flyoutIndex = -1; selectedItem.index = -1"
+          (document:mouseleave)="flyoutIndex = -1; selectedItem.index = -1"
         >
           <a
             class="flyout-header"
@@ -75,10 +105,6 @@
       </ng-container>
       <!-- Expanded Navigation -->
       <ng-template #expanded>
-        <ng-template [ngIf]="section.module">
-          <div class="nav-divider"></div>
-          <span class="title">{{ section.module }}</span>
-        </ng-template>
         <ng-container
           *ngIf="section.children?.length > 0; else noChildExpanded"
         >
@@ -88,7 +114,7 @@
             (clrVerticalNavGroupExpandedChange)="setNavState($event, i)"
           >
             <clr-icon
-              [attr.shape]="section.iconName | default: 'home'"
+              [attr.shape]="section.iconName | default: 'exclamation-circle'"
               clrVerticalNavIcon
             ></clr-icon>
             {{ section.title }}
@@ -132,21 +158,38 @@
             [routerLinkActiveOptions]="{ exact: true }"
             routerLinkActive="active"
           >
-            <clr-icon
-              [attr.shape]="section.iconName | default: 'home'"
+            <clr-icon *ngIf="section.iconName"
+              [attr.shape]="section.iconName"
               clrVerticalNavIcon
             ></clr-icon>
-            <div class="nav-item-text">
+            <div class="nav-item-text"
+                 [ngClass]="{ 'nav-item-padded': !section.iconName }"
+            >
               {{ section.title }}
             </div>
           </a>
         </ng-template>
       </ng-template>
     </ng-container>
+    <div *ngIf="!collapsed" class="nav-description">
+      <div class="nav-description-inner">
+        <div class="clr-row">
+          <div class="clr-col-12">
+            <div class="card">
+              <div class="card-header">
+                {{ getModuleTitle() }}
+              </div>
+              <div class="card-block">
+                <div class="card-text">
+                {{ getModuleDescription() }}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
-
-  <!-- Theme switcher -->
-  <div class="theme-switcher">
-    <app-theme-switch-button [collapsed]="collapsed"></app-theme-switch-button>
-  </div>
+</div>
 </clr-vertical-nav>
+</div>

--- a/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.scss
+++ b/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.scss
@@ -28,10 +28,98 @@
   margin-left: 1.5rem;
 }
 
+:host ::ng-deep .navigation-top {
+  height: 100%;
+  clr-vertical-nav {
+    padding-top: 0px;
+  }
+}
+
+:host ::ng-deep .clr-vertical-nav .nav-group-text {
+  padding-right: 0px;
+}
+
+:host ::ng-deep .nav-group-content .nav-group-trigger-icon {
+  margin-left: 6px;
+}
+
+.navigation-top-collapsed {
+  width: 97px;
+}
+
+.navigation-top-collapsed-labels {
+  width: 117px;
+}
+
+.module-tabs {
+  width: 56px;
+  margin-right: 0px;
+}
+
+.module-tabs-labels {
+  width: 76px;
+  margin-right: 0px;
+}
+
+.button-tool.active,
+.button-tool-labels.active {
+  background-color: var(--selection-color)!important;
+}
+
+.button-tool {
+  width: 48px!important;
+  height: 48px!important;
+  padding: 4px 10px 10px 10px!important;
+  background-color: transparent!important;
+  outline: none;
+
+  .icon-nav {
+    width: 28px;
+    height: 28px;
+    margin-top: 8px;
+  }
+}
+
+.button-tool-labels {
+  width: 68px!important;
+  height: 64px!important;
+  padding: 0px 0px 0px 0px!important;
+  background-color: transparent!important;
+  outline: none;
+
+  .icon-nav {
+    width: 28px;
+    height: 28px;
+    margin-left: 18px;
+    margin-top: 8px;
+  }
+}
+
+.button-wrapper {
+  display: flex;
+  flex-direction: column;
+  height: 60px;
+}
+
+.button-text-wrapper {
+  display: flex;
+  align-items: center;
+  height: 24px;
+}
+
+.button-text {
+  width: 64px;
+  padding-left: 6px;
+  font-size: 10px;
+  line-height:  12px;
+  text-align: center;
+  white-space: normal;
+}
+
 .clr-vertical-nav {
   height: 100%;
   background: none;
-  width: 300px;
+  width: 350px;
   transition: none;
   will-change: none;
 
@@ -50,11 +138,15 @@
   .nav-icon {
     margin-top: auto;
     margin-bottom: auto;
-    margin-left: 0.8rem;
+    margin-left: 0.6rem;
   }
 
   .nav-item-text {
     line-height: 1.5rem;
+  }
+
+  .nav-item-padded {
+    padding-left: 16px;
   }
 
   .nav-group:not(.is-expanded) {
@@ -84,14 +176,73 @@
     color: var(--selection-color-hover);
   }
 
+  .navigation-main {
+    display: flex;
+    flex-direction: row;
+    flex-basis: 100%;
+    border-left: 1px solid rgba(173, 187, 196, 0.3);
+    border-bottom: 1px solid rgba(173, 187, 196, 0.3);
+  }
+
   .navigation-items {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+    overflow-y: hidden;
+    padding-top: 0.6rem;
+    border-left: 1px solid rgba(173, 187, 196, 0.3);
+  }
+
+  .navigation-items-collapsed {
+    width: 40px !important;
+    padding-top: 0.6rem;
+    height: 100%;
+    overflow-y: hidden;
+    border-left: 1px solid rgba(173, 187, 196, 0.3);
+  }
+
+  .top-level {
     flex-grow: 1;
     overflow-y: auto;
   }
 
-  .navigation-items-collapsed {
+  .top-level-collapsed {
+    display: flex;
+    flex-direction: column;
     flex-grow: 1;
     overflow-y: hidden;
+    padding-top: 16px;
+    border-left: 1px solid rgba(173, 187, 196, 0.3);
+  }
+
+  .nav-description{
+    display: flex;
+    flex: auto;
+    justify-content: flex-end;
+    flex-direction: column;
+  }
+
+  .nav-description-inner{
+    padding: 0.6rem;
+
+    .card {
+      min-height: 12rem;
+    }
+
+    .card-text {
+      line-height: 1.3;
+      font-size: 0.6rem;
+      overflow-wrap: anywhere;
+    }
+
+    .card-header {
+      font-size: 0.7rem;
+      padding: .6rem .6rem;
+    }
+
+    .card-block {
+      padding: .6rem .6rem;
+    }
   }
 
   .flyout-header {
@@ -135,7 +286,7 @@
     z-index: 502;
     position: fixed;
     margin-top: -30px;
-    margin-left: 48px;
+    margin-left: 40px;
     background-color: var(--flyout-background-color, #1b2a32);
     color: var(--flyout-color);
     padding: 0px;

--- a/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.scss
+++ b/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.scss
@@ -59,6 +59,10 @@
 .module-tabs-labels {
   width: 76px;
   margin-right: 0px;
+
+  ::ng-deep ul {
+    padding-top: 0.4rem;
+  }
 }
 
 .button-tool.active,
@@ -189,7 +193,7 @@
     flex-direction: column;
     flex-grow: 1;
     overflow-y: hidden;
-    padding-top: 0.6rem;
+    padding-top: 0.4rem;
     border-left: 1px solid rgba(173, 187, 196, 0.3);
   }
 

--- a/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.ts
@@ -100,7 +100,7 @@ export class NavigationComponent implements OnInit, OnDestroy {
       event.preventDefault();
       event.cancelBubble = true;
       this.themeService.switchTheme();
-    } else if (event.key === 'N' && event.ctrlKey) {
+    } else if (event.key === 'b' && event.ctrlKey) {
       event.preventDefault();
       event.cancelBubble = true;
       this.updateNavCollapsed(!this.collapsed);


### PR DESCRIPTION
Navigation redesign based on #1353. After going through a few iterations, we settled down on a module based two panel solution that still supports collapsed and expanded state and moves some of the rarely used actions to keyboard shortcuts for now and Preferences in future. 

Major changes:
- removed the Navigation Collapse/Expand toggle that used to take a lot of space at the top - that is now available only through `<Ctrl><Shift>N` and will be soon added to Preferences, 
- similarly, removed the Light/Dark theme switch - now available only through `<Ctrl><Shift>T`,
- the main navigation is now separated into two vertical panels: modules on the left and list of items that belong to selected module on right(right panel is collapsable),
- reorganized modules grouping, so module scoped plugins are recognized now, 
- added the module description card to display details about each module - currently that's only a text field, should have rich content in future,
- Added optional labels to module icons, toggle with `<Ctrl><Shift>L`,   

**Which issue(s) this PR fixes**
- Fixes #1353
