### PR TITLE
Switch resolved address to pubic npm registry

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8407,13 +8407,13 @@
     },
     "character-entities": {
       "version": "1.2.4",
-      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/character-entities/-/character-entities-1.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
       "integrity": "sha1-4Sw5Obfq9OWxXnrUxeKOHUjFsWs=",
       "dev": true
     },
     "character-entities-legacy": {
       "version": "1.1.4",
-      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
       "integrity": "sha1-lLwYRdznClu50uzHSHJWYSk9j8E=",
       "dev": true
     },


### PR DESCRIPTION
**What this PR does / why we need it**:

Attempts to resolve the artifactory URL will fail, and break the build.
This is likely due to new behavior in npm 7.

**Release note**:
```
n/a
```
