### PR TITLE
Display Ingress host as a link

### DIFF
--- a/changelogs/unreleased/1431-mklanjsek
+++ b/changelogs/unreleased/1431-mklanjsek
@@ -1,0 +1,1 @@
+Use link when displaying Ingress host

--- a/internal/printer/ingress.go
+++ b/internal/printer/ingress.go
@@ -40,9 +40,10 @@ func IngressListHandler(ctx context.Context, list *extv1beta1.IngressList, optio
 			return nil, err
 		}
 
+		isTLS := len(ingress.Spec.TLS) > 0
 		row["Name"] = nameLink
 		row["Labels"] = component.NewLabels(ingress.Labels)
-		row["Hosts"] = getHostComponent(formatIngressHosts(ingress.Spec.Rules))
+		row["Hosts"] = getHostComponent(formatIngressHosts(ingress.Spec.Rules), isTLS)
 		row["Address"] = component.NewText(loadBalancerStatusStringer(ingress.Status.LoadBalancer))
 		row["Ports"] = component.NewText(ports)
 		row["Age"] = component.NewTimestamp(ingress.CreationTimestamp.Time)
@@ -55,10 +56,25 @@ func IngressListHandler(ctx context.Context, list *extv1beta1.IngressList, optio
 	return ot.ToComponent()
 }
 
-func getHostComponent(link string) component.Component {
+func getHostComponent(link string, isTLS bool) component.Component {
 	_, err := url.Parse(link)
 	if strings.Contains(link, ".") && err == nil {
-		return component.NewLink("", link, "http://"+link)
+		prefix := "http://"
+		if isTLS {
+			prefix = "https://"
+		}
+
+		links := strings.Split(link, ",")
+		if len(links) == 1 {
+			return component.NewLink("", link, prefix+link)
+		}
+
+		// multiple urls, use Markdown instead
+		urls := make([]string, len(links))
+		for i := range urls {
+			urls[i] = fmt.Sprintf("[%s](%s)", links[i], prefix+links[i])
+		}
+		return component.NewMarkdownText(strings.Join(urls, ", "))
 	} else {
 		return component.NewText(link)
 	}

--- a/internal/printer/ingress.go
+++ b/internal/printer/ingress.go
@@ -8,6 +8,7 @@ package printer
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -41,7 +42,7 @@ func IngressListHandler(ctx context.Context, list *extv1beta1.IngressList, optio
 
 		row["Name"] = nameLink
 		row["Labels"] = component.NewLabels(ingress.Labels)
-		row["Hosts"] = component.NewText(formatIngressHosts(ingress.Spec.Rules))
+		row["Hosts"] = getHostComponent(formatIngressHosts(ingress.Spec.Rules))
 		row["Address"] = component.NewText(loadBalancerStatusStringer(ingress.Status.LoadBalancer))
 		row["Ports"] = component.NewText(ports)
 		row["Age"] = component.NewTimestamp(ingress.CreationTimestamp.Time)
@@ -52,6 +53,15 @@ func IngressListHandler(ctx context.Context, list *extv1beta1.IngressList, optio
 	}
 
 	return ot.ToComponent()
+}
+
+func getHostComponent(link string) component.Component {
+	_, err := url.Parse(link)
+	if strings.Contains(link, ".") && err == nil {
+		return component.NewLink("", link, "http://"+link)
+	} else {
+		return component.NewText(link)
+	}
 }
 
 // IngressHandler is a printFunc that prints an Ingress

--- a/web/src/app/modules/shared/components/presentation/link/link.component.html
+++ b/web/src/app/modules/shared/components/presentation/link/link.component.html
@@ -1,5 +1,5 @@
 <ng-template [ngIf]="isExternal" [ngIfElse]="internal">
-  <a href="{{ ref }}">{{ value }}</a>
+  <a target ="_blank" href="{{ ref }}">{{ value }}</a>
 </ng-template>
 
 <ng-template #internal>


### PR DESCRIPTION
Instead of showing plain text, we will now try to detect if ingress host field contains the Url, and show it as a link if it does. 

This change also modifies the Link component to open the **external** links inside the separate browser window. This makes sense especially with a move to Electron app. All internal Octant links are handled same as before.

**Which issue(s) this PR fixes**
- Fixes #1431 

