### PR TITLE
Normalize markdown styles to match other text in datagrids

### DIFF
--- a/changelogs/unreleased/1503-scothis
+++ b/changelogs/unreleased/1503-scothis
@@ -1,0 +1,1 @@
+Normalize markdown styles to match other text in datagrids

--- a/web/src/styles.scss
+++ b/web/src/styles.scss
@@ -22,5 +22,10 @@
 
 // avoid markdown text rendering badly in table/cards
 .datagrid-cell .markdown p, .card-block .markdown p {
-  margin-top: 0;
+  line-height: 0.7rem;
+  font-size: 0.65rem;
+
+  &:first-child {
+    margin-top: 0;
+  }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

There was a previous attempt to override the styles for markdown rendered text within a data grid, this PR re-normalizes the styling.

Before:
<img width="488" alt="Screen Shot 2020-10-21 at 10 57 31 AM" src="https://user-images.githubusercontent.com/302992/96738661-ef88c800-138c-11eb-9e28-78214a6dda8e.png">

After:
<img width="484" alt="Screen Shot 2020-10-21 at 10 56 51 AM" src="https://user-images.githubusercontent.com/302992/96738668-f1528b80-138c-11eb-9b1d-67daff9b192d.png">

**Which issue(s) this PR fixes**
- Fixes #1503 

**Release note**:
```
Normalize markdown styles to match other text in datagrids
```
