### PR TITLE
Allow table sorting by multiple keys

### DIFF
--- a/changelogs/unreleased/1566-GuessWhoSamFoo
+++ b/changelogs/unreleased/1566-GuessWhoSamFoo
@@ -1,0 +1,1 @@
+Added multi key table sort and added reverse method

--- a/internal/modules/configuration/plugin_describer.go
+++ b/internal/modules/configuration/plugin_describer.go
@@ -92,7 +92,7 @@ func (d *PluginListDescriber) Describe(ctx context.Context, namespace string, op
 		tbl.Add(row)
 	}
 
-	tbl.Sort(false, "Name")
+	tbl.Sort("Name")
 
 	return component.ContentResponse{
 		Components: []component.Component{list},

--- a/internal/modules/configuration/plugin_describer.go
+++ b/internal/modules/configuration/plugin_describer.go
@@ -92,7 +92,7 @@ func (d *PluginListDescriber) Describe(ctx context.Context, namespace string, op
 		tbl.Add(row)
 	}
 
-	tbl.Sort("Name", false)
+	tbl.Sort(false, "Name")
 
 	return component.ContentResponse{
 		Components: []component.Component{list},

--- a/internal/printer/configmap.go
+++ b/internal/printer/configmap.go
@@ -122,7 +122,7 @@ func describeConfigMapData(cm *corev1.ConfigMap) (*component.Table, error) {
 		table.Add(row)
 	}
 
-	table.Sort("Key", false)
+	table.Sort(false, "Key")
 
 	return table, nil
 }

--- a/internal/printer/configmap.go
+++ b/internal/printer/configmap.go
@@ -122,7 +122,7 @@ func describeConfigMapData(cm *corev1.ConfigMap) (*component.Table, error) {
 		table.Add(row)
 	}
 
-	table.Sort(false, "Key")
+	table.Sort("Key")
 
 	return table, nil
 }

--- a/internal/printer/customresource.go
+++ b/internal/printer/customresource.go
@@ -95,7 +95,7 @@ func CreateCustomResourceList(crdObject *unstructured.Unstructured, resources *u
 		table.Add(row)
 	}
 
-	table.Sort(false, "Name")
+	table.Sort("Name")
 
 	return table, nil
 }

--- a/internal/printer/customresource.go
+++ b/internal/printer/customresource.go
@@ -95,7 +95,7 @@ func CreateCustomResourceList(crdObject *unstructured.Unstructured, resources *u
 		table.Add(row)
 	}
 
-	table.Sort("Name", false)
+	table.Sort(false, "Name")
 
 	return table, nil
 }

--- a/internal/printer/deployment.go
+++ b/internal/printer/deployment.go
@@ -145,7 +145,7 @@ func createDeploymentConditionsView(deployment *appsv1.Deployment) (*component.T
 		table.Add(row)
 	}
 
-	table.Sort("Type", false)
+	table.Sort(false, "Type")
 
 	return table, nil
 }

--- a/internal/printer/deployment.go
+++ b/internal/printer/deployment.go
@@ -145,7 +145,7 @@ func createDeploymentConditionsView(deployment *appsv1.Deployment) (*component.T
 		table.Add(row)
 	}
 
-	table.Sort(false, "Type")
+	table.Sort("Type")
 
 	return table, nil
 }

--- a/internal/printer/event.go
+++ b/internal/printer/event.go
@@ -78,7 +78,8 @@ func EventListHandler(ctx context.Context, list *corev1.EventList, opts Options)
 		table.Add(row)
 	}
 
-	table.Sort(true, "Last Seen")
+	table.Sort("Last Seen")
+	table.Reverse()
 
 	return table, nil
 }

--- a/internal/printer/event.go
+++ b/internal/printer/event.go
@@ -78,7 +78,7 @@ func EventListHandler(ctx context.Context, list *corev1.EventList, opts Options)
 		table.Add(row)
 	}
 
-	table.Sort("Last Seen", true)
+	table.Sort(true, "Last Seen")
 
 	return table, nil
 }

--- a/internal/printer/horizontalpodautoscaler.go
+++ b/internal/printer/horizontalpodautoscaler.go
@@ -240,7 +240,7 @@ func createHorizontalPodAutoscalerConditionsView(horizontalPodAutoscaler *autosc
 		table.Add(row)
 	}
 
-	table.Sort(false, "Type")
+	table.Sort("Type")
 
 	return table, nil
 }

--- a/internal/printer/horizontalpodautoscaler.go
+++ b/internal/printer/horizontalpodautoscaler.go
@@ -240,7 +240,7 @@ func createHorizontalPodAutoscalerConditionsView(horizontalPodAutoscaler *autosc
 		table.Add(row)
 	}
 
-	table.Sort("Type", false)
+	table.Sort(false, "Type")
 
 	return table, nil
 }

--- a/internal/printer/namespace.go
+++ b/internal/printer/namespace.go
@@ -218,7 +218,7 @@ func printNamespaceResourceQuotas(quotas []corev1.ResourceQuota) map[string]comp
 			row["Limit"] = component.NewText(q["hard"][resource])
 			table.Add(row)
 		}
-		table.Sort(false, "Resource")
+		table.Sort("Resource")
 		items[quotas[i].Name] = component.FlexLayoutItem{Width: component.WidthHalf, View: table}
 	}
 	return items

--- a/internal/printer/namespace.go
+++ b/internal/printer/namespace.go
@@ -218,7 +218,7 @@ func printNamespaceResourceQuotas(quotas []corev1.ResourceQuota) map[string]comp
 			row["Limit"] = component.NewText(q["hard"][resource])
 			table.Add(row)
 		}
-		table.Sort("Resource", false)
+		table.Sort(false, "Resource")
 		items[quotas[i].Name] = component.FlexLayoutItem{Width: component.WidthHalf, View: table}
 	}
 	return items

--- a/internal/printer/node.go
+++ b/internal/printer/node.go
@@ -320,7 +320,7 @@ func createNodeConditionsView(node *corev1.Node) (*component.Table, error) {
 		table.Add(row)
 	}
 
-	table.Sort(false, "Type")
+	table.Sort("Type")
 
 	return table, nil
 }
@@ -345,7 +345,7 @@ func createNodeImagesView(node *corev1.Node) (*component.Table, error) {
 		table.Add(row)
 	}
 
-	table.Sort(false, "Names")
+	table.Sort("Names")
 
 	return table, nil
 }

--- a/internal/printer/node.go
+++ b/internal/printer/node.go
@@ -320,7 +320,7 @@ func createNodeConditionsView(node *corev1.Node) (*component.Table, error) {
 		table.Add(row)
 	}
 
-	table.Sort("Type", false)
+	table.Sort(false, "Type")
 
 	return table, nil
 }
@@ -345,7 +345,7 @@ func createNodeImagesView(node *corev1.Node) (*component.Table, error) {
 		table.Add(row)
 	}
 
-	table.Sort("Names", false)
+	table.Sort(false, "Names")
 
 	return table, nil
 }

--- a/internal/printer/object_table.go
+++ b/internal/printer/object_table.go
@@ -147,7 +147,7 @@ func (ol *ObjectTable) ToComponent() (component.Component, error) {
 	}
 
 	if so := ol.sortOrder; so != nil {
-		table.Sort(so.name, so.reverse)
+		table.Sort(so.reverse, so.name)
 	}
 
 	return table, nil

--- a/internal/printer/object_table.go
+++ b/internal/printer/object_table.go
@@ -147,7 +147,10 @@ func (ol *ObjectTable) ToComponent() (component.Component, error) {
 	}
 
 	if so := ol.sortOrder; so != nil {
-		table.Sort(so.reverse, so.name)
+		table.Sort(so.name)
+		if so.reverse {
+			table.Reverse()
+		}
 	}
 
 	return table, nil

--- a/internal/printer/secret.go
+++ b/internal/printer/secret.go
@@ -110,7 +110,7 @@ func describeSecretData(secret corev1.Secret) (*component.Table, error) {
 		table.Add(row)
 	}
 
-	table.Sort("Key", false)
+	table.Sort(false, "Key")
 
 	return table, nil
 }

--- a/internal/printer/secret.go
+++ b/internal/printer/secret.go
@@ -110,7 +110,7 @@ func describeSecretData(secret corev1.Secret) (*component.Table, error) {
 		table.Add(row)
 	}
 
-	table.Sort(false, "Key")
+	table.Sort("Key")
 
 	return table, nil
 }

--- a/pkg/view/component/link.go
+++ b/pkg/view/component/link.go
@@ -117,5 +117,4 @@ func (t *Link) LessThan(i interface{}) bool {
 	}
 
 	return t.Config.Text < v.Config.Text
-
 }

--- a/pkg/view/component/table.go
+++ b/pkg/view/component/table.go
@@ -168,11 +168,15 @@ func (t *Table) SetPlaceholder(placeholder string) {
 }
 
 // Sort sorts a table by one or more keys with booleans for reverse and object status.
-func (t *Table) Sort(reverse bool, keys ...string) {
+func (t *Table) Sort(keys ...string) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
 	var sortFuncs []lessFunc
+
+	if len(keys) == 0 {
+		return
+	}
 
 	for _, key := range keys {
 		nameFunc := func(i, j TableRow) bool {
@@ -188,15 +192,22 @@ func (t *Table) Sort(reverse bool, keys ...string) {
 				return false
 			}
 
-			if reverse {
-				return !a.LessThan(b)
-			}
 			return a.LessThan(b)
 		}
 		sortFuncs = append(sortFuncs, nameFunc)
 	}
 
 	OrderedBy(sortFuncs).Sort(t.Rows())
+}
+
+func (t *Table) Reverse() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	rows := t.Rows()
+	for i, j := 0, len(rows)-1; i < j; i, j = i+1, j-1 {
+		rows[i], rows[j] = rows[j], rows[i]
+	}
 }
 
 type lessFunc func(p1, p2 TableRow) bool

--- a/pkg/view/component/table_test.go
+++ b/pkg/view/component/table_test.go
@@ -195,15 +195,33 @@ func Test_Table_Sort(t *testing.T) {
 				{"a": NewText("1"), "b": NewText("3")},
 			},
 		},
+		{
+			name:     "multiple keys reversed",
+			reverse:  true,
+			multiple: true,
+			rows: []TableRow{
+				{"a": NewText("1"), "b": NewText("2")},
+				{"a": NewText("1"), "b": NewText("1")},
+				{"a": NewText("1"), "b": NewText("3")},
+			},
+			expected: []TableRow{
+				{"a": NewText("1"), "b": NewText("3")},
+				{"a": NewText("1"), "b": NewText("2")},
+				{"a": NewText("1"), "b": NewText("1")},
+			},
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			table := NewTableWithRows("table", "placeholder", NewTableCols("a"), tc.rows)
 			if tc.multiple {
-				table.Sort(tc.reverse, "a", "b")
+				table.Sort("a", "b")
 			} else {
-				table.Sort(tc.reverse, "a")
+				table.Sort("a")
+			}
+			if tc.reverse {
+				table.Reverse()
 			}
 			expected := NewTableWithRows("table", "placeholder", NewTableCols("a"), tc.expected)
 

--- a/pkg/view/component/table_test.go
+++ b/pkg/view/component/table_test.go
@@ -149,6 +149,7 @@ func Test_Table_Sort(t *testing.T) {
 		name     string
 		rows     []TableRow
 		reverse  bool
+		multiple bool
 		expected []TableRow
 	}{
 		{
@@ -179,12 +180,31 @@ func Test_Table_Sort(t *testing.T) {
 				{"a": NewText("1")},
 			},
 		},
+		{
+			name:     "multiple keys",
+			reverse:  false,
+			multiple: true,
+			rows: []TableRow{
+				{"a": NewText("1"), "b": NewText("2")},
+				{"a": NewText("1"), "b": NewText("1")},
+				{"a": NewText("1"), "b": NewText("3")},
+			},
+			expected: []TableRow{
+				{"a": NewText("1"), "b": NewText("1")},
+				{"a": NewText("1"), "b": NewText("2")},
+				{"a": NewText("1"), "b": NewText("3")},
+			},
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			table := NewTableWithRows("table", "placeholder", NewTableCols("a"), tc.rows)
-			table.Sort("a", tc.reverse)
+			if tc.multiple {
+				table.Sort(tc.reverse, "a", "b")
+			} else {
+				table.Sort(tc.reverse, "a")
+			}
 			expected := NewTableWithRows("table", "placeholder", NewTableCols("a"), tc.expected)
 
 			assert.Equal(t, expected, table)

--- a/web/src/stories/table.stories.mdx
+++ b/web/src/stories/table.stories.mdx
@@ -1,0 +1,135 @@
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
+import { object, withKnobs } from '@storybook/addon-knobs';
+import {DatagridComponent} from "../app/modules/shared/components/presentation/datagrid/datagrid.component";
+import {TableComponent} from "../app/modules/shared/components/presentation/table/table.component";
+
+export const tableDocs= {source: {code: `cols := component.NewTableCols("A", "B")
+table := component.NewTable("Table Title", "Empty text", cols)
+table.Add(component.TableRow{
+	"A": component.NewText("1"),
+})
+table.Sort("A")
+table.Reverse()`}}
+
+export const textView = {
+  config: {
+    value: 'Table Title',
+  },
+  metadata: {
+    type: 'text',
+  },
+};
+
+<h1>Table Component</h1>
+<h2>Description</h2>
+
+<p>A table component is used to show tabular data with support for filtering, pagination, and sorting.</p>
+
+<p>When used in a Summary component, the table is intended to show simpler data as pagination, title, and filtering are removed.</p>
+<h2>Example</h2>
+
+<Meta title="Components/Table" component={DatagridComponent} />
+
+<Canvas withToolbar>
+  <Story name="Table component" parameters={{ docs: tableDocs }} height="800px" >
+  {{
+    props: {
+      view: object('View', {
+        metadata: {
+          type: 'table',
+          title: [textView],
+        },
+        config: {
+          columns: [
+            {
+              name: 'A',
+              accessor: 'A',
+            },
+            {
+              name: 'B',
+              accessor: 'B',
+            },
+          ],
+          rows: [
+            {
+              A: {
+                config: {
+                  value: '1',
+                },
+                metadata: {
+                  type: 'text'
+                },
+              },
+              B: {
+                config: {
+                  value: '2',
+                },
+                metadata: {
+                  type: 'text',
+                },
+              },
+            },
+          ],
+          emptyContent: 'Empty text',
+          loading: false,
+          filters: {},
+        },
+      }),
+    },
+    component: DatagridComponent,
+  }}
+  </Story>
+</Canvas>
+
+<h2>Props</h2>
+<ArgsTable of={DatagridComponent} />
+
+<Canvas withToolbar>
+  <Story name="Table used with summary" parameters={{ docs: tableDocs }} height="" >
+  {{
+    props: {
+      view: object('View', {
+        metadata: {
+          type: 'table',
+        },
+        config: {
+          columns: [
+            {
+              name: 'A',
+              accessor: 'A',
+            },
+            {
+              name: 'B',
+              accessor: 'B',
+            },
+          ],
+          rows: [
+            {
+              A: {
+                config: {
+                  value: '1',
+                },
+                metadata: {
+                  type: 'text'
+                },
+              },
+              B: {
+                config: {
+                  value: '2',
+                },
+                metadata: {
+                  type: 'text',
+                },
+              },
+            },
+          ],
+        },
+      }),
+    },
+    component: TableComponent,
+  }}
+  </Story>
+</Canvas>
+
+<h2>Props</h2>
+<ArgsTable of={TableComponent} />


### PR DESCRIPTION
**What this PR does / why we need it**:
~~This PR adds sorting with multiple keys and sorts items with an error status by default in order to increase visibility of unhealthy cluster items.~~ This is a **breaking API change** as `table.Sort` is in `pkg`

Since datagrids are paginated, this results in a poor user experience if the status of an object changes while a user is looking at it. We will need to rethink if the goal should be filtering instead.

**Which issue(s) this PR fixes**
- ref #1565 

Signed-off-by: GuessWhoSamFoo <foos@vmware.com>
