### PR TITLE
Add Preferences UI

### DIFF
--- a/changelogs/unreleased/1498-mklanjsek
+++ b/changelogs/unreleased/1498-mklanjsek
@@ -1,0 +1,1 @@
+Add Preferences to the bottom of the Vertical Navigation

--- a/web/main.ts
+++ b/web/main.ts
@@ -27,7 +27,14 @@ const errLogPath = path.join(tmpPath, 'api.err-' + date + '.log');
 const template: Electron.MenuItemConstructorOptions[] = [
   {
     label: 'File',
-    submenu: [{ label: 'Quit Octant', role: 'close' }],
+    submenu: [
+      { label: 'Preferences',
+        click(){
+          win.webContents.send('openPreferences');
+        } },
+      { type: 'separator' },
+      { label: 'Quit Octant', role: 'close' }
+      ],
   },
   {
     label: 'Edit',

--- a/web/src/app/modules/shared/models/preference.ts
+++ b/web/src/app/modules/shared/models/preference.ts
@@ -30,6 +30,7 @@ export interface RadioElement extends Element {
 export interface TextElement extends Element {
   type: 'text';
   config: {
+    label: string;
     placeholder: string;
   };
 }

--- a/web/src/app/modules/shared/services/electron/electron.service.ts
+++ b/web/src/app/modules/shared/services/electron/electron.service.ts
@@ -7,6 +7,7 @@ import { Injectable } from '@angular/core';
 import { ipcRenderer, webFrame } from 'electron';
 import * as childProcess from 'child_process';
 import * as fs from 'fs';
+import { PreferencesService } from '../preferences/preferences.service';
 
 @Injectable({
   providedIn: 'root',
@@ -18,7 +19,7 @@ export class ElectronService {
   fs: typeof fs;
 
   public portNumber: number;
-  constructor() {
+  constructor(private preferencesService: PreferencesService) {
     if (this.isElectron()) {
       this.ipcRenderer = window.require('electron').ipcRenderer;
       this.webFrame = window.require('electron').webFrame;
@@ -27,6 +28,12 @@ export class ElectronService {
 
       this.ipcRenderer.once('port-message', (event, message) => {
         this.portNumber = message;
+      });
+
+      this.ipcRenderer.on('openPreferences', () => {
+        if (!this.preferencesService.preferencesOpened.value) {
+          this.preferencesService.preferencesOpened.next(true);
+        }
       });
     }
   }

--- a/web/src/app/modules/shared/services/navigation/navigation.service.ts
+++ b/web/src/app/modules/shared/services/navigation/navigation.service.ts
@@ -42,9 +42,6 @@ export class NavigationService {
   current = new BehaviorSubject<Navigation>(emptyNavigation);
   modules = new BehaviorSubject<Module[]>([]);
   selectedItem = new BehaviorSubject<Selection>({ module: 0, index: -1 });
-  public showLabels: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(
-    true
-  );
   activeUrl = new BehaviorSubject<string>('');
 
   constructor(

--- a/web/src/app/modules/shared/services/navigation/navigation.service.ts
+++ b/web/src/app/modules/shared/services/navigation/navigation.service.ts
@@ -42,9 +42,6 @@ export class NavigationService {
   current = new BehaviorSubject<Navigation>(emptyNavigation);
   modules = new BehaviorSubject<Module[]>([]);
   selectedItem = new BehaviorSubject<Selection>({ module: 0, index: -1 });
-  public collapsed: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(
-    false
-  );
   public showLabels: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(
     true
   );

--- a/web/src/app/modules/shared/services/preferences/preferences.service.spec.ts
+++ b/web/src/app/modules/shared/services/preferences/preferences.service.spec.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2020 the Octant contributors. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { TestBed } from '@angular/core/testing';
+
+import { PreferencesService } from './preferences.service';
+
+describe('PreferencesService', () => {
+  let service: PreferencesService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(PreferencesService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/web/src/app/modules/shared/services/preferences/preferences.service.spec.ts
+++ b/web/src/app/modules/shared/services/preferences/preferences.service.spec.ts
@@ -18,4 +18,17 @@ describe('PreferencesService', () => {
   it('should be created', () => {
     expect(service).toBeTruthy();
   });
+
+  it('collapsed set properly', () => {
+    const defaultPrefs = service.getPreferences();
+    const defaultElement = defaultPrefs.panels[0].sections[1].elements[0];
+    expect(defaultElement.name).toEqual('general.navigation');
+    expect(defaultElement.value).toEqual('expanded');
+
+    service.navCollapsed.next(true);
+    const newPrefs = service.getPreferences();
+    const newElement = newPrefs.panels[0].sections[1].elements[0];
+    expect(newElement.name).toEqual('general.navigation');
+    expect(newElement.value).toEqual('collapsed');
+  });
 });

--- a/web/src/app/modules/shared/services/preferences/preferences.service.ts
+++ b/web/src/app/modules/shared/services/preferences/preferences.service.ts
@@ -12,19 +12,28 @@ import { ThemeService } from '../theme/theme.service';
   providedIn: 'root',
 })
 export class PreferencesService {
-  public preferencesOpened: BehaviorSubject<boolean> = new BehaviorSubject<
-    boolean
-  >(false);
+  public preferencesOpened: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(
+    false
+  );
 
   public navCollapsed: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(
     false
   );
 
+  public showLabels: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(
+    true
+  );
+
   constructor(private themeService: ThemeService) {}
 
-  public preferencesChanged(update: any) {
+  public preferencesChanged(update: Preferences) {
     const collapsed = update['general.navigation'] === 'collapsed';
+    const showLabels = update['general.labels'] === 'show';
     const isLightTheme = update['general.theme'] === 'light';
+
+    if (this.showLabels.value !== showLabels) {
+      this.showLabels.next(showLabels);
+    }
 
     if (this.navCollapsed.value !== collapsed) {
       this.navCollapsed.next(collapsed);
@@ -83,6 +92,28 @@ export class PreferencesService {
                       {
                         label: 'Collapsed',
                         value: 'collapsed',
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+            {
+              name: 'Navigation labels',
+              elements: [
+                {
+                  name: 'general.labels',
+                  type: 'radio',
+                  value: this.showLabels.value ? 'show' : 'hide',
+                  config: {
+                    values: [
+                      {
+                        label: 'Show Labels',
+                        value: 'show',
+                      },
+                      {
+                        label: 'Hide Labels',
+                        value: 'hide',
                       },
                     ],
                   },

--- a/web/src/app/modules/shared/services/preferences/preferences.service.ts
+++ b/web/src/app/modules/shared/services/preferences/preferences.service.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2020 the Octant contributors. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { Preferences } from '../../models/preference';
+import { ThemeService } from '../theme/theme.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class PreferencesService {
+  public preferencesOpened: BehaviorSubject<boolean> = new BehaviorSubject<
+    boolean
+  >(false);
+
+  public navCollapsed: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(
+    false
+  );
+
+  constructor(private themeService: ThemeService) {}
+
+  public preferencesChanged(update: any) {
+    const collapsed = update['general.navigation'] === 'collapsed';
+    const isLightTheme = update['general.theme'] === 'light';
+
+    if (this.navCollapsed.value !== collapsed) {
+      this.navCollapsed.next(collapsed);
+    }
+
+    if (this.themeService.isLightThemeEnabled() !== isLightTheme) {
+      this.themeService.switchTheme();
+    }
+  }
+
+  // TODO move to better place and merge with server side prefs.
+  public getPreferences(): Preferences {
+    return {
+      updateName: 'generalPreferences',
+      panels: [
+        {
+          name: 'General',
+          sections: [
+            {
+              name: 'Color Theme',
+              elements: [
+                {
+                  name: 'general.theme',
+                  type: 'radio',
+                  value: this.themeService.isLightThemeEnabled()
+                    ? 'light'
+                    : 'dark',
+                  config: {
+                    values: [
+                      {
+                        label: 'Dark',
+                        value: 'dark',
+                      },
+                      {
+                        label: 'Light',
+                        value: 'light',
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+            {
+              name: 'Navigation',
+              elements: [
+                {
+                  name: 'general.navigation',
+                  type: 'radio',
+                  value: this.navCollapsed.value ? 'collapsed' : 'expanded',
+                  config: {
+                    values: [
+                      {
+                        label: 'Expanded',
+                        value: 'expanded',
+                      },
+                      {
+                        label: 'Collapsed',
+                        value: 'collapsed',
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+  }
+}

--- a/web/src/app/modules/shared/services/theme/theme.service.ts
+++ b/web/src/app/modules/shared/services/theme/theme.service.ts
@@ -56,7 +56,7 @@ export class ThemeService implements OnDestroy {
 
     const themeType = localStorage.getItem('theme') as ThemeType;
     this.themeType = themeType || defaultTheme.type;
-    
+
     this.renderer = rendererFactory.createRenderer(null, null);
 
     this.storageEventHandler = (e: StorageEvent): void => {

--- a/web/src/app/modules/shared/services/theme/theme.service.ts
+++ b/web/src/app/modules/shared/services/theme/theme.service.ts
@@ -34,7 +34,10 @@ export const lightTheme: Theme = {
   assetPath: 'assets/css/clr-ui.min.css',
 };
 
-export const defaultTheme = lightTheme;
+export const defaultTheme = window.matchMedia('(prefers-color-scheme:dark)')
+  .matches
+  ? darkTheme
+  : lightTheme;
 
 @Injectable({
   providedIn: 'root',
@@ -53,6 +56,7 @@ export class ThemeService implements OnDestroy {
 
     const themeType = localStorage.getItem('theme') as ThemeType;
     this.themeType = themeType || defaultTheme.type;
+    
     this.renderer = rendererFactory.createRenderer(null, null);
 
     this.storageEventHandler = (e: StorageEvent): void => {

--- a/web/src/app/modules/sugarloaf/components/smart/container/container.component.html
+++ b/web/src/app/modules/sugarloaf/components/smart/container/container.component.html
@@ -49,5 +49,6 @@
     [(isOpen)]="preferencesOpened"
     [preferences]="preferences"
     (preferencesChanged)="preferencesChanged($event)"
+    (isOpenChange)="preferencesOpenChanged($event)"
   ></app-preferences>
 </div>

--- a/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.html
+++ b/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.html
@@ -9,6 +9,7 @@
   (clrVerticalNavCollapsedChange)="updateNavCollapsed($event)"
 >
   <div class="navigation-main">
+  <div class="module-nav">
     <clr-tabs clrLayout="vertical"
       [ngClass]="{
         'module-tabs': !showLabels,
@@ -38,7 +39,25 @@
         </ng-template>
       </clr-tab>
       </clr-tabs>
-    <!-- Navigation items -->
+    <div class="prefs-button">
+      <div (click)="showPrefs()" class="btn-icon btn-link nav-link"
+           [ngClass]="{
+            'button-tool': !showLabels,
+            'button-tool-labels': showLabels
+          }">
+        <div *ngIf="showLabels" class="button-wrapper">
+          <clr-icon class="icon-nav" shape="cog"></clr-icon>
+          <div class="button-text-wrapper">
+            <div class="button-text">Preferences</div>
+          </div>
+        </div>
+        <app-octant-tooltip *ngIf="!showLabels" tooltipText="Preferences">
+          <clr-icon class="icon-nav" shape="cog"></clr-icon>
+        </app-octant-tooltip>
+      </div>
+    </div>
+  </div>
+  <!-- Navigation items -->
   <div
     [ngClass]="{
       'navigation-items-collapsed': collapsed,

--- a/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.scss
+++ b/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.scss
@@ -52,8 +52,13 @@
 }
 
 .module-tabs {
-  width: 56px;
+  width: 48px;
   margin-right: 0px;
+
+  ::ng-deep ul {
+    padding-left: 0rem;
+    padding-top: 0.4rem;
+  }
 }
 
 .module-tabs-labels {

--- a/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.scss
+++ b/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.scss
@@ -61,6 +61,7 @@
   margin-right: 0px;
 
   ::ng-deep ul {
+    padding-left: 0rem;
     padding-top: 0.4rem;
   }
 }
@@ -74,6 +75,7 @@
   width: 48px!important;
   height: 48px!important;
   padding: 4px 10px 10px 10px!important;
+  margin: 0 auto;
   background-color: transparent!important;
   outline: none;
 
@@ -85,16 +87,16 @@
 }
 
 .button-tool-labels {
-  width: 68px!important;
+  width: 76px!important;
   height: 64px!important;
-  padding: 0px 0px 0px 0px!important;
+  padding: 0px!important;
   background-color: transparent!important;
   outline: none;
 
   .icon-nav {
     width: 28px;
     height: 28px;
-    margin-left: 18px;
+    margin-left: 0px;
     margin-top: 8px;
   }
 }
@@ -103,6 +105,8 @@
   display: flex;
   flex-direction: column;
   height: 60px;
+  width: 100%;
+  align-items: center;
 }
 
 .button-text-wrapper {
@@ -113,7 +117,7 @@
 
 .button-text {
   width: 64px;
-  padding-left: 6px;
+  padding-left: 0px;
   font-size: 10px;
   line-height:  12px;
   text-align: center;
@@ -186,6 +190,16 @@
     flex-basis: 100%;
     border-left: 1px solid rgba(173, 187, 196, 0.3);
     border-bottom: 1px solid rgba(173, 187, 196, 0.3);
+
+    .module-nav {
+      display: flex;
+      flex-direction: column;
+
+      clr-tabs {
+        flex: auto;
+        border-bottom: 1px solid rgba(173, 187, 196, 0.3);
+      }
+    }
   }
 
   .navigation-items {

--- a/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.ts
@@ -86,7 +86,7 @@ export class NavigationComponent implements OnInit, OnDestroy {
       }
     );
 
-    this.subscriptionShowLabels = this.navigationService.showLabels.subscribe(
+    this.subscriptionShowLabels = this.preferencesService.showLabels.subscribe(
       col => {
         if (this.showLabels !== col) {
           this.showLabels = col;
@@ -109,7 +109,7 @@ export class NavigationComponent implements OnInit, OnDestroy {
     } else if (event.key === 'L' && event.ctrlKey) {
       event.preventDefault();
       event.cancelBubble = true;
-      this.navigationService.showLabels.next(!this.showLabels);
+      this.preferencesService.showLabels.next(!this.showLabels);
     }
   }
 

--- a/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.ts
@@ -19,6 +19,7 @@ import {
 } from '../../../../shared/services/navigation/navigation.service';
 import { Router } from '@angular/router';
 import { ThemeService } from '../../../../shared/services/theme/theme.service';
+import { PreferencesService } from '../../../../shared/services/preferences/preferences.service';
 
 const emptyNavigation: Navigation = {
   sections: [],
@@ -50,6 +51,7 @@ export class NavigationComponent implements OnInit, OnDestroy {
     private navigationService: NavigationService,
     private router: Router,
     private themeService: ThemeService,
+    private preferencesService: PreferencesService,
     private cd: ChangeDetectorRef
   ) {}
 
@@ -75,7 +77,7 @@ export class NavigationComponent implements OnInit, OnDestroy {
       }
     );
 
-    this.subscriptionCollapsed = this.navigationService.collapsed.subscribe(
+    this.subscriptionCollapsed = this.preferencesService.navCollapsed.subscribe(
       col => {
         if (this.collapsed !== col) {
           this.collapsed = col;
@@ -140,6 +142,10 @@ export class NavigationComponent implements OnInit, OnDestroy {
     return path;
   }
 
+  showPrefs() {
+    this.preferencesService.preferencesOpened.next(true);
+  }
+
   openPopup(index: number) {
     this.setNavState(true, index);
     this.setLastSelection(index);
@@ -163,7 +169,7 @@ export class NavigationComponent implements OnInit, OnDestroy {
   }
 
   updateNavCollapsed(value: boolean): void {
-    this.navigationService.collapsed.next(value);
+    this.preferencesService.navCollapsed.next(value);
   }
 
   setLastSelection(index) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This change adds Preferences button at the bottom of the Left Navigation. That will open a Preferences dialog that currently has only two entries: Theme toggle and Navigation toggle. We will add more entries as we go on and merge it with existing Electron prefs after Electron build is fixed.

![Screen Shot 2020-10-22 at 12 10 56 PM](https://user-images.githubusercontent.com/34245594/96912506-b8371b80-145f-11eb-910f-5fba71dfa9de.png)

**Which issue(s) this PR fixes**
- Fixes #1498
