### PR TITLE
Prevent angular sanitizer from removing log content

### DIFF
--- a/changelogs/unreleased/1582-mklanjsek
+++ b/changelogs/unreleased/1582-mklanjsek
@@ -1,0 +1,1 @@
+Prevent angular sanitizer from removing log content

--- a/web/src/app/modules/shared/components/smart/logs/logs.component.html
+++ b/web/src/app/modules/shared/components/smart/logs/logs.component.html
@@ -124,7 +124,7 @@
           ></div>
           <div
             class="container-log-message"
-            [innerHTML]="highlightText(log.message) | ansipipe"
+            [innerHTML]="highlightText(log.message | escapepipe | ansipipe)"
           ></div>
         </div>
       </div>

--- a/web/src/app/modules/shared/components/smart/logs/logs.component.integration.spec.ts
+++ b/web/src/app/modules/shared/components/smart/logs/logs.component.integration.spec.ts
@@ -18,6 +18,7 @@ import { PodLogsService } from 'src/app/modules/shared/pod-logs/pod-logs.service
 import { LogsComponent } from './logs.component';
 import { AnsiPipe } from '../../../pipes/ansiPipe/ansi.pipe';
 import { windowProvider, WindowToken } from '../../../../../window';
+import { StringEscapePipe } from '../../../pipes/stringEscape/string.escape.pipe';
 
 function createTestLogsView(
   durations: Since[],
@@ -73,7 +74,7 @@ describe('LogsComponent <-> PodsLogsService', () => {
   beforeEach(
     waitForAsync(() => {
       TestBed.configureTestingModule({
-        declarations: [LogsComponent, AnsiPipe],
+        declarations: [LogsComponent, AnsiPipe, StringEscapePipe],
         providers: [
           PodLogsService,
           { provide: WindowToken, useFactory: windowProvider },

--- a/web/src/app/modules/shared/components/smart/logs/logs.component.scss
+++ b/web/src/app/modules/shared/components/smart/logs/logs.component.scss
@@ -8,18 +8,19 @@
 
   .log-actions {
     display: flex;
+    flex-wrap: wrap;
     margin-top: 16px;
     margin-bottom: 6px;
   }
   .clr-control-container {
     input {
-      width: 240px;
+      width: 180px;
     }
   }
   .container-select {
-    margin-right: 24px;
+    margin-right: 16px;
     select {
-      width: 194px;
+      width: 180px;
     }
   }
   .clr-select-wrapper {
@@ -39,6 +40,7 @@
     &-buttons {
       margin-top: 14px;
       margin-left: 6px;
+      min-width: 64px;
     }
     &-btn {
       padding-left: 6px;
@@ -65,6 +67,9 @@
     }
     .toggle-timestamp {
       margin-right: 0px;
+    }
+    label {
+      min-width: 120px;
     }
   }
   .container-logs {

--- a/web/src/app/modules/shared/components/smart/logs/logs.component.spec.ts
+++ b/web/src/app/modules/shared/components/smart/logs/logs.component.spec.ts
@@ -9,6 +9,7 @@ import { By } from '@angular/platform-browser';
 import { DebugElement, ElementRef } from '@angular/core';
 import { AnsiPipe } from '../../../pipes/ansiPipe/ansi.pipe';
 import { windowProvider, WindowToken } from '../../../../../window';
+import { StringEscapePipe } from '../../../pipes/stringEscape/string.escape.pipe';
 
 /**
  * Adds lines of logs to LogsComponent
@@ -39,7 +40,7 @@ describe('LogsComponent', () => {
   beforeEach(
     waitForAsync(() => {
       TestBed.configureTestingModule({
-        declarations: [LogsComponent, AnsiPipe],
+        declarations: [LogsComponent, AnsiPipe, StringEscapePipe],
         providers: [{ provide: WindowToken, useFactory: windowProvider }],
       }).compileComponents();
     })
@@ -105,6 +106,26 @@ describe('LogsComponent', () => {
     expect(selectHighlights[0].nativeElement.innerText).toEqual(
       'Just for test'
     );
+  });
+
+  it('should handle text that has to be escaped (#1582)', () => {
+    const expectedLogEntry = `2020-11-01T11:56:45.910889701Z {"@timestamp":"2020-11-01T11:56:45.909Z","level":"INFO","class":"rs.jms.message.received.from.mq","message":"GenericMessage [payload=<?xml version="1.0" encoding="UTF-8"?><ns:Message\\n xmlns:ns="http://otpbank.ru/Message"\\n><MessageHeader\\n><MessageDate\\n>2020-11-01T14:56:45</MessageDate\\n><ProcessID\\n>Broker</ProcessID\\n><MessageType\\n>CreateOpty</MessageType\\n><MessageID\\n>100B2F2E5E64EDB65E6E0533CA0A8C03EDD</MessageID\\n><IntegrationID\\n>4c020f7acfd84c2d8af05dfbd1404e1c</IntegrationID\\n><InitiatorSystem\\n>SIEBEL</InitiatorSystem\\n><SourceSystem\\n>SIEBEL</SourceSystem\\n><TargetSystemList\\n><TargetSystem\\n>mcs-posbroker-api</TargetSystem\\n></TargetSystemList\\n><Version\\n>1.0</Version\\n><ResultInfo\\n><Code\\n>0</Code\\n><Description\\n></Description\\n><Exception\\n></Exception\\n></ResultInfo\\n></MessageHeader\\n><MessageBody\\n><CreateOptyResponse\\n><Opty_Id\\n>2-1OGXGXFW</Opty_Id\\n><Error_Code\\n>0</Error_Code\\n><Error_Message\\n></Error_Message\\n></CreateOptyResponse\\n></MessageBody\\n></ns:Message\\n>, headers={JMS_IBM_Character_Set=UTF-8, errorChannel=org.springframework.messaging.core.GenericMessagingTemplate$TemporaryReplyChannel@b8364f77, JMS_IBM_MsgType=8, jms_destination=queue://WMB02PQM/POS_CBCREATEOPTY_SIEBEL_RES, JMSXUserID=siebel , JMS_IBM_Encoding=273, priority=4, jms_timestamp=1604231805837, JMSXAppID=WebSphere MQ Client for Java, JMS_IBM_PutApplType=28, JMS_IBM_Format=MQSTR , replyChannel=org.springframework.messaging.core.GenericMessagingTemplate$TemporaryReplyChannel@b8364f77, jms_redelivered=false, JMS_IBM_PutDate=20201101, JMSXDeliveryCount=1, jms_correlationId=784b0c72-8937-4615-b911-54b656e82460, ws_soapAction="document/http://siebel.com/CustomUI:CreateOpty_spcv2", JMS_IBM_PutTime=11564589, jms_type=SiebelJMSMessage, id=fa092de7-e6c7-a00e-3647-d3c6a8eae2fe, jms_messageId=ID:414d5120574d42303250514d20202020667e9e5f298f3623, timestamp=1604231805909}]","trace":"","span":"","parent":"","thread":"http-nio-8080-exec-9"}`;
+    const logList = [];
+    logList.push({
+      timestamp: '2020-11-01T11:56:45.910889701Z',
+      message: `2020-11-01T11:56:45.910889701Z {"@timestamp":"2020-11-01T11:56:45.909Z","level":"INFO","class":"rs.jms.message.received.from.mq","message":"GenericMessage [payload=<?xml version=\"1.0\" encoding=\"UTF-8\"?><ns:Message\n xmlns:ns=\"http://otpbank.ru/Message\"\n><MessageHeader\n><MessageDate\n>2020-11-01T14:56:45</MessageDate\n><ProcessID\n>Broker</ProcessID\n><MessageType\n>CreateOpty</MessageType\n><MessageID\n>100B2F2E5E64EDB65E6E0533CA0A8C03EDD</MessageID\n><IntegrationID\n>4c020f7acfd84c2d8af05dfbd1404e1c</IntegrationID\n><InitiatorSystem\n>SIEBEL</InitiatorSystem\n><SourceSystem\n>SIEBEL</SourceSystem\n><TargetSystemList\n><TargetSystem\n>mcs-posbroker-api</TargetSystem\n></TargetSystemList\n><Version\n>1.0</Version\n><ResultInfo\n><Code\n>0</Code\n><Description\n></Description\n><Exception\n></Exception\n></ResultInfo\n></MessageHeader\n><MessageBody\n><CreateOptyResponse\n><Opty_Id\n>2-1OGXGXFW</Opty_Id\n><Error_Code\n>0</Error_Code\n><Error_Message\n></Error_Message\n></CreateOptyResponse\n></MessageBody\n></ns:Message\n>, headers={JMS_IBM_Character_Set=UTF-8, errorChannel=org.springframework.messaging.core.GenericMessagingTemplate$TemporaryReplyChannel@b8364f77, JMS_IBM_MsgType=8, jms_destination=queue://WMB02PQM/POS_CBCREATEOPTY_SIEBEL_RES, JMSXUserID=siebel , JMS_IBM_Encoding=273, priority=4, jms_timestamp=1604231805837, JMSXAppID=WebSphere MQ Client for Java, JMS_IBM_PutApplType=28, JMS_IBM_Format=MQSTR , replyChannel=org.springframework.messaging.core.GenericMessagingTemplate$TemporaryReplyChannel@b8364f77, jms_redelivered=false, JMS_IBM_PutDate=20201101, JMSXDeliveryCount=1, jms_correlationId=784b0c72-8937-4615-b911-54b656e82460, ws_soapAction=\"document/http://siebel.com/CustomUI:CreateOpty_spcv2\", JMS_IBM_PutTime=11564589, jms_type=SiebelJMSMessage, id=fa092de7-e6c7-a00e-3647-d3c6a8eae2fe, jms_messageId=ID:414d5120574d42303250514d20202020667e9e5f298f3623, timestamp=1604231805909}]","trace":"","span":"","parent":"","thread":"http-nio-8080-exec-9"}`,
+      container: 'test-container',
+    });
+
+    component.shouldDisplayTimestamp = false;
+    component.containerLogs = logList;
+    fixture.detectChanges();
+
+    const logLines: DebugElement[] = fixture.debugElement.queryAll(
+      By.css('.container-log-message')
+    );
+    expect(logLines.length).toEqual(1);
+    expect(logLines[0].nativeElement.innerText).toEqual(expectedLogEntry);
   });
 
   it('should filter case insensitive', () => {

--- a/web/src/app/modules/shared/pipes/ansiPipe/ansi.pipe.ts
+++ b/web/src/app/modules/shared/pipes/ansiPipe/ansi.pipe.ts
@@ -1,4 +1,4 @@
-import { Pipe, PipeTransform, SecurityContext } from '@angular/core';
+import { Pipe, PipeTransform } from '@angular/core';
 import {
   DomSanitizer,
   SafeHtml,

--- a/web/src/app/modules/shared/pipes/stringEscape/string.escape.pipe.spec.ts
+++ b/web/src/app/modules/shared/pipes/stringEscape/string.escape.pipe.spec.ts
@@ -1,0 +1,44 @@
+import { BrowserModule, DomSanitizer } from '@angular/platform-browser';
+import { inject, TestBed } from '@angular/core/testing';
+import { StringEscapePipe } from './string.escape.pipe';
+
+describe('StringEscapePipe', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [BrowserModule],
+    });
+  });
+
+  const testCases = [
+    {
+      input: `NOOP test`,
+      expected: 'NOOP test',
+    },
+    {
+      input: `<a>First test</a>`,
+      expected: '&lt;a&gt;First test&lt;/a&gt;',
+    },
+    {
+      input: '<div>><a>Multiple levels test</a></div>',
+      expected:
+        '&lt;div&gt;&gt;&lt;a&gt;Multiple levels test&lt;/a&gt;&lt;/div&gt;',
+    },
+    {
+      input: 'Message\n More \n...',
+      expected: 'Message\\n More \\n...',
+    },
+  ];
+
+  it('Input strings are escaped properly', inject(
+    [DomSanitizer],
+    (domSanitizer: DomSanitizer) => {
+      const pipe = new StringEscapePipe(domSanitizer);
+      expect(pipe).toBeTruthy();
+
+      testCases.forEach(testCase => {
+        const sanitizedValue = pipe.transform(testCase.input);
+        expect(sanitizedValue).toBe(testCase.expected);
+      });
+    }
+  ));
+});

--- a/web/src/app/modules/shared/pipes/stringEscape/string.escape.pipe.ts
+++ b/web/src/app/modules/shared/pipes/stringEscape/string.escape.pipe.ts
@@ -1,0 +1,23 @@
+import { Pipe, PipeTransform, SecurityContext } from '@angular/core';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+
+@Pipe({
+  name: 'escapepipe',
+})
+export class StringEscapePipe implements PipeTransform {
+  constructor(private sanitizer: DomSanitizer) {}
+
+  public transform(value: string): SafeHtml {
+    return this.sanitizer.sanitize(
+      SecurityContext.HTML,
+      this.escapePipe(value)
+    );
+  }
+
+  escapePipe(str: string): string {
+    return str
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/\n/g, '\\n');
+  }
+}

--- a/web/src/app/modules/shared/pod-logs/pod-logs.service.ts
+++ b/web/src/app/modules/shared/pod-logs/pod-logs.service.ts
@@ -12,7 +12,6 @@ const API_BASE = getAPIBase();
 
 export class PodLogsStreamer {
   public logEntry: BehaviorSubject<LogEntry>;
-  private intervalID: number;
 
   constructor(
     private namespace: string,

--- a/web/src/app/modules/shared/shared.module.ts
+++ b/web/src/app/modules/shared/shared.module.ts
@@ -80,6 +80,7 @@ import { OctantTooltipComponent } from './components/presentation/octant-tooltip
 import { BottomPanelComponent } from './components/smart/bottom-panel/bottom-panel.component';
 import { DataModule } from '../../data/data.module';
 import { OverlayscrollbarsModule } from 'overlayscrollbars-ngx';
+import { StringEscapePipe } from './pipes/stringEscape/string.escape.pipe';
 
 @NgModule({
   declarations: [
@@ -128,6 +129,7 @@ import { OverlayscrollbarsModule } from 'overlayscrollbars-ngx';
     ResourceViewerComponent,
     SafePipe,
     AnsiPipe,
+    StringEscapePipe,
     FormatPathPipe,
     RelativePipe,
     TruncatePipe,
@@ -295,6 +297,7 @@ import { OverlayscrollbarsModule } from 'overlayscrollbars-ngx';
     ViewContainerComponent,
     OctantTooltipComponent,
     BottomPanelComponent,
+    StringEscapePipe,
   ],
 })
 export class SharedModule {}


### PR DESCRIPTION
Added new `stringescape` pipe that escapes specific characters in order to prevent the angular sanitizer removing them from showing inside the log view.

While there, I fixed some small log layout issues - the log action bar is now breaking better for smaller screen sizes  

Here is how the specific log entry from #1582 looks now:
![Screen Shot 2020-11-10 at 11 41 50 AM](https://user-images.githubusercontent.com/34245594/98718219-62151400-234b-11eb-9d95-4db0e4fcc04d.png)

Signed-off-by: Milan Klanjsek <mklanjsek@pivotal.io>

**Which issue(s) this PR fixes**
- Fixes #1582
