### PR TITLE
Refactor form payloads

### DIFF
--- a/changelogs/unreleased/1563-GuessWhoSamFoo
+++ b/changelogs/unreleased/1563-GuessWhoSamFoo
@@ -1,0 +1,1 @@
+Removed formGroup from payload actions and updated to return values for multiple checkboxes

--- a/pkg/view/component/form.go
+++ b/pkg/view/component/form.go
@@ -620,6 +620,7 @@ type Form struct {
 func (f *Form) MarshalJSON() ([]byte, error) {
 	t := struct {
 		Fields []map[string]interface{} `json:"fields"`
+		Action string                   `json:"action,omitempty"`
 	}{}
 
 	for _, field := range f.Fields {
@@ -636,6 +637,7 @@ func (f *Form) MarshalJSON() ([]byte, error) {
 
 		t.Fields = append(t.Fields, m)
 	}
+	t.Action = f.Action
 
 	return json.Marshal(t)
 }

--- a/web/src/app/modules/shared/components/presentation/form/form.component.html
+++ b/web/src/app/modules/shared/components/presentation/form/form.component.html
@@ -10,9 +10,10 @@
             <input
               type="checkbox"
               clrCheckbox
-              [formControlName]="field.name"
+              [formArraylName]="field.name"
               [value]="opt.value"
               [checked]="opt.checked"
+              (change)="onCheck($event, field.name)"
             />
             <label>{{ opt.label }}</label>
           </clr-checkbox-wrapper>

--- a/web/src/app/modules/shared/components/presentation/form/form.component.ts
+++ b/web/src/app/modules/shared/components/presentation/form/form.component.ts
@@ -5,7 +5,9 @@
 import { Component, Input, OnInit, Output } from '@angular/core';
 import { ActionField, ActionForm } from '../../../models/content';
 import {
+  FormArray,
   FormBuilder,
+  FormControl,
   FormGroup,
   ValidatorFn,
   Validators,
@@ -27,6 +29,7 @@ export class FormComponent implements OnInit {
   form: ActionForm;
 
   formGroup: FormGroup;
+  formArray: FormArray;
 
   constructor(private formBuilder: FormBuilder) {}
 
@@ -38,9 +41,30 @@ export class FormComponent implements OnInit {
           field.value,
           this.getValidators(field.validators),
         ];
+        if (field.configuration?.choices && field.type === 'checkbox') {
+          const choices: Choice[] = field.configuration.choices;
+          controls[field.name] = new FormArray([]);
+          choices.forEach((choice: Choice) => {
+            if (choice.checked) {
+              controls[field.name].push(new FormControl(choice.value));
+            }
+          });
+        }
       });
-
       this.formGroup = this.formBuilder.group(controls);
+    }
+  }
+
+  onCheck(event, field: string) {
+    this.formArray = this.formGroup.get(field) as FormArray;
+    if (event.target.checked) {
+      this.formArray.push(new FormControl(event.target.value));
+    } else {
+      this.formArray.controls.forEach((fc: FormControl, index: number) => {
+        if (fc.value === event.target.value) {
+          this.formArray.removeAt(index);
+        }
+      });
     }
   }
 

--- a/web/src/app/modules/shared/components/presentation/heptagon-label/heptagon-label.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/heptagon-label/heptagon-label.component.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 import { Point } from '../../../models/point';
 import { HeptagonLabelComponent } from './heptagon-label.component';
 
@@ -10,11 +10,13 @@ describe('HeptagonLabelComponent', () => {
   let component: HeptagonLabelComponent;
   let fixture: ComponentFixture<HeptagonLabelComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [HeptagonLabelComponent],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [HeptagonLabelComponent],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(HeptagonLabelComponent);

--- a/web/src/app/modules/shared/components/presentation/modal/modal.component.ts
+++ b/web/src/app/modules/shared/components/presentation/modal/modal.component.ts
@@ -10,7 +10,6 @@ import {
 import { FormComponent } from '../form/form.component';
 import { ModalService } from '../../../services/modal/modal.service';
 import { Subscription } from 'rxjs';
-import { WebsocketService } from '../../../../../data/services/websocket/websocket.service';
 import { ActionService } from '../../../services/action/action.service';
 
 interface Choice {
@@ -41,8 +40,7 @@ export class ModalComponent
 
   constructor(
     private actionService: ActionService,
-    private modalService: ModalService,
-    private websocketService: WebsocketService
+    private modalService: ModalService
   ) {
     super();
   }
@@ -72,9 +70,9 @@ export class ModalComponent
 
   onFormSubmit() {
     if (this.modalAppForm && this.modalAppForm.formGroup.valid) {
-      this.websocketService.sendMessage('action.octant.dev/performAction', {
+      this.actionService.perform({
         action: this.action,
-        formGroup: this.modalAppForm.formGroup.value,
+        ...this.modalAppForm.formGroup.value,
       });
       this.opened = false;
     }

--- a/web/src/app/modules/shared/components/presentation/stepper/stepper.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/stepper/stepper.component.spec.ts
@@ -13,13 +13,14 @@ import {
 } from '@angular/platform-browser/animations';
 import { WebsocketService } from '../../../../../data/services/websocket/websocket.service';
 import { anything, deepEqual, instance, mock, verify } from 'ts-mockito';
+import { ActionService } from '../../../services/action/action.service';
 
 describe('StepperComponent', () => {
   let component: StepperComponent;
   let fixture: ComponentFixture<StepperComponent>;
   const formBuilder: FormBuilder = new FormBuilder();
 
-  const mockWebsocketService: WebsocketService = mock(WebsocketService);
+  const mockActionService: ActionService = mock(ActionService);
 
   const action = 'action.octant.dev/test';
   const view: StepperView = {
@@ -56,8 +57,8 @@ describe('StepperComponent', () => {
         providers: [
           { provide: FormBuilder, useValue: formBuilder },
           {
-            provide: WebsocketService,
-            useValue: instance(mockWebsocketService),
+            provide: ActionService,
+            useValue: instance(mockActionService),
           },
         ],
       }).compileComponents();
@@ -90,12 +91,8 @@ describe('StepperComponent', () => {
         fixture.detectChanges();
 
         verify(
-          mockWebsocketService.sendMessage(
-            'action.octant.dev/performAction',
-            deepEqual({
-              action,
-              formGroup: anything(),
-            })
+          mockActionService.perform(
+            deepEqual({ action, 'step 1': {}, 'confirmation step': {} })
           )
         ).once();
       });

--- a/web/src/app/modules/shared/components/presentation/stepper/stepper.component.ts
+++ b/web/src/app/modules/shared/components/presentation/stepper/stepper.component.ts
@@ -6,8 +6,8 @@ import {
   ValidatorFn,
   Validators,
 } from '@angular/forms';
-import { WebsocketService } from '../../../../../data/services/websocket/websocket.service';
 import { AbstractViewComponent } from '../../abstract-view/abstract-view.component';
+import { ActionService } from '../../../services/action/action.service';
 
 interface Choice {
   label: string;
@@ -33,7 +33,7 @@ export class StepperComponent extends AbstractViewComponent<StepperView> {
 
   constructor(
     private formBuilder: FormBuilder,
-    private websocketService: WebsocketService
+    private actionService: ActionService
   ) {
     super();
   }
@@ -71,13 +71,10 @@ export class StepperComponent extends AbstractViewComponent<StepperView> {
   }
 
   onFormSubmit() {
-    this.websocketService.sendMessage('action.octant.dev/performAction', {
+    this.actionService.perform({
       action: this.action,
-      formGroup: this.formGroup.value,
+      ...this.formGroup.value,
     });
-    if (isDevMode()) {
-      console.log('stepper form: ' + this.formGroup.value);
-    }
   }
 
   onFormCancel() {

--- a/web/src/app/modules/shared/components/presentation/tabs/tabs.component.ts
+++ b/web/src/app/modules/shared/components/presentation/tabs/tabs.component.ts
@@ -17,7 +17,7 @@ import {
 } from 'src/app/modules/shared/models/content';
 import { SliderService } from 'src/app/modules/shared/slider/slider.service';
 import { ViewService } from '../../../services/view/view.service';
-import { WebsocketService } from '../../../../../data/services/websocket/websocket.service';
+import { ActionService } from '../../../services/action/action.service';
 
 interface Tab {
   name: string;
@@ -51,7 +51,7 @@ export class TabsComponent implements OnChanges, OnInit {
     private activatedRoute: ActivatedRoute,
     private viewService: ViewService,
     private sliderService: SliderService,
-    private wss: WebsocketService
+    private actionService: ActionService
   ) {}
 
   ngOnInit() {
@@ -133,7 +133,7 @@ export class TabsComponent implements OnChanges, OnInit {
     if (tabIndex > -1) {
       if (this.payloads[tabIndex]) {
         const payload = this.payloads[tabIndex];
-        this.wss.sendMessage('action.octant.dev/performAction', payload);
+        this.actionService.perform(payload);
       }
 
       this.tabs = [


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR contains **breaking changes** to the plugin API around form usage. Since these patterns are not yet widely used (or unusable in the case of knative), changes can still be merged into 0.16.2

1. Check boxes
Previously check boxes with multiple input choices would generate a payload with only the checkbox label and a bool if any of the input choices were selected. e.g.
```
component.NewFormFieldCheckBox("checkbox", "test", []component.InputChoice{
	{
		Label:   "a",
		Value:   "1",
		Checked: true,
	},
	{
		Label:   "b",
		Value:   "2",
		Checked: false,
	},
})
```
Results in the loss of input choice values:
```
{
   "type":"action.octant.dev/performAction",
   "payload":{
      "test":true,
      "action":"action.octant.dev/example
   }
}
```
This is now changed to return an array of checked values similar to the behavior of `Select`.

2. Remove `formGroup`
Components were previoues using websocket service and sending messages with payloads. This is now moved to action service to deduplicate `action.octant.dev/performAction`. `formGroup` is removed so that plugin authors don't have to parse `request.Payload.Raw` and use `request.Payload.String` directly. ref #1504 

3. Marshal action to form
Forms added to modals will now be read by action handler in plugins.

**Which issue(s) this PR fixes**
- Fixes #1508 

Signed-off-by: GuessWhoSamFoo <foos@vmware.com>
