### PR TITLE
Fix resource viewer when a metrics server resource is unavailable

### DIFF
--- a/internal/octant/pod_metrics_loader.go
+++ b/internal/octant/pod_metrics_loader.go
@@ -8,6 +8,7 @@ package octant
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -163,9 +164,10 @@ func (ml *ClusterPodMetricsLoader) SupportsMetrics(ctx context.Context) (bool, e
 
 		lists, err := discoveryClient.ServerPreferredNamespacedResources()
 		if err != nil {
-			if discovery.IsGroupDiscoveryFailedError(err) {
+			if discovery.IsGroupDiscoveryFailedError(err) && strings.Contains(err.Error(), "metrics") {
 				logger := log.From(ctx)
-				logger.Warnf("metrics failed error: %w", err)
+				logger.Debugf("metrics discovery failed: %w", err)
+				ml.hasPodMetricsSupport = false
 				return
 			}
 			sErr = fmt.Errorf("get preferred namespaced resources: %w", err)


### PR DESCRIPTION
Signed-off-by: Wayne Witzel III <wayne@riotousliving.com>


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**
- Fixes #1619

No change log needed as this is a continuation of the work for #1559 and this fix and change is captured there. 