### PR TITLE
Fix karma test warnings

### DIFF
--- a/web/src/app/components/smart/home/home.component.spec.ts
+++ b/web/src/app/components/smart/home/home.component.spec.ts
@@ -1,11 +1,8 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { HomeComponent } from './home.component';
 import { initServiceStub } from 'src/app/testing/init-service-stub';
 import { InitService } from 'src/app/modules/shared/services/init/init.service';
-import { OverlayScrollbarsComponent } from 'overlayscrollbars-ngx';
-import { ApplyYAMLComponent } from 'src/app/modules/sugarloaf/components/smart/apply-yaml/apply-yaml.component';
-import { EditorComponent } from 'src/app/modules/shared/components/smart/editor/editor.component';
 import { SharedModule } from 'src/app/modules/shared/shared.module';
 
 describe('HomeComponent', () => {
@@ -13,23 +10,20 @@ describe('HomeComponent', () => {
   let fixture: ComponentFixture<HomeComponent>;
   let initService: InitService;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      providers: [
-        {
-          provide: InitService,
-          useValue: initServiceStub,
-        },
-        SharedModule,
-      ],
-      declarations: [
-        HomeComponent,
-        ApplyYAMLComponent,
-        EditorComponent,
-        OverlayScrollbarsComponent,
-      ],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        providers: [
+          {
+            provide: InitService,
+            useValue: initServiceStub,
+          },
+          SharedModule,
+        ],
+        declarations: [HomeComponent],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     initService = TestBed.inject(InitService);

--- a/web/src/app/data/services/websocket/websocket.service.spec.ts
+++ b/web/src/app/data/services/websocket/websocket.service.spec.ts
@@ -14,6 +14,7 @@ import {
 import uniqueId from 'lodash/uniqueId';
 import { BehaviorSubject } from 'rxjs';
 import { WindowToken } from '../../../window';
+import { OverlayscrollbarsModule } from 'overlayscrollbars-ngx';
 
 class NotifierServiceMock {
   private signalsStream: BehaviorSubject<NotifierSignal[]>;
@@ -39,6 +40,7 @@ describe('WebsocketService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
+      imports: [OverlayscrollbarsModule],
       providers: [
         WebsocketService,
         {

--- a/web/src/app/modules/denali/components/smart/home/home.component.spec.ts
+++ b/web/src/app/modules/denali/components/smart/home/home.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { HomeComponent } from './home.component';
 import { MonacoEditorConfig, MonacoProviderService } from 'ng-monaco-editor';
@@ -7,12 +7,14 @@ describe('AppComponent', () => {
   let component: HomeComponent;
   let fixture: ComponentFixture<HomeComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      providers: [MonacoProviderService, MonacoEditorConfig],
-      declarations: [HomeComponent],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        providers: [MonacoProviderService, MonacoEditorConfig],
+        declarations: [HomeComponent],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(HomeComponent);

--- a/web/src/app/modules/shared/components/missing-component/missing-component.component.spec.ts
+++ b/web/src/app/modules/shared/components/missing-component/missing-component.component.spec.ts
@@ -1,7 +1,6 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { MissingComponentComponent } from './missing-component.component';
-import { BrowserModule } from '@angular/platform-browser';
 import { CommonModule } from '@angular/common';
 import { ApplyYAMLComponent } from 'src/app/modules/sugarloaf/components/smart/apply-yaml/apply-yaml.component';
 import { OverlayScrollbarsComponent } from 'overlayscrollbars-ngx';
@@ -10,16 +9,18 @@ describe('MissingComponentComponent', () => {
   let component: MissingComponentComponent;
   let fixture: ComponentFixture<MissingComponentComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [
-        MissingComponentComponent,
-        ApplyYAMLComponent,
-        OverlayScrollbarsComponent,
-      ],
-      imports: [CommonModule],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [
+          MissingComponentComponent,
+          ApplyYAMLComponent,
+          OverlayScrollbarsComponent,
+        ],
+        imports: [CommonModule],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(MissingComponentComponent);

--- a/web/src/app/modules/shared/components/presentation/alert/alert.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/alert/alert.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { AlertComponent } from './alert.component';
 import { By } from '@angular/platform-browser';
@@ -9,11 +9,13 @@ describe('AlertComponent', () => {
   let component: AlertComponent;
   let fixture: ComponentFixture<AlertComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [AlertComponent, OctantTooltipComponent],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [AlertComponent, OctantTooltipComponent],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(AlertComponent);

--- a/web/src/app/modules/shared/components/presentation/annotations/annotations.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/annotations/annotations.component.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { AnnotationsComponent } from './annotations.component';
 
@@ -10,11 +10,13 @@ describe('AnnotationsComponent', () => {
   let component: AnnotationsComponent;
   let fixture: ComponentFixture<AnnotationsComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [AnnotationsComponent],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [AnnotationsComponent],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(AnnotationsComponent);

--- a/web/src/app/modules/shared/components/presentation/breadcrumb/breadcrumb.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/breadcrumb/breadcrumb.component.spec.ts
@@ -2,21 +2,25 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { SharedModule } from '../../../shared.module';
 import { BreadcrumbComponent } from './breadcrumb.component';
 import { By } from '@angular/platform-browser';
 import { DebugElement } from '@angular/core';
+import { OverlayScrollbarsComponent } from 'overlayscrollbars-ngx';
 
 describe('BreadcrumbComponent', () => {
   let component: BreadcrumbComponent;
   let fixture: ComponentFixture<BreadcrumbComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [SharedModule],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [OverlayScrollbarsComponent],
+        imports: [SharedModule],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(BreadcrumbComponent);

--- a/web/src/app/modules/shared/components/presentation/button-group/button-group.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/button-group/button-group.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { ButtonGroupComponent } from './button-group.component';
 import { ButtonGroupView } from '../../../models/content';
@@ -8,12 +8,14 @@ describe('ButtonGroupComponent', () => {
   let component: ButtonGroupComponent;
   let fixture: ComponentFixture<ButtonGroupComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ButtonGroupComponent],
-      providers: [{ provide: WindowToken, useFactory: windowProvider }],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [ButtonGroupComponent],
+        providers: [{ provide: WindowToken, useFactory: windowProvider }],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ButtonGroupComponent);

--- a/web/src/app/modules/shared/components/presentation/card-list/card-list.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/card-list/card-list.component.spec.ts
@@ -1,18 +1,26 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { CardListComponent } from './card-list.component';
 import { CardListView } from '../../../models/content';
 import { SharedModule } from '../../../shared.module';
+import {
+  OverlayScrollbarsComponent,
+  OverlayscrollbarsModule,
+} from 'overlayscrollbars-ngx';
+import { IndicatorComponent } from '../indicator/indicator.component';
 
 describe('CardListComponent', () => {
   let component: CardListComponent;
   let fixture: ComponentFixture<CardListComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [SharedModule],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [OverlayScrollbarsComponent, IndicatorComponent],
+        imports: [SharedModule, OverlayscrollbarsModule],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(CardListComponent);

--- a/web/src/app/modules/shared/components/presentation/card/card.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/card/card.component.spec.ts
@@ -1,9 +1,8 @@
 import {
-  async,
   ComponentFixture,
   fakeAsync,
   TestBed,
-  tick,
+  waitForAsync,
 } from '@angular/core/testing';
 
 import { CardComponent } from './card.component';
@@ -13,10 +12,12 @@ import { ViewService } from '../../../services/view/view.service';
 import { viewServiceStub } from 'src/app/testing/view-service.stub';
 import { SharedModule } from '../../../shared.module';
 import { FormComponent } from '../form/form.component';
-import { WebsocketService } from '../../../../../data/services/websocket/websocket.service';
-import { WebsocketServiceMock } from '../../../../../data/services/websocket/mock';
 import { windowProvider, WindowToken } from '../../../../../window';
 import { EditorComponent } from '../../smart/editor/editor.component';
+import {
+  OverlayScrollbarsComponent,
+  OverlayscrollbarsModule,
+} from 'overlayscrollbars-ngx';
 
 describe('CardComponent', () => {
   let component: CardComponent;
@@ -33,17 +34,19 @@ describe('CardComponent', () => {
     },
   };
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [EditorComponent],
-      imports: [SharedModule],
-      providers: [
-        { provide: FormBuilder, useValue: formBuilder },
-        { provide: ViewService, useValue: viewServiceStub },
-        { provide: WindowToken, useFactory: windowProvider },
-      ],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [EditorComponent, OverlayScrollbarsComponent],
+        imports: [SharedModule, OverlayscrollbarsModule],
+        providers: [
+          { provide: FormBuilder, useValue: formBuilder },
+          { provide: ViewService, useValue: viewServiceStub },
+          { provide: WindowToken, useFactory: windowProvider },
+        ],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(CardComponent);

--- a/web/src/app/modules/shared/components/presentation/code/code.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/code/code.component.spec.ts
@@ -2,18 +2,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { CodeComponent } from './code.component';
 
 describe('CodeComponent', () => {
   let component: CodeComponent;
   let fixture: ComponentFixture<CodeComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [CodeComponent],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [CodeComponent],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(CodeComponent);
@@ -25,14 +27,17 @@ describe('CodeComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('copy button copies text', async(() => {
-    spyOn(component, 'copyToClipboard');
+  it(
+    'copy button copies text',
+    waitForAsync(() => {
+      spyOn(component, 'copyToClipboard');
 
-    const button = fixture.debugElement.nativeElement.querySelector('button');
-    button.click();
+      const button = fixture.debugElement.nativeElement.querySelector('button');
+      button.click();
 
-    fixture.whenStable().then(() => {
-      expect(component.copyToClipboard).toHaveBeenCalled();
-    });
-  }));
+      fixture.whenStable().then(() => {
+        expect(component.copyToClipboard).toHaveBeenCalled();
+      });
+    })
+  );
 });

--- a/web/src/app/modules/shared/components/presentation/containers/containers.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/containers/containers.component.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { OverlayScrollbarsComponent } from 'overlayscrollbars-ngx';
 
 import { ContainersComponent } from './containers.component';
@@ -11,11 +11,13 @@ describe('ContainersComponent', () => {
   let component: ContainersComponent;
   let fixture: ComponentFixture<ContainersComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ContainersComponent, OverlayScrollbarsComponent],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [ContainersComponent, OverlayScrollbarsComponent],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ContainersComponent);

--- a/web/src/app/modules/shared/components/presentation/cytoscape/cytoscape.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/cytoscape/cytoscape.component.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { CytoscapeComponent } from './cytoscape.component';
 
@@ -10,11 +10,13 @@ describe('CytoscapeComponent', () => {
   let component: CytoscapeComponent;
   let fixture: ComponentFixture<CytoscapeComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [CytoscapeComponent],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [CytoscapeComponent],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(CytoscapeComponent);

--- a/web/src/app/modules/shared/components/presentation/cytoscape2/cytoscape2.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/cytoscape2/cytoscape2.component.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { Cytoscape2Component } from './cytoscape2.component';
 
@@ -10,11 +10,13 @@ describe('Cytoscape2Component', () => {
   let component: Cytoscape2Component;
   let fixture: ComponentFixture<Cytoscape2Component>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [Cytoscape2Component],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [Cytoscape2Component],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(Cytoscape2Component);

--- a/web/src/app/modules/shared/components/presentation/datagrid/datagrid.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/datagrid/datagrid.component.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { DatagridComponent } from './datagrid.component';
 import { SharedModule } from '../../../shared.module';
 import { windowProvider, WindowToken } from '../../../../../window';
@@ -11,12 +11,14 @@ describe('DatagridComponent', () => {
   let component: DatagridComponent;
   let fixture: ComponentFixture<DatagridComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [SharedModule],
-      providers: [{ provide: WindowToken, useFactory: windowProvider }],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [SharedModule],
+        providers: [{ provide: WindowToken, useFactory: windowProvider }],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(DatagridComponent);

--- a/web/src/app/modules/shared/components/presentation/donut-chart/donut-chart.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/donut-chart/donut-chart.component.spec.ts
@@ -3,20 +3,28 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { DonutChartComponent } from './donut-chart.component';
 import { DonutChartView } from '../../../models/content';
+import { SharedModule } from '../../../shared.module';
+import {
+  OverlayScrollbarsComponent,
+  OverlayscrollbarsModule,
+} from 'overlayscrollbars-ngx';
 
 describe('DonutChartComponent', () => {
   let component: DonutChartComponent;
   let fixture: ComponentFixture<DonutChartComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [DonutChartComponent],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [DonutChartComponent, OverlayScrollbarsComponent],
+        imports: [SharedModule, OverlayscrollbarsModule],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(DonutChartComponent);

--- a/web/src/app/modules/shared/components/presentation/error/error.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/error/error.component.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { ErrorComponent } from './error.component';
 import { SharedModule } from '../../../shared.module';
 
@@ -10,11 +10,13 @@ describe('ErrorComponent', () => {
   let component: ErrorComponent;
   let fixture: ComponentFixture<ErrorComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [SharedModule],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [SharedModule],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ErrorComponent);

--- a/web/src/app/modules/shared/components/presentation/expression-selector/expression-selector.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/expression-selector/expression-selector.component.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { ExpressionSelectorComponent } from './expression-selector.component';
 
@@ -10,11 +10,13 @@ describe('ExpressionSelectorComponent', () => {
   let component: ExpressionSelectorComponent;
   let fixture: ComponentFixture<ExpressionSelectorComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ExpressionSelectorComponent],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [ExpressionSelectorComponent],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ExpressionSelectorComponent);

--- a/web/src/app/modules/shared/components/presentation/flexlayout/flexlayout.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/flexlayout/flexlayout.component.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { FlexlayoutComponent } from './flexlayout.component';
 import { SharedModule } from '../../../shared.module';
 
@@ -10,11 +10,13 @@ describe('FlexlayoutComponent', () => {
   let component: FlexlayoutComponent;
   let fixture: ComponentFixture<FlexlayoutComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [SharedModule],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [SharedModule],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(FlexlayoutComponent);

--- a/web/src/app/modules/shared/components/presentation/form/form.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/form/form.component.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { FormComponent } from './form.component';
 import { ReactiveFormsModule } from '@angular/forms';
@@ -11,12 +11,14 @@ describe('FormComponent', () => {
   let component: FormComponent;
   let fixture: ComponentFixture<FormComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [FormComponent],
-      imports: [ReactiveFormsModule],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [FormComponent],
+        imports: [ReactiveFormsModule],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(FormComponent);

--- a/web/src/app/modules/shared/components/presentation/graphviz/graphviz.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/graphviz/graphviz.component.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { GraphvizComponent } from './graphviz.component';
 import { Component } from '@angular/core';
@@ -19,11 +19,13 @@ describe('GraphvizComponent', () => {
   let component: TestWrapperComponent;
   let fixture: ComponentFixture<TestWrapperComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [TestWrapperComponent, GraphvizComponent],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [TestWrapperComponent, GraphvizComponent],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TestWrapperComponent);

--- a/web/src/app/modules/shared/components/presentation/heptagon-grid-row/heptagon-grid-row.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/heptagon-grid-row/heptagon-grid-row.component.spec.ts
@@ -2,7 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  ComponentFixture,
+  fakeAsync,
+  TestBed,
+  waitForAsync,
+} from '@angular/core/testing';
 
 import {
   HeptagonGridRowComponent,
@@ -10,17 +15,21 @@ import {
 } from './heptagon-grid-row.component';
 import { HeptagonComponent } from '../../smart/heptagon/heptagon.component';
 import { windowProvider, WindowToken } from '../../../../../window';
+import { SharedModule } from '../../../shared.module';
 
 describe('HeptagonGridRowComponent', () => {
   let component: HeptagonGridRowComponent;
   let fixture: ComponentFixture<HeptagonGridRowComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [HeptagonGridRowComponent, HeptagonComponent],
-      providers: [{ provide: WindowToken, useFactory: windowProvider }],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [HeptagonGridRowComponent, HeptagonComponent],
+        imports: [SharedModule],
+        providers: [{ provide: WindowToken, useFactory: windowProvider }],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(HeptagonGridRowComponent);
@@ -40,17 +49,22 @@ describe('HeptagonGridRowComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should report when a heptagon is hovered', () => {
-    let got: HoverStatus;
-    component.hoverState.subscribe((status: HoverStatus) => (got = status));
+  it(
+    'should report when a heptagon is hovered',
+    waitForAsync(() => {
+      fixture.whenStable().then(() => {
+        let got: HoverStatus;
+        component.hoverState.subscribe((status: HoverStatus) => (got = status));
 
-    component.updateHover(true, 1);
+        component.updateHover(true, 1);
 
-    const expected: HoverStatus = {
-      row: component.row,
-      col: 1,
-      hovered: true,
-    };
-    expect(got).toEqual(expected);
-  });
+        const expected: HoverStatus = {
+          row: component.row,
+          col: 1,
+          hovered: true,
+        };
+        expect(got).toEqual(expected);
+      });
+    })
+  );
 });

--- a/web/src/app/modules/shared/components/presentation/heptagon-grid/heptagon-grid.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/heptagon-grid/heptagon-grid.component.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { HeptagonGridComponent } from './heptagon-grid.component';
 import {
   HeptagonGridRowComponent,
@@ -16,17 +16,19 @@ describe('HeptagonGridComponent', () => {
   let component: HeptagonGridComponent;
   let fixture: ComponentFixture<HeptagonGridComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [
-        HeptagonGridComponent,
-        HeptagonGridRowComponent,
-        HeptagonLabelComponent,
-        HeptagonComponent,
-      ],
-      providers: [{ provide: WindowToken, useFactory: windowProvider }],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [
+          HeptagonGridComponent,
+          HeptagonGridRowComponent,
+          HeptagonLabelComponent,
+          HeptagonComponent,
+        ],
+        providers: [{ provide: WindowToken, useFactory: windowProvider }],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(HeptagonGridComponent);

--- a/web/src/app/modules/shared/components/presentation/iframe/iframe.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/iframe/iframe.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { SafePipe } from '../../../pipes/safe/safe.pipe';
 import { IFrameComponent } from './iframe.component';
@@ -7,11 +7,13 @@ describe('IFrameComponent', () => {
   let component: IFrameComponent;
   let fixture: ComponentFixture<IFrameComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [IFrameComponent, SafePipe],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [IFrameComponent, SafePipe],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(IFrameComponent);

--- a/web/src/app/modules/shared/components/presentation/indicator/indicator.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/indicator/indicator.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import {
   IndicatorComponent,
   Status,
@@ -22,11 +22,13 @@ describe('IndicatorComponent', () => {
 
   let element: HTMLDivElement;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [WrapperComponent, IndicatorComponent],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [WrapperComponent, IndicatorComponent],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(WrapperComponent);

--- a/web/src/app/modules/shared/components/presentation/label-selector/label-selector.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/label-selector/label-selector.component.spec.ts
@@ -2,7 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import {
+  OverlayScrollbarsComponent,
+  OverlayscrollbarsModule,
+} from 'overlayscrollbars-ngx';
+import { EditorComponent } from '../../smart/editor/editor.component';
 
 import { LabelSelectorComponent } from './label-selector.component';
 
@@ -10,11 +15,18 @@ describe('LabelSelectorComponent', () => {
   let component: LabelSelectorComponent;
   let fixture: ComponentFixture<LabelSelectorComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [LabelSelectorComponent],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [
+          LabelSelectorComponent,
+          EditorComponent,
+          OverlayScrollbarsComponent,
+        ],
+        imports: [OverlayscrollbarsModule],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(LabelSelectorComponent);

--- a/web/src/app/modules/shared/components/presentation/labels/labels.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/labels/labels.component.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { LabelsComponent } from './labels.component';
 
@@ -10,11 +10,13 @@ describe('LabelsComponent', () => {
   let component: LabelsComponent;
   let fixture: ComponentFixture<LabelsComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [LabelsComponent],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [LabelsComponent],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(LabelsComponent);

--- a/web/src/app/modules/shared/components/presentation/link/link.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/link/link.component.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { LinkComponent } from './link.component';
 import { SharedModule } from '../../../shared.module';
@@ -11,11 +11,13 @@ describe('LinkComponent', () => {
   let component: LinkComponent;
   let fixture: ComponentFixture<LinkComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [SharedModule, RouterTestingModule],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [SharedModule, RouterTestingModule],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(LinkComponent);

--- a/web/src/app/modules/shared/components/presentation/list/list.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/list/list.component.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { ListComponent } from './list.component';
 import { SharedModule } from '../../../shared.module';
 
@@ -10,11 +10,13 @@ describe('ListComponent', () => {
   let component: ListComponent;
   let fixture: ComponentFixture<ListComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [SharedModule],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [SharedModule],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ListComponent);

--- a/web/src/app/modules/shared/components/presentation/loading/loading.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/loading/loading.component.spec.ts
@@ -2,19 +2,23 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { LoadingComponent } from './loading.component';
 import { SharedModule } from '../../../shared.module';
+import { OverlayScrollbarsComponent } from 'overlayscrollbars-ngx';
 
 describe('LoadingComponent', () => {
   let component: LoadingComponent;
   let fixture: ComponentFixture<LoadingComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [SharedModule],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [OverlayScrollbarsComponent],
+        imports: [SharedModule],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(LoadingComponent);

--- a/web/src/app/modules/shared/components/presentation/modal/modal.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/modal/modal.component.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { ModalComponent } from './modal.component';
 import { SharedModule } from '../../../shared.module';
 import { ModalService } from '../../../services/modal/modal.service';
@@ -13,16 +13,18 @@ describe('ModalComponent', () => {
   let component: ModalComponent;
   let fixture: ComponentFixture<ModalComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [SharedModule],
-      declarations: [ModalComponent, OctantTooltipComponent],
-      providers: [
-        { provide: ModalService },
-        { provide: WindowToken, useFactory: windowProvider },
-      ],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [SharedModule],
+        declarations: [ModalComponent, OctantTooltipComponent],
+        providers: [
+          { provide: ModalService },
+          { provide: WindowToken, useFactory: windowProvider },
+        ],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ModalComponent);

--- a/web/src/app/modules/shared/components/presentation/object-status/object-status.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/object-status/object-status.component.spec.ts
@@ -2,19 +2,26 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { ObjectStatusComponent } from './object-status.component';
 import { SharedModule } from '../../../shared.module';
+import {
+  OverlayScrollbarsComponent,
+  OverlayscrollbarsModule,
+} from 'overlayscrollbars-ngx';
 
 describe('ObjectStatusComponent', () => {
   let component: ObjectStatusComponent;
   let fixture: ComponentFixture<ObjectStatusComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [SharedModule],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [OverlayScrollbarsComponent],
+        imports: [SharedModule, OverlayscrollbarsModule],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ObjectStatusComponent);

--- a/web/src/app/modules/shared/components/presentation/octant-tooltip/octant-tooltip.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/octant-tooltip/octant-tooltip.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { OctantTooltipComponent } from './octant-tooltip';
 import { SharedModule } from '../../../shared.module';
 import { windowProvider, WindowToken } from '../../../../../window';
@@ -11,12 +11,14 @@ describe('OctantTooltipComponent', () => {
   let component: OctantTooltipComponent;
   let fixture: ComponentFixture<OctantTooltipComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [SharedModule],
-      providers: [{ provide: WindowToken, useFactory: windowProvider }],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [SharedModule],
+        providers: [{ provide: WindowToken, useFactory: windowProvider }],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(OctantTooltipComponent);

--- a/web/src/app/modules/shared/components/presentation/overflow-labels/overflow-labels.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/overflow-labels/overflow-labels.component.spec.ts
@@ -2,27 +2,30 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { OverflowLabelsComponent } from './overflow-labels.component';
 import { By } from '@angular/platform-browser';
 import { LabelFilterService } from '../../../services/label-filter/label-filter.service';
-import { WebsocketService } from '../../../../../data/services/websocket/websocket.service';
-import { WebsocketServiceMock } from '../../../../../data/services/websocket/mock';
 import { windowProvider, WindowToken } from '../../../../../window';
+import { SharedModule } from '../../../shared.module';
+import { OctantTooltipComponent } from '../octant-tooltip/octant-tooltip';
 
 describe('OverflowLabelsComponent', () => {
   let component: OverflowLabelsComponent;
   let fixture: ComponentFixture<OverflowLabelsComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [OverflowLabelsComponent],
-      providers: [
-        LabelFilterService,
-        { provide: WindowToken, useFactory: windowProvider },
-      ],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [OverflowLabelsComponent, OctantTooltipComponent],
+        providers: [
+          SharedModule,
+          LabelFilterService,
+          { provide: WindowToken, useFactory: windowProvider },
+        ],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(OverflowLabelsComponent);

--- a/web/src/app/modules/shared/components/presentation/overflow-selectors/overflow-selectors.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/overflow-selectors/overflow-selectors.component.spec.ts
@@ -2,18 +2,25 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { SharedModule } from '../../../shared.module';
+import { OctantTooltipComponent } from '../octant-tooltip/octant-tooltip';
 import { OverflowSelectorsComponent } from './overflow-selectors.component';
+import { windowProvider, WindowToken } from '../../../../../window';
 
 describe('OverflowSelectorsComponent', () => {
   let component: OverflowSelectorsComponent;
   let fixture: ComponentFixture<OverflowSelectorsComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [OverflowSelectorsComponent],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [OverflowSelectorsComponent, OctantTooltipComponent],
+        imports: [SharedModule],
+        providers: [{ provide: WindowToken, useFactory: windowProvider }],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(OverflowSelectorsComponent);

--- a/web/src/app/modules/shared/components/presentation/pod-status/pod-status.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/pod-status/pod-status.component.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { HeptagonGridComponent } from '../heptagon-grid/heptagon-grid.component';
 import { PodStatusComponent } from './pod-status.component';
 import { Component, Input } from '@angular/core';
@@ -25,24 +25,26 @@ describe('PodStatusComponent', () => {
   let component: PodStatusComponent;
   let fixture: ComponentFixture<PodStatusComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [HighlightModule],
-      declarations: [PodStatusComponent, TestGridComponent],
-      providers: [
-        { provide: HeptagonGridComponent, useClass: TestGridComponent },
-        {
-          provide: HIGHLIGHT_OPTIONS,
-          useValue: {
-            languages: {
-              json: () => import('highlight.js/lib/languages/json'),
-              yaml: () => import('highlight.js/lib/languages/yaml'),
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [HighlightModule],
+        declarations: [PodStatusComponent, TestGridComponent],
+        providers: [
+          { provide: HeptagonGridComponent, useClass: TestGridComponent },
+          {
+            provide: HIGHLIGHT_OPTIONS,
+            useValue: {
+              languages: {
+                json: () => import('highlight.js/lib/languages/json'),
+                yaml: () => import('highlight.js/lib/languages/yaml'),
+              },
             },
           },
-        },
-      ],
-    }).compileComponents();
-  }));
+        ],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(PodStatusComponent);

--- a/web/src/app/modules/shared/components/presentation/port-forward/port-forward.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/port-forward/port-forward.component.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { PortForwardComponent } from './port-forward.component';
 
@@ -10,11 +10,13 @@ describe('PortForwardComponent', () => {
   let component: PortForwardComponent;
   let fixture: ComponentFixture<PortForwardComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [PortForwardComponent],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [PortForwardComponent],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(PortForwardComponent);

--- a/web/src/app/modules/shared/components/presentation/ports/ports.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/ports/ports.component.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { PortsComponent } from './ports.component';
 import { ButtonGroupComponent } from '../button-group/button-group.component';
@@ -11,11 +11,13 @@ describe('PortsComponent', () => {
   let component: PortsComponent;
   let fixture: ComponentFixture<PortsComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [PortsComponent, ButtonGroupComponent],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [PortsComponent, ButtonGroupComponent],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(PortsComponent);

--- a/web/src/app/modules/shared/components/presentation/preferences/preferences.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/preferences/preferences.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { PreferencesComponent } from './preferences.component';
 import { BrowserModule } from '@angular/platform-browser';
@@ -8,12 +8,14 @@ describe('PreferencesComponent', () => {
   let component: PreferencesComponent;
   let fixture: ComponentFixture<PreferencesComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [PreferencesComponent],
-      imports: [BrowserModule, ReactiveFormsModule, FormsModule],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [PreferencesComponent],
+        imports: [BrowserModule, ReactiveFormsModule, FormsModule],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(PreferencesComponent);

--- a/web/src/app/modules/shared/components/presentation/quadrant/quadrant.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/quadrant/quadrant.component.spec.ts
@@ -2,19 +2,26 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { QuadrantComponent } from './quadrant.component';
 import { SharedModule } from '../../../shared.module';
+import {
+  OverlayScrollbarsComponent,
+  OverlayscrollbarsModule,
+} from 'overlayscrollbars-ngx';
 
 describe('QuadrantComponent', () => {
   let component: QuadrantComponent;
   let fixture: ComponentFixture<QuadrantComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [SharedModule],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [OverlayScrollbarsComponent],
+        imports: [SharedModule, OverlayscrollbarsModule],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(QuadrantComponent);

--- a/web/src/app/modules/shared/components/presentation/resource-viewer/resource-viewer.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/resource-viewer/resource-viewer.component.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { ResourceViewerComponent } from './resource-viewer.component';
 import { SharedModule } from '../../../shared.module';
 import { OverlayScrollbarsComponent } from 'overlayscrollbars-ngx';
@@ -11,12 +11,14 @@ describe('ResourceViewerComponent', () => {
   let component: ResourceViewerComponent;
   let fixture: ComponentFixture<ResourceViewerComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [OverlayScrollbarsComponent],
-      imports: [SharedModule],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [OverlayScrollbarsComponent],
+        imports: [SharedModule],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ResourceViewerComponent);

--- a/web/src/app/modules/shared/components/presentation/selectors/selectors.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/selectors/selectors.component.spec.ts
@@ -2,19 +2,23 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { SelectorsComponent } from './selectors.component';
 import { SharedModule } from '../../../shared.module';
+import { EditorComponent } from '../../smart/editor/editor.component';
 
 describe('SelectorsComponent', () => {
   let component: SelectorsComponent;
   let fixture: ComponentFixture<SelectorsComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [SharedModule],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [EditorComponent],
+        imports: [SharedModule],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(SelectorsComponent);

--- a/web/src/app/modules/shared/components/presentation/single-stat/single-stat.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/single-stat/single-stat.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { SingleStatComponent } from './single-stat.component';
 import { SingleStatView } from '../../../models/content';
@@ -7,11 +7,13 @@ describe('SingleStatComponent', () => {
   let component: SingleStatComponent;
   let fixture: ComponentFixture<SingleStatComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [SingleStatComponent],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [SingleStatComponent],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(SingleStatComponent);

--- a/web/src/app/modules/shared/components/presentation/stepper/stepper.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/stepper/stepper.component.spec.ts
@@ -1,4 +1,9 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  async,
+  ComponentFixture,
+  TestBed,
+  waitForAsync,
+} from '@angular/core/testing';
 import { StepperComponent } from './stepper.component';
 import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { StepperView } from '../../../models/content';
@@ -40,19 +45,24 @@ describe('StepperComponent', () => {
     },
   };
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [
-        ReactiveFormsModule,
-        BrowserAnimationsModule,
-        NoopAnimationsModule,
-      ],
-      providers: [
-        { provide: FormBuilder, useValue: formBuilder },
-        { provide: WebsocketService, useValue: instance(mockWebsocketService) },
-      ],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [
+          ReactiveFormsModule,
+          BrowserAnimationsModule,
+          NoopAnimationsModule,
+        ],
+        providers: [
+          { provide: FormBuilder, useValue: formBuilder },
+          {
+            provide: WebsocketService,
+            useValue: instance(mockWebsocketService),
+          },
+        ],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(StepperComponent);
@@ -63,23 +73,32 @@ describe('StepperComponent', () => {
     fixture.detectChanges();
   });
 
-  it('should submit form after completing each step', () => {
-    let nextButton = fixture.debugElement.nativeElement.querySelector('.next');
-    nextButton.click();
-    fixture.detectChanges();
+  it(
+    'should submit form after completing each step',
+    waitForAsync(() => {
+      fixture.whenStable().then(() => {
+        let nextButton = fixture.debugElement.nativeElement.querySelector(
+          '.next'
+        );
+        nextButton.click();
+        fixture.detectChanges();
 
-    nextButton = fixture.debugElement.nativeElement.querySelector('.submit');
-    nextButton.click();
-    fixture.detectChanges();
+        nextButton = fixture.debugElement.nativeElement.querySelector(
+          '.submit'
+        );
+        nextButton.click();
+        fixture.detectChanges();
 
-    verify(
-      mockWebsocketService.sendMessage(
-        'action.octant.dev/performAction',
-        deepEqual({
-          action,
-          formGroup: anything(),
-        })
-      )
-    ).once();
-  });
+        verify(
+          mockWebsocketService.sendMessage(
+            'action.octant.dev/performAction',
+            deepEqual({
+              action,
+              formGroup: anything(),
+            })
+          )
+        ).once();
+      });
+    })
+  );
 });

--- a/web/src/app/modules/shared/components/presentation/summary/summary.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/summary/summary.component.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { SummaryComponent } from './summary.component';
 import { SharedModule } from '../../../shared.module';
 import { windowProvider, WindowToken } from '../../../../../window';
@@ -11,12 +11,14 @@ describe('SummaryComponent', () => {
   let component: SummaryComponent;
   let fixture: ComponentFixture<SummaryComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [SharedModule],
-      providers: [{ provide: WindowToken, useFactory: windowProvider }],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [SharedModule],
+        providers: [{ provide: WindowToken, useFactory: windowProvider }],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(SummaryComponent);

--- a/web/src/app/modules/shared/components/presentation/table/table.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/table/table.component.spec.ts
@@ -2,19 +2,23 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { TableComponent } from './table.component';
 import { SharedModule } from '../../../shared.module';
+import { IndicatorComponent } from '../indicator/indicator.component';
 
 describe('TableComponent', () => {
   let component: TableComponent;
   let fixture: ComponentFixture<TableComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [SharedModule],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [IndicatorComponent],
+        imports: [SharedModule],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TableComponent);

--- a/web/src/app/modules/shared/components/presentation/tabs/tabs.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/tabs/tabs.component.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { TabsComponent } from './tabs.component';
 import { SharedModule } from '../../../shared.module';
 import { windowProvider, WindowToken } from '../../../../../window';
@@ -12,13 +12,15 @@ describe('TabsComponent', () => {
   let component: TabsComponent;
   let fixture: ComponentFixture<TabsComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [OctantTooltipComponent],
-      imports: [SharedModule],
-      providers: [{ provide: WindowToken, useFactory: windowProvider }],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [OctantTooltipComponent],
+        imports: [SharedModule],
+        providers: [{ provide: WindowToken, useFactory: windowProvider }],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TabsComponent);

--- a/web/src/app/modules/shared/components/presentation/text/text.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/text/text.component.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 import { Component } from '@angular/core';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { TextView } from '../../../models/content';
 import { TextComponent } from './text.component';
@@ -20,13 +20,15 @@ describe('TextComponent', () => {
     let component: TestWrapperComponent;
     let fixture: ComponentFixture<TestWrapperComponent>;
 
-    beforeEach(async(() => {
-      TestBed.configureTestingModule({
-        providers: [ClrPopoverToggleService],
-        declarations: [TestWrapperComponent, TextComponent],
-        imports: [ClarityModule],
-      }).compileComponents();
-    }));
+    beforeEach(
+      waitForAsync(() => {
+        TestBed.configureTestingModule({
+          providers: [ClrPopoverToggleService],
+          declarations: [TestWrapperComponent, TextComponent],
+          imports: [ClarityModule],
+        }).compileComponents();
+      })
+    );
 
     beforeEach(() => {
       fixture = TestBed.createComponent(TestWrapperComponent);

--- a/web/src/app/modules/shared/components/presentation/timestamp/timestamp.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/timestamp/timestamp.component.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { TimestampComponent } from './timestamp.component';
 import { SharedModule } from '../../../shared.module';
 import { windowProvider, WindowToken } from '../../../../../window';
@@ -12,13 +12,15 @@ describe('TimestampComponent', () => {
   let component: TimestampComponent;
   let fixture: ComponentFixture<TimestampComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [SharedModule],
-      declarations: [EditorComponent],
-      providers: [{ provide: WindowToken, useFactory: windowProvider }],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [SharedModule],
+        declarations: [EditorComponent],
+        providers: [{ provide: WindowToken, useFactory: windowProvider }],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TimestampComponent);

--- a/web/src/app/modules/shared/components/presentation/title/title.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/title/title.component.spec.ts
@@ -4,7 +4,7 @@
  *
  */
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { TitleComponent } from './title.component';
 import { TextComponent } from '../text/text.component';
@@ -14,11 +14,13 @@ describe('TitleComponent', () => {
   let component: TitleComponent;
   let fixture: ComponentFixture<TitleComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [TitleComponent, TextComponent, LinkComponent],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [TitleComponent, TextComponent, LinkComponent],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TitleComponent);

--- a/web/src/app/modules/shared/components/presentation/yaml/yaml.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/yaml/yaml.component.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { YamlComponent } from './yaml.component';
 import { SharedModule } from '../../../shared.module';
 
@@ -10,11 +10,13 @@ describe('YamlComponent', () => {
   let component: YamlComponent;
   let fixture: ComponentFixture<YamlComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [SharedModule],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [SharedModule],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(YamlComponent);

--- a/web/src/app/modules/shared/components/smart/bottom-panel/bottom-panel.component.spec.ts
+++ b/web/src/app/modules/shared/components/smart/bottom-panel/bottom-panel.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import {
   BottomPanelComponent,
@@ -14,12 +14,14 @@ describe('BottomPanelComponent', () => {
   let component: BottomPanelComponent;
   let fixture: ComponentFixture<BottomPanelComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [BottomPanelComponent],
-      imports: [NoopAnimationsModule, ResizableModule],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [BottomPanelComponent],
+        imports: [NoopAnimationsModule, ResizableModule],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(BottomPanelComponent);

--- a/web/src/app/modules/shared/components/smart/context-selector/context-selector.component.spec.ts
+++ b/web/src/app/modules/shared/components/smart/context-selector/context-selector.component.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { ContextSelectorComponent } from './context-selector.component';
 import { KubeContextService } from '../../../services/kube-context/kube-context.service';
@@ -34,18 +34,20 @@ describe('ContextSelectorComponent', () => {
   let component: ContextSelectorComponent;
   let fixture: ComponentFixture<ContextSelectorComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [
-        ContextSelectorComponent,
-        OctantTooltipComponent,
-        TruncatePipe,
-      ],
-      providers: [
-        { provide: KubeContextService, useClass: MockKubeContextService },
-      ],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [
+          ContextSelectorComponent,
+          OctantTooltipComponent,
+          TruncatePipe,
+        ],
+        providers: [
+          { provide: KubeContextService, useClass: MockKubeContextService },
+        ],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ContextSelectorComponent);

--- a/web/src/app/modules/shared/components/smart/context-selector/context-selector.component.ts
+++ b/web/src/app/modules/shared/components/smart/context-selector/context-selector.component.ts
@@ -32,7 +32,9 @@ export class ContextSelectorComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.kubeContextSubscription.unsubscribe();
+    if (this.kubeContextSubscription) {
+      this.kubeContextSubscription.unsubscribe();
+    }
   }
 
   contextClass(context: ContextDescription) {

--- a/web/src/app/modules/shared/components/smart/editor/editor.component.spec.ts
+++ b/web/src/app/modules/shared/components/smart/editor/editor.component.spec.ts
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { EditorComponent } from './editor.component';
 import {
   MonacoEditorConfig,
@@ -15,22 +15,24 @@ describe('EditorComponent', () => {
   let component: EditorComponent;
   let fixture: ComponentFixture<EditorComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      providers: [
-        MonacoProviderService,
-        MonacoEditorConfig,
-        { provide: WindowToken, useFactory: windowProvider },
-      ],
-      imports: [
-        MonacoEditorModule.forRoot({
-          baseUrl: '',
-          defaultOptions: {},
-        }),
-      ],
-      declarations: [EditorComponent],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        providers: [
+          MonacoProviderService,
+          MonacoEditorConfig,
+          { provide: WindowToken, useFactory: windowProvider },
+        ],
+        imports: [
+          MonacoEditorModule.forRoot({
+            baseUrl: '',
+            defaultOptions: {},
+          }),
+        ],
+        declarations: [EditorComponent],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(EditorComponent);

--- a/web/src/app/modules/shared/components/smart/filters/filters.component.spec.ts
+++ b/web/src/app/modules/shared/components/smart/filters/filters.component.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { ActivatedRoute, Router } from '@angular/router';
 import { BehaviorSubject } from 'rxjs';
 import {
@@ -10,7 +10,6 @@ import {
   LabelFilterService,
 } from 'src/app/modules/shared/services/label-filter/label-filter.service';
 import { ActivatedRouteStub } from 'src/app/testing/activated-route-stub';
-import { FormsModule } from '@angular/forms';
 import { FiltersComponent } from './filters.component';
 import { SharedModule } from '../../../shared.module';
 import { ApplyYAMLComponent } from 'src/app/modules/sugarloaf/components/smart/apply-yaml/apply-yaml.component';
@@ -28,21 +27,23 @@ describe('FiltersComponent', () => {
   let fixture: ComponentFixture<FiltersComponent>;
   let routerSpy: any;
 
-  beforeEach(async(() => {
-    const mockRouter = {
-      navigate: jasmine.createSpy('navigate'),
-    };
+  beforeEach(
+    waitForAsync(() => {
+      const mockRouter = {
+        navigate: jasmine.createSpy('navigate'),
+      };
 
-    TestBed.configureTestingModule({
-      declarations: [ApplyYAMLComponent, OverlayScrollbarsComponent],
-      imports: [SharedModule],
-      providers: [
-        { provide: Router, useValue: mockRouter },
-        { provide: ActivatedRoute, useValue: activatedRouteStub },
-        { provide: LabelFilterService, useValue: labelFilterService },
-      ],
-    }).compileComponents();
-  }));
+      TestBed.configureTestingModule({
+        declarations: [ApplyYAMLComponent, OverlayScrollbarsComponent],
+        imports: [SharedModule],
+        providers: [
+          { provide: Router, useValue: mockRouter },
+          { provide: ActivatedRoute, useValue: activatedRouteStub },
+          { provide: LabelFilterService, useValue: labelFilterService },
+        ],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     routerSpy = TestBed.inject(Router);
@@ -51,9 +52,12 @@ describe('FiltersComponent', () => {
     fixture.detectChanges();
   });
 
-  it('should create', async(() => {
-    fixture.whenStable().then(() => {
-      expect(component).toBeTruthy();
-    });
-  }));
+  it(
+    'should create',
+    waitForAsync(() => {
+      fixture.whenStable().then(() => {
+        expect(component).toBeTruthy();
+      });
+    })
+  );
 });

--- a/web/src/app/modules/shared/components/smart/helper/helper.component.spec.ts
+++ b/web/src/app/modules/shared/components/smart/helper/helper.component.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { HelperComponent } from './helper.component';
 import { HelperService } from '../../../services/helper/helper.service';
@@ -13,16 +13,18 @@ describe('HelperComponent', () => {
   let component: HelperComponent;
   let fixture: ComponentFixture<HelperComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [HelperComponent],
-      providers: [
-        { provide: HelperService },
-        { provide: WindowToken, useFactory: windowProvider },
-      ],
-      imports: [BrowserAnimationsModule],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [HelperComponent],
+        providers: [
+          { provide: HelperService },
+          { provide: WindowToken, useFactory: windowProvider },
+        ],
+        imports: [BrowserAnimationsModule],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(HelperComponent);

--- a/web/src/app/modules/shared/components/smart/helper/helper.component.ts
+++ b/web/src/app/modules/shared/components/smart/helper/helper.component.ts
@@ -73,7 +73,9 @@ export class HelperComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.buildInfoSubscription.unsubscribe();
+    if (this.buildInfoSubscription) {
+      this.buildInfoSubscription.unsubscribe();
+    }
   }
 
   @HostListener('window:keydown', ['$event'])

--- a/web/src/app/modules/shared/components/smart/heptagon/heptagon.component.spec.ts
+++ b/web/src/app/modules/shared/components/smart/heptagon/heptagon.component.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { HeptagonComponent } from './heptagon.component';
 import { Point } from '../../../models/point';
@@ -14,16 +14,18 @@ describe('HeptagonComponent', () => {
   let component: HeptagonComponent;
   let fixture: ComponentFixture<HeptagonComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [
-        HeptagonComponent,
-        OctantTooltipComponent,
-        OverlayScrollbarsComponent,
-      ],
-      providers: [{ provide: WindowToken, useFactory: windowProvider }],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [
+          HeptagonComponent,
+          OctantTooltipComponent,
+          OverlayScrollbarsComponent,
+        ],
+        providers: [{ provide: WindowToken, useFactory: windowProvider }],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(HeptagonComponent);

--- a/web/src/app/modules/shared/components/smart/slider-view/slider-view.component.spec.ts
+++ b/web/src/app/modules/shared/components/smart/slider-view/slider-view.component.spec.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { SliderViewComponent } from './slider-view.component';
 import { SharedModule } from '../../../shared.module';
@@ -14,12 +14,14 @@ describe('SliderViewComponent', () => {
   let component: SliderViewComponent;
   let fixture: ComponentFixture<SliderViewComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [SharedModule, BrowserAnimationsModule],
-      providers: [{ provide: WindowToken, useFactory: windowProvider }],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [SharedModule, BrowserAnimationsModule],
+        providers: [{ provide: WindowToken, useFactory: windowProvider }],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(SliderViewComponent);

--- a/web/src/app/modules/shared/components/smart/terminal/terminal.component.spec.ts
+++ b/web/src/app/modules/shared/components/smart/terminal/terminal.component.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2019 the Octant contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { TerminalComponent } from './terminal.component';
 import { TerminalView } from '../../../models/content';
 import { windowProvider, WindowToken } from '../../../../../window';
@@ -10,12 +10,14 @@ describe('TerminalComponent', () => {
   let component: TerminalComponent;
   let fixture: ComponentFixture<TerminalComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [TerminalComponent],
-      providers: [{ provide: WindowToken, useClass: windowProvider() }],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [TerminalComponent],
+        providers: [{ provide: WindowToken, useClass: windowProvider() }],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TerminalComponent);

--- a/web/src/app/modules/shared/components/view/view-container.component.spec.ts
+++ b/web/src/app/modules/shared/components/view/view-container.component.spec.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { ViewContainerComponent } from './view-container.component';
 import { DYNAMIC_COMPONENTS_MAPPING } from '../../dynamic-components';
@@ -13,19 +13,21 @@ describe('ViewContainerComponent', () => {
   let component: ViewContainerComponent;
   let fixture: ComponentFixture<ViewContainerComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ViewContainerComponent],
-      providers: [
-        {
-          provide: DYNAMIC_COMPONENTS_MAPPING,
-          useValue: {
-            text: TextComponent,
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [ViewContainerComponent],
+        providers: [
+          {
+            provide: DYNAMIC_COMPONENTS_MAPPING,
+            useValue: {
+              text: TextComponent,
+            },
           },
-        },
-      ],
-    }).compileComponents();
-  }));
+        ],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ViewContainerComponent);

--- a/web/src/app/modules/shared/directives/view-host/view-host.directive.spec.ts
+++ b/web/src/app/modules/shared/directives/view-host/view-host.directive.spec.ts
@@ -1,11 +1,20 @@
+import { TestBed } from '@angular/core/testing';
+import { EditorComponent } from '../../components/smart/editor/editor.component';
 /*
  * Copyright (c) 2020 the Octant contributors. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
 import { ViewHostDirective } from './view-host.directive';
+import { SharedModule } from '../../shared.module';
 
 describe('ViewHostDirective', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [EditorComponent],
+      imports: [SharedModule],
+    });
+  });
   it('should create an instance', () => {
     const directive = new ViewHostDirective(undefined);
     expect(directive).toBeTruthy();

--- a/web/src/app/modules/shared/pipes/default/default.pipe.spec.ts
+++ b/web/src/app/modules/shared/pipes/default/default.pipe.spec.ts
@@ -1,9 +1,18 @@
+import { TestBed } from '@angular/core/testing';
+import { EditorComponent } from '../../components/smart/editor/editor.component';
 // Copyright (c) 2019 the Octant contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
 import { DefaultPipe } from './default.pipe';
+import { SharedModule } from '../../shared.module';
 
 describe('DefaultPipe', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [EditorComponent],
+      providers: [SharedModule],
+    });
+  });
   it('create an instance', () => {
     const pipe = new DefaultPipe();
     expect(pipe).toBeTruthy();

--- a/web/src/app/modules/shared/pod-logs/pod-logs.service.spec.ts
+++ b/web/src/app/modules/shared/pod-logs/pod-logs.service.spec.ts
@@ -7,11 +7,13 @@ import { TestBed } from '@angular/core/testing';
 import { PodLogsService } from './pod-logs.service';
 import { windowProvider, WindowToken } from '../../../window';
 import { EditorComponent } from '../components/smart/editor/editor.component';
+import { SharedModule } from '../shared.module';
 
 describe('PodLogsService', () => {
   beforeEach(() =>
     TestBed.configureTestingModule({
       declarations: [EditorComponent],
+      imports: [SharedModule],
       providers: [{ provide: WindowToken, useFactory: windowProvider }],
     })
   );

--- a/web/src/app/modules/shared/services/action/action.service.spec.ts
+++ b/web/src/app/modules/shared/services/action/action.service.spec.ts
@@ -3,12 +3,14 @@ import { TestBed } from '@angular/core/testing';
 import { ActionService } from './action.service';
 import { WebsocketService } from '../../../../data/services/websocket/websocket.service';
 import { WebsocketServiceMock } from '../../../../data/services/websocket/mock';
+import { EditorComponent } from '../../components/smart/editor/editor.component';
 
 describe('ActionService', () => {
   let service: ActionService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
+      declarations: [EditorComponent],
       providers: [
         ActionService,
         {

--- a/web/src/app/modules/shared/services/icon/icon.service.spec.ts
+++ b/web/src/app/modules/shared/services/icon/icon.service.spec.ts
@@ -1,30 +1,36 @@
 // Copyright (c) 2019 the Octant contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
-import { async, TestBed } from '@angular/core/testing';
+import { TestBed, waitForAsync } from '@angular/core/testing';
 import { EditorComponent } from '../../components/smart/editor/editor.component';
 import { HighlightModule, HIGHLIGHT_OPTIONS } from 'ngx-highlightjs';
 import { IconService } from './icon.service';
 import { SharedModule } from '../../shared.module';
+import {
+  OverlayScrollbarsComponent,
+  OverlayscrollbarsModule,
+} from 'overlayscrollbars-ngx';
 
 describe('IconService', () => {
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [HighlightModule, SharedModule],
-      declarations: [EditorComponent],
-      providers: [
-        {
-          provide: HIGHLIGHT_OPTIONS,
-          useValue: {
-            languages: {
-              json: () => import('highlight.js/lib/languages/json'),
-              yaml: () => import('highlight.js/lib/languages/yaml'),
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [HighlightModule, SharedModule, OverlayscrollbarsModule],
+        declarations: [EditorComponent, OverlayScrollbarsComponent],
+        providers: [
+          {
+            provide: HIGHLIGHT_OPTIONS,
+            useValue: {
+              languages: {
+                json: () => import('highlight.js/lib/languages/json'),
+                yaml: () => import('highlight.js/lib/languages/yaml'),
+              },
             },
           },
-        },
-      ],
-    });
-  }));
+        ],
+      });
+    })
+  );
 
   it('should be created', () => {
     const service: IconService = TestBed.inject(IconService);

--- a/web/src/app/modules/shared/services/kube-context/kube-context.service.spec.ts
+++ b/web/src/app/modules/shared/services/kube-context/kube-context.service.spec.ts
@@ -11,10 +11,12 @@ import {
 } from './kube-context.service';
 import { WebsocketServiceMock } from '../../../../data/services/websocket/mock';
 import { WebsocketService } from '../../../../data/services/websocket/websocket.service';
+import { SharedModule } from '../../shared.module';
 
 describe('KubeContextService', () => {
   beforeEach(() =>
     TestBed.configureTestingModule({
+      imports: [SharedModule],
       providers: [
         KubeContextService,
         {

--- a/web/src/app/modules/shared/services/label-filter/label-filter.service.spec.ts
+++ b/web/src/app/modules/shared/services/label-filter/label-filter.service.spec.ts
@@ -6,12 +6,17 @@ import { inject, TestBed } from '@angular/core/testing';
 import { LabelFilterService } from './label-filter.service';
 import { WebsocketService } from '../../../../data/services/websocket/websocket.service';
 import { WebsocketServiceMock } from '../../../../data/services/websocket/mock';
-import { OverlayScrollbarsComponent } from 'overlayscrollbars-ngx';
+import {
+  OverlayScrollbarsComponent,
+  OverlayscrollbarsModule,
+} from 'overlayscrollbars-ngx';
+import { EditorComponent } from '../../components/smart/editor/editor.component';
 
 describe('LabelFilterService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [OverlayScrollbarsComponent],
+      declarations: [OverlayScrollbarsComponent, EditorComponent],
+      imports: [OverlayscrollbarsModule],
       providers: [
         LabelFilterService,
         {

--- a/web/src/app/modules/shared/services/modal/modal.service.spec.ts
+++ b/web/src/app/modules/shared/services/modal/modal.service.spec.ts
@@ -4,11 +4,17 @@
  */
 
 import { TestBed } from '@angular/core/testing';
+import {
+  OverlayScrollbarsComponent,
+  OverlayscrollbarsModule,
+} from 'overlayscrollbars-ngx';
 import { ModalService } from './modal.service';
 
 describe('ModalService', () => {
   beforeEach(() =>
     TestBed.configureTestingModule({
+      declarations: [OverlayScrollbarsComponent],
+      imports: [OverlayscrollbarsModule],
       providers: [ModalService],
     })
   );

--- a/web/src/app/modules/shared/services/namespace/namespace.service.spec.ts
+++ b/web/src/app/modules/shared/services/namespace/namespace.service.spec.ts
@@ -9,10 +9,15 @@ import {
   WebsocketService,
 } from '../../../../data/services/websocket/websocket.service';
 import { WebsocketServiceMock } from '../../../../data/services/websocket/mock';
+import { OverlayScrollbarsComponent } from 'overlayscrollbars-ngx';
+import { SharedModule } from '../../shared.module';
+import { EditorComponent } from '../../components/smart/editor/editor.component';
 
 describe('NamespaceService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
+      declarations: [OverlayScrollbarsComponent, EditorComponent],
+      imports: [SharedModule],
       providers: [
         NamespaceService,
         {

--- a/web/src/app/modules/shared/services/theme/theme.service.spec.ts
+++ b/web/src/app/modules/shared/services/theme/theme.service.spec.ts
@@ -5,6 +5,10 @@ import { inject, TestBed } from '@angular/core/testing';
 import { ThemeService } from './theme.service';
 import { DOCUMENT } from '@angular/common';
 import { MonacoEditorConfig, MonacoProviderService } from 'ng-monaco-editor';
+import {
+  OverlayScrollbarsComponent,
+  OverlayscrollbarsModule,
+} from 'overlayscrollbars-ngx';
 
 describe('ThemeService', () => {
   let service: ThemeService;
@@ -12,10 +16,12 @@ describe('ThemeService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
+      declarations: [OverlayScrollbarsComponent],
       providers: [
         ThemeService,
         MonacoProviderService,
         MonacoEditorConfig,
+        OverlayscrollbarsModule,
         Document,
       ],
     });

--- a/web/src/app/modules/shared/slider/slider.service.spec.ts
+++ b/web/src/app/modules/shared/slider/slider.service.spec.ts
@@ -2,27 +2,44 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { TestBed } from '@angular/core/testing';
+import { TestBed, waitForAsync } from '@angular/core/testing';
+import {
+  OverlayScrollbarsComponent,
+  OverlayscrollbarsModule,
+} from 'overlayscrollbars-ngx';
+import { EditorComponent } from '../components/smart/editor/editor.component';
 import { SliderService } from './slider.service';
 
 describe('SliderService', () => {
   let service: SliderService;
 
-  beforeEach(() => {
-    service = TestBed.inject(SliderService);
-  });
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [OverlayScrollbarsComponent, EditorComponent],
+        providers: [OverlayscrollbarsModule],
+      });
+      service = TestBed.inject(SliderService);
+    })
+  );
 
   it('should be created', () => {
     expect(service).toBeTruthy();
   });
 
-  it('set value', () => {
-    service.setHeight(100);
-    service.setHeight$.subscribe(current => expect(current).toEqual(100));
-  });
+  it(
+    'set value',
+    waitForAsync(() => {
+      service.setHeight(100);
+      service.setHeight$.subscribe(current => expect(current).toEqual(100));
+    })
+  );
 
-  it('reset to default', () => {
-    service.resetDefault();
-    service.setHeight$.subscribe(current => expect(current).toEqual(36));
-  });
+  it(
+    'reset to default',
+    waitForAsync(() => {
+      service.resetDefault();
+      service.setHeight$.subscribe(current => expect(current).toEqual(36));
+    })
+  );
 });

--- a/web/src/app/modules/sugarloaf/components/smart/apply-yaml/apply-yaml.component.spec.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/apply-yaml/apply-yaml.component.spec.ts
@@ -1,18 +1,20 @@
 // Copyright (c) 2020 the Octant contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { ApplyYAMLComponent } from './apply-yaml.component';
 
 describe('ApplyYAMLComponent', () => {
   let component: ApplyYAMLComponent;
   let fixture: ComponentFixture<ApplyYAMLComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ApplyYAMLComponent],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [ApplyYAMLComponent],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ApplyYAMLComponent);

--- a/web/src/app/modules/sugarloaf/components/smart/container/container.component.spec.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/container/container.component.spec.ts
@@ -5,7 +5,12 @@
  */
 
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { async, inject, TestBed } from '@angular/core/testing';
+import {
+  ComponentFixture,
+  inject,
+  TestBed,
+  waitForAsync,
+} from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ClarityModule, ClrPopoverToggleService } from '@clr/angular';
 import { BrowserModule } from '@angular/platform-browser';
@@ -27,65 +32,85 @@ import { WebsocketServiceMock } from '../../../../../data/services/websocket/moc
 import { ClarityIcons } from '@clr/icons';
 import { ThemeSwitchButtonComponent } from '../theme-switch/theme-switch-button.component';
 import { QuickSwitcherComponent } from '../quick-switcher/quick-switcher.component';
-import { MonacoEditorConfig, MonacoProviderService } from 'ng-monaco-editor';
+import {
+  MonacoEditorConfig,
+  MonacoEditorModule,
+  MonacoProviderService,
+} from 'ng-monaco-editor';
 import { UploaderComponent } from '../uploader/uploader.component';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { windowProvider, WindowToken } from '../../../../../window';
+import { SharedModule } from 'src/app/modules/shared/shared.module';
+import { OverlayScrollbarsComponent } from 'overlayscrollbars-ngx';
+import { ApplyYAMLComponent } from '../apply-yaml/apply-yaml.component';
+import { EditorComponent } from 'src/app/modules/shared/components/smart/editor/editor.component';
 
 describe('AppComponent', () => {
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      providers: [
-        { provide: WebsocketService, useClass: WebsocketServiceMock },
-        { provide: WindowToken, useFactory: windowProvider },
-        { provide: window, useValue: ClarityIcons },
-        ClrPopoverToggleService,
-        MonacoProviderService,
-        MonacoEditorConfig,
-      ],
-      imports: [
-        BrowserModule,
-        RouterTestingModule,
-        ClarityModule,
-        HttpClientTestingModule,
-        FormsModule,
-        NgSelectModule,
-        ReactiveFormsModule,
-        BrowserAnimationsModule,
-      ],
-      declarations: [
-        ContainerComponent,
-        NamespaceComponent,
-        PageNotFoundComponent,
-        HelperComponent,
-        PreferencesComponent,
-        InputFilterComponent,
-        NotifierComponent,
-        NavigationComponent,
-        ContextSelectorComponent,
-        DefaultPipe,
-        FilterTextPipe,
-        ThemeSwitchButtonComponent,
-        QuickSwitcherComponent,
-        UploaderComponent,
-      ],
-    }).compileComponents();
-  }));
+  let component: ContainerComponent;
+  let fixture: ComponentFixture<ContainerComponent>;
+
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        providers: [
+          { provide: WebsocketService, useClass: WebsocketServiceMock },
+          { provide: WindowToken, useFactory: windowProvider },
+          { provide: window, useValue: ClarityIcons },
+          ClrPopoverToggleService,
+          MonacoProviderService,
+          MonacoEditorConfig,
+        ],
+        imports: [
+          BrowserModule,
+          RouterTestingModule,
+          ClarityModule,
+          HttpClientTestingModule,
+          FormsModule,
+          NgSelectModule,
+          ReactiveFormsModule,
+          BrowserAnimationsModule,
+          SharedModule,
+        ],
+        declarations: [
+          ApplyYAMLComponent,
+          ContainerComponent,
+          NamespaceComponent,
+          PageNotFoundComponent,
+          HelperComponent,
+          PreferencesComponent,
+          InputFilterComponent,
+          NotifierComponent,
+          NavigationComponent,
+          ContextSelectorComponent,
+          DefaultPipe,
+          FilterTextPipe,
+          ThemeSwitchButtonComponent,
+          QuickSwitcherComponent,
+          UploaderComponent,
+          OverlayScrollbarsComponent,
+        ],
+      }).compileComponents();
+    })
+  );
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ContainerComponent);
+    component = fixture.componentInstance;
+  });
+
+  afterEach(() => {
+    TestBed.resetTestingModule();
+  });
 
   it('should create the home', () => {
-    const fixture = TestBed.createComponent(ContainerComponent);
-    const app = fixture.debugElement.componentInstance;
-    fixture.detectChanges();
-    expect(app).toBeTruthy();
+    expect(component).toBeTruthy();
   });
 
   describe('at startup', () => {
     it('opens a websocket connection', inject(
       [WebsocketService],
       (websocketService: WebsocketServiceMock) => {
-        const fixture = TestBed.createComponent(ContainerComponent);
         fixture.detectChanges();
-
         expect(websocketService.isOpen).toBeTruthy();
       }
     ));

--- a/web/src/app/modules/sugarloaf/components/smart/content/content.component.spec.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/content/content.component.spec.ts
@@ -4,7 +4,7 @@
  *
  */
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { ActivatedRoute, Params, Router, RouterEvent } from '@angular/router';
 import { ActivatedRouteStub } from 'src/app/testing/activated-route-stub';
 import { ContentComponent } from './content.component';
@@ -30,38 +30,40 @@ describe('OverviewComponent', () => {
   let routerMock;
   let contentSpy;
 
-  beforeEach(async(() => {
-    eventSubject = new ReplaySubject<RouterEvent>(1);
-    routerMock = {
-      events: eventSubject.asObservable(),
-      routerState: {
-        snapshot: {
-          url: '/',
+  beforeEach(
+    waitForAsync(() => {
+      eventSubject = new ReplaySubject<RouterEvent>(1);
+      routerMock = {
+        events: eventSubject.asObservable(),
+        routerState: {
+          snapshot: {
+            url: '/',
+          },
         },
-      },
-      parseUrl: (_: string) => {
-        return {
-          root: {
-            children: {
-              primary: {
-                segments: ['foo', 'bar'],
+        parseUrl: (_: string) => {
+          return {
+            root: {
+              children: {
+                primary: {
+                  segments: ['foo', 'bar'],
+                },
               },
             },
-          },
-        };
-      },
-    };
-    TestBed.configureTestingModule({
-      imports: [SugarloafModule],
-      providers: [
-        { provide: ActivatedRoute, useValue: new ActivatedRouteStub({}) },
-        { provide: Router, useValue: routerMock },
-        { provide: ContentService, useClass: ContentServiceMock },
+          };
+        },
+      };
+      TestBed.configureTestingModule({
+        imports: [SugarloafModule],
+        providers: [
+          { provide: ActivatedRoute, useValue: new ActivatedRouteStub({}) },
+          { provide: Router, useValue: routerMock },
+          { provide: ContentService, useClass: ContentServiceMock },
 
-        IconService,
-      ],
-    }).compileComponents();
-  }));
+          IconService,
+        ],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ContentComponent);

--- a/web/src/app/modules/sugarloaf/components/smart/input-filter/input-filter.component.spec.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/input-filter/input-filter.component.spec.ts
@@ -2,7 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  ComponentFixture,
+  fakeAsync,
+  TestBed,
+  waitForAsync,
+} from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { InputFilterComponent } from './input-filter.component';
 import {
@@ -23,13 +28,15 @@ describe('InputFilterComponent', () => {
   let fixture: ComponentFixture<InputFilterComponent>;
   let labelFilterService: LabelFilterService;
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [FormsModule],
-      declarations: [InputFilterComponent, FilterTextPipe],
-      providers: [{ provide: LabelFilterService, useValue: labelFilterStub }],
-    }).compileComponents();
-  });
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [FormsModule],
+        declarations: [InputFilterComponent, FilterTextPipe],
+        providers: [{ provide: LabelFilterService, useValue: labelFilterStub }],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(InputFilterComponent);
@@ -62,7 +69,7 @@ describe('InputFilterComponent', () => {
     expect(tagListElement).not.toBeNull();
   });
 
-  it('should show the user text if there are no filters', () => {
+  it('should show the user text if there are no filters', fakeAsync(() => {
     labelFilterService = TestBed.inject(LabelFilterService);
     labelFilterService.filters.next([]);
     component.showTagList = true;
@@ -76,7 +83,7 @@ describe('InputFilterComponent', () => {
         userTextDebugElement.nativeElement;
       expect(userTextNativeElement.textContent).toMatch(/No current filters/i);
     });
-  });
+  }));
 
   it('should show the tags if there are filters', () => {
     labelFilterService = TestBed.inject(LabelFilterService);

--- a/web/src/app/modules/sugarloaf/components/smart/input-filter/input-filter.component.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/input-filter/input-filter.component.ts
@@ -41,7 +41,9 @@ export class InputFilterComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.labelFilterSubscription.unsubscribe();
+    if (this.labelFilterSubscription) {
+      this.labelFilterSubscription.unsubscribe();
+    }
   }
 
   @HostListener('document:click', ['$event'])

--- a/web/src/app/modules/sugarloaf/components/smart/namespace/namespace.component.spec.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/namespace/namespace.component.spec.ts
@@ -2,22 +2,29 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { NamespaceComponent } from './namespace.component';
 import { NgSelectModule } from '@ng-select/ng-select';
 import { windowProvider, WindowToken } from '../../../../../window';
+import { SharedModule } from 'src/app/modules/shared/shared.module';
+import {
+  OverlayScrollbarsComponent,
+  OverlayscrollbarsModule,
+} from 'overlayscrollbars-ngx';
 
 describe('NamespaceComponent', () => {
   let component: NamespaceComponent;
   let fixture: ComponentFixture<NamespaceComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [NgSelectModule],
-      declarations: [NamespaceComponent],
-      providers: [{ provide: WindowToken, useFactory: windowProvider }],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [NgSelectModule, OverlayscrollbarsModule],
+        declarations: [NamespaceComponent, OverlayScrollbarsComponent],
+        providers: [{ provide: WindowToken, useFactory: windowProvider }],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(NamespaceComponent);

--- a/web/src/app/modules/sugarloaf/components/smart/namespace/namespace.component.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/namespace/namespace.component.ts
@@ -73,7 +73,9 @@ export class NamespaceComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.namespaceSubscription.unsubscribe();
+    if (this.namespaceSubscription) {
+      this.namespaceSubscription.unsubscribe();
+    }
   }
 
   namespaceClass(namespace: string) {

--- a/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.spec.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2019 the Octant contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { DefaultPipe } from '../../../../shared/pipes/default/default.pipe';
 import { NavigationComponent } from './navigation.component';
 import { NamespaceComponent } from '../namespace/namespace.component';
@@ -14,22 +14,24 @@ describe('NavigationComponent', () => {
   let component: NavigationComponent;
   let fixture: ComponentFixture<NavigationComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      providers: [
-        MonacoProviderService,
-        MonacoEditorConfig,
-        { provide: WindowToken, useFactory: windowProvider },
-      ],
-      imports: [NgSelectModule],
-      declarations: [
-        NavigationComponent,
-        NamespaceComponent,
-        DefaultPipe,
-        ThemeSwitchButtonComponent,
-      ],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        providers: [
+          MonacoProviderService,
+          MonacoEditorConfig,
+          { provide: WindowToken, useFactory: windowProvider },
+        ],
+        imports: [NgSelectModule],
+        declarations: [
+          NavigationComponent,
+          NamespaceComponent,
+          DefaultPipe,
+          ThemeSwitchButtonComponent,
+        ],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(NavigationComponent);

--- a/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.ts
@@ -77,7 +77,9 @@ export class NavigationComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.navigationSubscription.unsubscribe();
+    if (this.navigationSubscription) {
+      this.navigationSubscription.unsubscribe();
+    }
   }
 
   identifyNavigationItem(index: number, item: NavigationChild): string {

--- a/web/src/app/modules/sugarloaf/components/smart/notifier/notifier.component.spec.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/notifier/notifier.component.spec.ts
@@ -2,7 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import {
+  OverlayScrollbarsComponent,
+  OverlayscrollbarsModule,
+} from 'overlayscrollbars-ngx';
 
 import { NotifierComponent } from './notifier.component';
 
@@ -10,11 +14,14 @@ describe('NotifierComponent', () => {
   let component: NotifierComponent;
   let fixture: ComponentFixture<NotifierComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [NotifierComponent],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [NotifierComponent, OverlayScrollbarsComponent],
+        imports: [OverlayscrollbarsModule],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(NotifierComponent);

--- a/web/src/app/modules/sugarloaf/components/smart/page-not-found/page-not-found.component.spec.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/page-not-found/page-not-found.component.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { OverlayScrollbarsComponent } from 'overlayscrollbars-ngx';
 import { PageNotFoundComponent } from './page-not-found.component';
 
@@ -10,11 +10,13 @@ describe('PageNotFoundComponent', () => {
   let component: PageNotFoundComponent;
   let fixture: ComponentFixture<PageNotFoundComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [PageNotFoundComponent, OverlayScrollbarsComponent],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [PageNotFoundComponent, OverlayScrollbarsComponent],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(PageNotFoundComponent);

--- a/web/src/app/modules/sugarloaf/components/smart/quick-switcher/quick-switcher.component.spec.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/quick-switcher/quick-switcher.component.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2019 the Octant contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { DefaultPipe } from '../../../../shared/pipes/default/default.pipe';
 import { QuickSwitcherComponent } from './quick-switcher.component';
@@ -11,12 +11,14 @@ describe('QuickSwitcherComponent', () => {
   let component: QuickSwitcherComponent;
   let fixture: ComponentFixture<QuickSwitcherComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [QuickSwitcherComponent, DefaultPipe],
-      providers: [{ provide: WindowToken, useFactory: windowProvider }],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [QuickSwitcherComponent, DefaultPipe],
+        providers: [{ provide: WindowToken, useFactory: windowProvider }],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(QuickSwitcherComponent);

--- a/web/src/app/modules/sugarloaf/components/smart/quick-switcher/quick-switcher.component.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/quick-switcher/quick-switcher.component.ts
@@ -84,8 +84,12 @@ export class QuickSwitcherComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.navigationSubscription.unsubscribe();
-    this.namespaceSubscription.unsubscribe();
+    if (this.navigationSubscription) {
+      this.navigationSubscription.unsubscribe();
+    }
+    if (this.namespaceSubscription) {
+      this.namespaceSubscription.unsubscribe();
+    }
   }
 
   identifyNavigationItem(index: number, item: NavigationChild): string {

--- a/web/src/app/modules/sugarloaf/components/smart/theme-switch/theme-switch-button.component.spec.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/theme-switch/theme-switch-button.component.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2019 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { ThemeSwitchButtonComponent } from './theme-switch-button.component';
 import { ThemeService } from '../../../../shared/services/theme/theme.service';
 import { themeServiceStub } from 'src/app/testing/theme-service-stub';
@@ -12,12 +12,14 @@ describe('ThemeSwitchButtonComponent', () => {
   let fixture: ComponentFixture<ThemeSwitchButtonComponent>;
   let themeService: ThemeService;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ThemeSwitchButtonComponent],
-      providers: [{ provide: ThemeService, useValue: themeServiceStub }],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [ThemeSwitchButtonComponent],
+        providers: [{ provide: ThemeService, useValue: themeServiceStub }],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     themeService = TestBed.inject(ThemeService);

--- a/web/src/app/modules/sugarloaf/components/smart/uploader/uploader.component.spec.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/uploader/uploader.component.spec.ts
@@ -2,20 +2,26 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { UploaderComponent } from './uploader.component';
 import { windowProvider, WindowToken } from '../../../../../window';
+import { SharedModule } from 'src/app/modules/shared/shared.module';
+import { IndicatorComponent } from 'src/app/modules/shared/components/presentation/indicator/indicator.component';
+import { EditorComponent } from 'src/app/modules/shared/components/smart/editor/editor.component';
 
 describe('UploaderComponent', () => {
   let component: UploaderComponent;
   let fixture: ComponentFixture<UploaderComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [UploaderComponent],
-      providers: [{ provide: WindowToken, useFactory: windowProvider }],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [UploaderComponent, IndicatorComponent, EditorComponent],
+        imports: [SharedModule],
+        providers: [{ provide: WindowToken, useFactory: windowProvider }],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(UploaderComponent);

--- a/web/src/app/modules/sugarloaf/pipes/filtertext/filtertext.pipe.spec.ts
+++ b/web/src/app/modules/sugarloaf/pipes/filtertext/filtertext.pipe.spec.ts
@@ -1,14 +1,16 @@
-import { async, TestBed } from '@angular/core/testing';
+import { TestBed, waitForAsync } from '@angular/core/testing';
 import { OverlayScrollbarsComponent } from 'overlayscrollbars-ngx';
 import { ApplyYAMLComponent } from '../../components/smart/apply-yaml/apply-yaml.component';
 import { FilterTextPipe } from './filtertext.pipe';
 
 describe('FilterTextPipe', () => {
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ApplyYAMLComponent, OverlayScrollbarsComponent],
-    });
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [ApplyYAMLComponent, OverlayScrollbarsComponent],
+      });
+    })
+  );
   it('create an instance', () => {
     const pipe = new FilterTextPipe();
     expect(pipe).toBeTruthy();

--- a/web/tsconfig.base.json
+++ b/web/tsconfig.base.json
@@ -9,6 +9,7 @@
     "module": "es2020",
     "moduleResolution": "node",
     "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "importHelpers": true,


### PR DESCRIPTION
This PR:
 - replaces most instances of `async` with `watForAsync` (see https://angular.io/api/core/testing/async)
 - adds missing component declarations to avoid warnings
 - fixes the scroll test in `logs.component.spec.ts` since there is no need to manually calculate the scroll height

Signed-off-by: GuessWhoSamFoo <foos@vmware.com>

