### PR TITLE
Help menu additional items

### DIFF
--- a/changelogs/unreleased/875-mklanjsek
+++ b/changelogs/unreleased/875-mklanjsek
@@ -1,0 +1,1 @@
+Implemented Help menu additional items

--- a/web/src/app/modules/shared/components/smart/helper/helper.component.html
+++ b/web/src/app/modules/shared/components/smart/helper/helper.component.html
@@ -12,15 +12,37 @@
         About Octant
       </div>
       <div
-        aria-label="Dropdown header About Octant"
+        aria-label="Dropdown header Show Releases"
+        clrDropdownItem
+        (click)="showReleases()"
+      >
+        Release Information
+      </div>
+      <div
+        class="with-shortcut"
+        aria-label="Dropdown header Keyboard Shortcuts"
         clrDropdownItem
         (click)="isShortcutModalOpen = true"
       >
         Keyboard Shortcuts
-        <span class="label">
+        <span class="label right-aligned">
           Ctrl
           <span class="badge">/</span>
         </span>
+      </div>
+      <div
+        aria-label="Dropdown header Open Issue"
+        clrDropdownItem
+        (click)="openIssue()"
+      >
+        Open an issue/Provide feedback
+      </div>
+      <div
+        aria-label="Dropdown header Show Documentation"
+        clrDropdownItem
+        (click)="showDocs()"
+      >
+        Octant Documentation
       </div>
     </clr-dropdown-menu>
   </clr-dropdown>
@@ -60,6 +82,39 @@
     </button>
   </div>
 </clr-modal>
+
+<clr-modal
+  [(clrModalOpen)]="isReleaseModalOpen"
+  [clrModalSize]= "'xl'"
+  [clrModalStaticBackdrop]="false"
+  [clrModalSkipAnimation]="true"
+>
+  <h3 class="modal-title">Octant Release Information</h3>
+  <div class="modal-body">
+    <ng-container *ngIf="releaseInfo.config.value; else loading">
+      <p class="release-info">
+        <app-view-text [view]="releaseInfo"></app-view-text>
+      </p>
+    </ng-container>
+    <ng-template #loading>
+      <div class="loading-spinner">
+        <span class="spinner">
+          Loading...
+        </span>
+      </div>
+    </ng-template>
+  </div>
+  <div class="modal-footer">
+    <button
+      type="button"
+      class="btn btn-primary"
+      (click)="isReleaseModalOpen = false"
+    >
+      Close
+    </button>
+  </div>
+</clr-modal>
+
 
 <clr-modal
   [(clrModalOpen)]="isShortcutModalOpen"

--- a/web/src/app/modules/shared/components/smart/helper/helper.component.scss
+++ b/web/src/app/modules/shared/components/smart/helper/helper.component.scss
@@ -14,3 +14,26 @@
     background: transparent;
   }
 }
+
+.right-aligned {
+  float: right;
+}
+
+clr-dropdown-menu .with-shortcut {
+  padding-right: 12px;
+}
+
+clr-dropdown-menu div {
+  padding-right: 48px;
+}
+
+.release-info {
+  height: 30rem;
+}
+
+.loading-spinner {
+  height: 30rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}

--- a/web/src/app/modules/shared/components/smart/helper/helper.component.ts
+++ b/web/src/app/modules/shared/components/smart/helper/helper.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit, OnDestroy, HostListener } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { HelperService } from '../../../../shared/services/helper/helper.service';
+import { TextView } from '../../../models/content';
 
 @Component({
   selector: 'app-helper',
@@ -11,8 +12,18 @@ export class HelperComponent implements OnInit, OnDestroy {
   version = '';
   commit = '';
   time = '';
+  releaseInfo: TextView = {
+    metadata: {
+      type: 'text',
+    },
+    config: {
+      value: '',
+      isMarkdown: true,
+    },
+  };
   isBuildModalOpen = false;
   isShortcutModalOpen = false;
+  isReleaseModalOpen = false;
   private buildInfoSubscription: Subscription;
 
   constructor(private helperService: HelperService) {}
@@ -27,6 +38,38 @@ export class HelperComponent implements OnInit, OnDestroy {
     this.buildInfoSubscription = this.helperService
       .buildTime()
       .subscribe(time => (this.time = time));
+  }
+
+  openIssue(): void {
+    window.open(
+      'https://github.com/vmware-tanzu/octant/issues/new/choose',
+      '_blank'
+    );
+  }
+
+  getReleaseInfo(version: string) {
+    const ver = version.substring(0, version.lastIndexOf('.'));
+    const baseUrl =
+      'https://raw.githubusercontent.com/vmware-tanzu/octant/master';
+    const url =
+      ver.length > 0
+        ? `${baseUrl}/changelogs/CHANGELOG-${ver}.md`
+        : `${baseUrl}/CHANGELOG.md`;
+
+    fetch(url)
+      .then(response => response.text())
+      .then(data => {
+        this.releaseInfo.config.value = data;
+      });
+  }
+
+  showReleases(): void {
+    this.getReleaseInfo(this.version);
+    this.isReleaseModalOpen = true;
+  }
+
+  showDocs(): void {
+    window.open('https://octant.dev/', '_blank');
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
This change adds remaining Help menu items:

- **Release Information** - shows the changelog for latest release in modal dialog (or summary changelog if version not available, for example in local build),
- **Open an issue/Provide feedback** - opens a new issue web page inside the new browser tab,
- **Octant Documentation** - opens `octant.dev` as external web page

![Screen Shot 2020-10-13 at 10 25 51 AM](https://user-images.githubusercontent.com/34245594/95891325-2b46e080-0d42-11eb-832c-dddfcec40d98.png)

![Screen Shot 2020-10-13 at 10 27 12 AM](https://user-images.githubusercontent.com/34245594/95891340-313cc180-0d42-11eb-8676-aec08d9aa22c.png)

Signed-off-by: Milan Klanjsek <mklanjsek@pivotal.io>

- Fixes #875 
