### PR TITLE
Improve calculating navigation selection from Url

### DIFF
--- a/web/src/app/modules/shared/services/navigation/navigation.service.spec.ts
+++ b/web/src/app/modules/shared/services/navigation/navigation.service.spec.ts
@@ -89,6 +89,38 @@ describe('NavigationService', () => {
       }
     ));
 
+    it('verify nav selection reverse lookup is correct', inject(
+      [NavigationService, WebsocketService, ContentService],
+      (svc: NavigationService, backendService: BackendService) => {
+        const currentNavigation: Navigation = {
+          sections: NAVIGATION_MOCK_DATA,
+          defaultPath: '',
+        };
+
+        backendService.triggerHandler(
+          'event.octant.dev/navigation',
+          currentNavigation
+        );
+
+        for (const path in expectedSelection) {
+          const prefixedPath = path.startsWith('/') ? path : '/' + path;
+          svc.activeUrl.next(prefixedPath);
+          svc.updateLastSelection();
+
+          svc.selectedItem.pipe(take(1)).subscribe(selection => {
+            expect(selection.index)
+              .withContext(`reverse lookup index navigation for ${path}`)
+              .toEqual(expectedSelection[path].index);
+            expect(selection.module)
+              .withContext(`reverse lookup module navigation for ${path}`)
+              .toEqual(expectedSelection[path].module);
+          });
+        }
+
+        svc.selectedItem.unsubscribe();
+      }
+    ));
+
     function verifySelection(
       path: string,
       svc: NavigationService,

--- a/web/src/app/modules/shared/services/navigation/navigation.test.data.ts
+++ b/web/src/app/modules/shared/services/navigation/navigation.test.data.ts
@@ -429,6 +429,10 @@ export const expectedSelection = {
   'argo-ui': { module: 3, index: 0 },
   '/knative': { module: 4, index: 0 },
   '/knative/serving/services': { module: 4, index: 1 },
+  '/knative/serving/services/event-display/revisions/event-display-dqtpl': {
+    module: 4,
+    index: 1,
+  },
   '/knative/serving/configurations': { module: 4, index: 2 },
   'plugin-name': { module: 5, index: 0 },
   'plugin-name/nested-once': { module: 5, index: 1 },

--- a/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.ts
@@ -118,10 +118,10 @@ export class NavigationComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.subscriptionModules.unsubscribe();
-    this.subscriptionSelectedItem.unsubscribe();
-    this.subscriptionCollapsed.unsubscribe();
-    this.subscriptionShowLabels.unsubscribe();
+    this.subscriptionModules?.unsubscribe();
+    this.subscriptionSelectedItem?.unsubscribe();
+    this.subscriptionCollapsed?.unsubscribe();
+    this.subscriptionShowLabels?.unsubscribe();
   }
 
   identifyNavigationItem(index: number, item: NavigationChild): string {


### PR DESCRIPTION
The algorithm that’s calculating selection from Url was not handling well situations when plugin paths are forming by adding on 2nd level navigation - everywhere else that’s done on 3rd level.

Reworked it, so now it ranks all known paths against the Url and one with deepest match wins. This insures that we will match the selection regardless how plugin authors decide to build their Url structure.

Signed-off-by: Milan Klanjsek <mklanjsek@pivotal.io>


