### PR TITLE
Updated deprecated set-env to output parameter

### DIFF
--- a/.github/workflows/preflight-checks.yaml
+++ b/.github/workflows/preflight-checks.yaml
@@ -46,7 +46,7 @@ jobs:
           go-version: 1.15.x
       - uses: actions/checkout@v2
       - name: Get tag
-        run: echo ::set-env name=GITHUB_TAG::${GITHUB_REF/refs\/tags\//}
+        run: echo "GITHUB_TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
       - name: Verify tag
         run: |
           bash ./ci/github-actions-tag-check.sh


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes the deprecated `set-env`.

Example of successful release on a fork: https://github.com/GuessWhoSamFoo/octant/actions/runs/362212377

**Which issue(s) this PR fixes**
- Fixes #1601 

Signed-off-by: GuessWhoSamFoo <foos@vmware.com>
