### PR TITLE
Show ConfigMaps (Volume-based) and PersistentVolumeClaims in Pod's resource viewer

### DIFF
--- a/internal/objectvisitor/pod_test.go
+++ b/internal/objectvisitor/pod_test.go
@@ -22,6 +22,7 @@ func TestPod_Visit(t *testing.T) {
 	serviceAccount := testutil.CreateServiceAccount("service-account")
 	configMap := testutil.CreateConfigMap("configmap")
 	secret := testutil.CreateSecret("secret")
+	pvc := testutil.CreatePersistentVolumeClaim("pvc")
 
 	object := testutil.CreatePod("pod")
 	object.Spec.ServiceAccountName = serviceAccount.Name
@@ -41,6 +42,9 @@ func TestPod_Visit(t *testing.T) {
 	q.EXPECT().
 		SecretsForPod(gomock.Any(), object).
 		Return([]*corev1.Secret{secret}, nil)
+	q.EXPECT().
+		PersistentVolumeClaimsForPod(gomock.Any(), object).
+		Return([]*corev1.PersistentVolumeClaim{pvc}, nil)
 
 	handler := fake.NewMockObjectHandler(controller)
 	handler.EXPECT().
@@ -53,6 +57,8 @@ func TestPod_Visit(t *testing.T) {
 		AddEdge(gomock.Any(), u, testutil.ToUnstructured(t, configMap)).
 		Return(nil)
 	handler.EXPECT().AddEdge(gomock.Any(), u, testutil.ToUnstructured(t, secret)).
+		Return(nil)
+	handler.EXPECT().AddEdge(gomock.Any(), u, testutil.ToUnstructured(t, pvc)).
 		Return(nil)
 
 	var visited []unstructured.Unstructured

--- a/internal/queryer/fake/mock_queryer.go
+++ b/internal/queryer/fake/mock_queryer.go
@@ -147,6 +147,21 @@ func (mr *MockQueryerMockRecorder) OwnerReference(arg0, arg1 interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OwnerReference", reflect.TypeOf((*MockQueryer)(nil).OwnerReference), arg0, arg1)
 }
 
+// PersistentVolumeClaimsForPod mocks base method
+func (m *MockQueryer) PersistentVolumeClaimsForPod(arg0 context.Context, arg1 *v10.Pod) ([]*v10.PersistentVolumeClaim, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PersistentVolumeClaimsForPod", arg0, arg1)
+	ret0, _ := ret[0].([]*v10.PersistentVolumeClaim)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PersistentVolumeClaimsForPod indicates an expected call of PersistentVolumeClaimsForPod
+func (mr *MockQueryerMockRecorder) PersistentVolumeClaimsForPod(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PersistentVolumeClaimsForPod", reflect.TypeOf((*MockQueryer)(nil).PersistentVolumeClaimsForPod), arg0, arg1)
+}
+
 // PodsForService mocks base method
 func (m *MockQueryer) PodsForService(arg0 context.Context, arg1 *v10.Service) ([]*v10.Pod, error) {
 	m.ctrl.T.Helper()

--- a/internal/queryer/queryer.go
+++ b/internal/queryer/queryer.go
@@ -839,6 +839,12 @@ func (osq *ObjectStoreQueryer) ConfigMapsForPod(ctx context.Context, pod *corev1
 			return nil, errors.Wrap(err, "converting unstructured configmap")
 		}
 
+		for _, v := range pod.Spec.Volumes {
+			if v.ConfigMap != nil && v.ConfigMap.Name == configMap.Name {
+				configMaps = append(configMaps, configMap)
+			}
+		}
+
 		for ci := range pod.Spec.Containers {
 			c := &pod.Spec.Containers[ci]
 			for _, e := range c.Env {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR improves the Pod's resource viewer to include:
* ConfigMaps that are referenced by a Pod via Volumes
* PersistentVolumeClaims that are referenced by a Pod

**Which issue(s) this PR fixes**
- Addresses #1541

**Special notes for your reviewer**:

There might be other resources that are missing from a Pod's resource viewer, but opening this PR to keep the scope somewhat small.

Keeping that in mind, should we keep #1541 open?

**Release note**:
```
The Pod resource viewer now shows ConfigMaps mounted via Volumes and PersistentVolumeClaims
```
