### PR TITLE
refactor dash.Runner startup

### DIFF
--- a/changelogs/unreleased/1676-jamieklassen
+++ b/changelogs/unreleased/1676-jamieklassen
@@ -1,0 +1,1 @@
+Refactor dash.Runner startup

--- a/cmd/octant-electron/main.go
+++ b/cmd/octant-electron/main.go
@@ -73,11 +73,16 @@ func run(ctx context.Context) error {
 
 	// TODO: this port should be random.
 	viper.Set(api.ListenerAddrKey, "127.0.0.1:7778")
+	listener, err := api.Listener()
+	if err != nil {
+		return fmt.Errorf("failed to create net listener: %w", err)
+	}
 
 	dashOptions := dash.Options{
 		DisableClusterOverview: false,
 		EnableOpenCensus:       false,
 		UserAgent:              fmt.Sprintf("octant-electron"), // TODO: create proper user agent
+		Listener:               listener,
 	}
 	shutdownCh := make(chan bool, 1)
 	startupCh := make(chan bool, 1)

--- a/cmd/octant-electron/main.go
+++ b/cmd/octant-electron/main.go
@@ -14,7 +14,6 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/vmware-tanzu/octant/internal/api"
-	ocontext "github.com/vmware-tanzu/octant/internal/context"
 	"github.com/vmware-tanzu/octant/internal/electron"
 	"github.com/vmware-tanzu/octant/internal/log"
 	"github.com/vmware-tanzu/octant/pkg/dash"
@@ -89,15 +88,14 @@ func run(ctx context.Context) error {
 	runCh := make(chan bool, 1)
 
 	ctx, cancel := context.WithCancel(ctx)
-	ctxKubeConfig := ocontext.WithKubeConfigCh(ctx)
 
-	runner, err := dash.NewRunner(ctxKubeConfig, logger, dashOptions)
+	runner, err := dash.NewRunner(ctx, logger, dashOptions)
 	if err != nil {
 		return fmt.Errorf("create octant runner: %w", err)
 	}
 
 	go func() {
-		runner.Start(ctxKubeConfig, logger, dashOptions, startupCh, shutdownCh)
+		runner.Start(dashOptions, startupCh, shutdownCh)
 		runCh <- true
 	}()
 

--- a/internal/commands/dash.go
+++ b/internal/commands/dash.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/vmware-tanzu/octant/internal/api"
 	"github.com/vmware-tanzu/octant/internal/config"
-	ocontext "github.com/vmware-tanzu/octant/internal/context"
 	"github.com/vmware-tanzu/octant/internal/log"
 	pconfig "github.com/vmware-tanzu/octant/pkg/config"
 	"github.com/vmware-tanzu/octant/pkg/dash"
@@ -119,14 +118,13 @@ func newOctantCmd(version string, gitCommit string, buildTime string) *cobra.Com
 
 				_ = klogFlagSet.Parse(klogOpts)
 
-				ctxKubeConfig := ocontext.WithKubeConfigCh(ctx)
-				runner, err := dash.NewRunner(ctxKubeConfig, logger, options)
+				runner, err := dash.NewRunner(ctx, logger, options)
 				if err != nil {
 					golog.Printf("unable to start runner: %v", err)
 					os.Exit(1)
 				}
 
-				runner.Start(ctxKubeConfig, logger, options, nil, shutdownCh)
+				runner.Start(options, nil, shutdownCh)
 
 				runCh <- true
 			}()

--- a/internal/commands/dash.go
+++ b/internal/commands/dash.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog"
 
+	"github.com/vmware-tanzu/octant/internal/api"
 	"github.com/vmware-tanzu/octant/internal/config"
 	ocontext "github.com/vmware-tanzu/octant/internal/context"
 	"github.com/vmware-tanzu/octant/internal/log"
@@ -66,6 +67,13 @@ func newOctantCmd(version string, gitCommit string, buildTime string) *cobra.Com
 				viper.Set("kubeconfig", clientcmd.NewDefaultClientConfigLoadingRules().GetDefaultFilename())
 			}
 
+			listener, err := api.Listener()
+			if err != nil {
+				err = fmt.Errorf("failed to create net listener: %w", err)
+				golog.Printf("use OCTANT_LISTENER_ADDR to set host:port: %s", err)
+				os.Exit(1)
+			}
+
 			go func() {
 				buildInfo := config.BuildInfo{
 					Version: version,
@@ -86,6 +94,7 @@ func newOctantCmd(version string, gitCommit string, buildTime string) *cobra.Com
 					ClientBurst:            viper.GetInt("client-burst"),
 					UserAgent:              fmt.Sprintf("octant/%s", version),
 					BuildInfo:              buildInfo,
+					Listener:               listener,
 				}
 
 				klogVerbosity := viper.GetString("klog-verbosity")

--- a/pkg/dash/dash.go
+++ b/pkg/dash/dash.go
@@ -106,10 +106,7 @@ func NewRunner(ctx context.Context, logger log.Logger, options Options) (*Runner
 	} else {
 		logger.Infof("no valid kube config found, initializing loading API")
 		// Initialize the API
-		apiService, apiErr = r.initLoadingAPI(ctx, logger, options)
-		if apiErr != nil {
-			return nil, fmt.Errorf("failed to start loading api: %w", err)
-		}
+		apiService = api.NewLoadingAPI(ctx, api.PathPrefix, r.actionManager, r.websocketClientManager, logger)
 	}
 
 	d, err := newDash(options.Listener, options.Namespace, options.FrontendURL, options.BrowserPath, apiService, pluginService, logger)
@@ -169,12 +166,6 @@ func (r *Runner) Start(ctx context.Context, logger log.Logger, options Options, 
 
 	shutdownCh <- true
 	return nil
-}
-
-func (r *Runner) initLoadingAPI(ctx context.Context, logger log.Logger, _ Options) (*api.LoadingAPI, error) {
-	apiService := api.NewLoadingAPI(ctx, api.PathPrefix, r.actionManager, r.websocketClientManager, logger)
-
-	return apiService, nil
 }
 
 func (r *Runner) initAPI(ctx context.Context, logger log.Logger, options Options) (*api.API, *pluginAPI.GRPCService, error) {

--- a/pkg/dash/dash_test.go
+++ b/pkg/dash/dash_test.go
@@ -7,14 +7,31 @@
 package dash
 
 import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/gorilla/websocket"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ocontext "github.com/vmware-tanzu/octant/internal/context"
 	"github.com/vmware-tanzu/octant/internal/log"
+	"github.com/vmware-tanzu/octant/pkg/event"
+
+	pkglog "github.com/vmware-tanzu/octant/pkg/log"
 )
 
 func TestRunner_ValidateKubeconfig(t *testing.T) {
@@ -80,4 +97,338 @@ func TestRunner_ValidateKubeconfig(t *testing.T) {
 			assert.Equal(t, path, test.expected)
 		})
 	}
+}
+
+type inMemoryListener struct {
+	conns chan net.Conn
+}
+
+func NewInMemoryListener() *inMemoryListener {
+	return &inMemoryListener{conns: make(chan net.Conn)}
+}
+
+func (iml *inMemoryListener) Accept() (net.Conn, error) {
+	return <-iml.conns, nil
+}
+func (iml *inMemoryListener) Close() error {
+	return nil
+}
+func (iml *inMemoryListener) Dial(network, addr string) (net.Conn, error) {
+	server, client := net.Pipe()
+	iml.conns <- AddrOverriddingConn{server}
+	return AddrOverriddingConn{client}, nil
+}
+func (iml *inMemoryListener) Addr() net.Addr {
+	return localhostAddr{}
+}
+
+type AddrOverriddingConn struct {
+	net.Conn
+}
+
+func (AddrOverriddingConn) LocalAddr() net.Addr {
+	return localhostAddr{}
+}
+func (AddrOverriddingConn) RemoteAddr() net.Addr {
+	return localhostAddr{}
+}
+
+type localhostAddr struct{}
+
+func (localhostAddr) Network() string {
+	return "tcp"
+}
+func (localhostAddr) String() string {
+	return "127.0.0.1:7777"
+}
+
+func TestNewRunnerLoadsValidKubeConfigFilteringNonexistent(t *testing.T) {
+	srv := fakeK8sAPIThatForbidsWatchingCRDs()
+	defer srv.Close()
+	stubRiceBox("dist/dash-frontend")
+	kubeConfig := tempFile(makeKubeConfig("test-context", srv.URL))
+	defer os.Remove(kubeConfig.Name())
+
+	listener := NewInMemoryListener()
+	cancel, _ := makeRunner(
+		Options{
+			KubeConfig: strings.Join(
+				[]string{
+					"/non/existent/kubeconfig",
+					kubeConfig.Name(),
+				},
+				string(filepath.ListSeparator),
+			),
+			Listener: listener,
+		},
+		log.NopLogger(),
+	)
+	defer cancel()
+	kubeConfigEvent := waitForKubeConfigEvent(listener)
+
+	require.Equal(t, "test-context", kubeConfigEvent.Data.CurrentContext)
+}
+
+func TestNewRunnerRunsLoadingAPIWhenStartedWithoutKubeConfig(t *testing.T) {
+	srv := fakeK8sAPIThatForbidsWatchingCRDs()
+	defer srv.Close()
+	stubRiceBox("dist/dash-frontend")
+
+	listener := NewInMemoryListener()
+	cancel, _ := makeRunner(Options{Listener: listener}, log.NopLogger())
+	defer cancel()
+	kubeConfig := makeKubeConfig("test-context", srv.URL)
+	websocketWrite(
+		fmt.Sprintf(`{
+	"type": "action.octant.dev/uploadKubeConfig",
+	"payload": {"kubeConfig": "%s"}
+}`, base64.StdEncoding.EncodeToString(kubeConfig)),
+		listener,
+	)
+	// wait for API to reload
+	for {
+		if websocketReadTimeout(listener, 10*time.Millisecond) {
+			break
+		}
+	}
+	kubeConfigEvent := waitForKubeConfigEvent(listener)
+
+	require.Equal(t, "test-context", kubeConfigEvent.Data.CurrentContext)
+}
+
+func TestNewRunnerShutsDownPluginsWhenStoppedBeforeReceivingKubeConfig(t *testing.T) {
+	stubRiceBox("dist/dash-frontend")
+	listener := NewInMemoryListener()
+	shutdownCh := make(chan bool)
+	options := Options{
+		Listener: listener,
+	}
+	logger := log.NopLogger()
+	ctx, cancel := context.WithCancel(context.Background())
+	ctx = ocontext.WithKubeConfigCh(ctx)
+	runner, err := NewRunner(ctx, logger, options)
+	require.NoError(t, err)
+
+	go runner.Start(ctx, logger, options, make(chan bool), shutdownCh)
+	cancel()
+
+	select {
+	case <-time.After(10 * time.Millisecond):
+		require.Fail(t, "failed to shut down within 10 ms")
+	case <-shutdownCh:
+	}
+}
+
+func websocketWrite(message string, listener *inMemoryListener) error {
+	dialer := websocket.DefaultDialer
+	dialer.NetDial = listener.Dial
+	wsConn, _, err := dialer.Dial("ws://127.0.0.1:7777/api/v1/stream", nil)
+	if err != nil {
+		return err
+	}
+	w, err := wsConn.NextWriter(websocket.TextMessage)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write([]byte(message))
+	if err != nil {
+		return err
+	}
+	w.Close()
+	wsConn.Close()
+	return nil
+}
+
+func websocketReadTimeout(listener *inMemoryListener, timeout time.Duration) bool {
+	dialer := websocket.DefaultDialer
+	dialer.NetDial = listener.Dial
+	wsConn, _, _ := dialer.Dial("ws://127.0.0.1:7777/api/v1/stream", nil)
+	defer wsConn.Close()
+	reader := make(chan interface{}, 1)
+	go func() {
+		wsConn.NextReader()
+		reader <- nil
+	}()
+	select {
+	case <-reader:
+		return true
+	case <-time.After(timeout):
+		return false
+	}
+}
+
+func makeKubeConfig(currentContext, serverAddr string) []byte {
+	return []byte(fmt.Sprintf(`contexts:
+- context: {cluster: cluster}
+  name: %s
+clusters:
+- cluster: {server: %s}
+  name: cluster
+current-context: %s
+`, currentContext, serverAddr, currentContext))
+}
+
+func waitForKubeConfigEvent(listener *inMemoryListener) kubeConfigEvent {
+	var message kubeConfigEvent
+	dialer := websocket.DefaultDialer
+	dialer.NetDial = listener.Dial
+	wsConn, resp, err := dialer.Dial("ws://127.0.0.1:7777/api/v1/stream", nil)
+	if err != nil {
+		fmt.Println(resp)
+		panic(err)
+	}
+	defer wsConn.Close()
+	for {
+		msgBytes, _ := readNextMessage(wsConn)
+		json.Unmarshal(msgBytes, &message)
+		if message.Type == event.EventTypeKubeConfig {
+			break
+		}
+	}
+	return message
+}
+
+type kubeConfigEvent struct {
+	Type event.EventType `json:"type"`
+	Data struct {
+		CurrentContext string `json:"currentContext"`
+	} `json:"data"`
+}
+
+func tempFile(contents []byte) *os.File {
+	tmpFile, _ := ioutil.TempFile("", "")
+	tmpFile.Write(contents)
+	tmpFile.Close()
+	return tmpFile
+}
+
+func makeRunner(options Options, logger pkglog.Logger) (context.CancelFunc, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	ctx = ocontext.WithKubeConfigCh(ctx)
+	runner, err := NewRunner(ctx, logger, options)
+	if err != nil {
+		return cancel, err
+	}
+	go runner.Start(ctx, logger, options, make(chan bool), make(chan bool))
+	return cancel, nil
+}
+
+func fakeK8sAPIThatForbidsWatchingCRDs() *httptest.Server {
+	l, _ := net.Listen("tcp", "127.0.0.1:0")
+	srv := httptest.NewUnstartedServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/api":
+				w.Write([]byte(fmt.Sprintf(`{
+	"kind": "APIVersions",
+	"versions": ["v1"],
+	"serverAddressByClientCIDRs": [
+		{
+			"clientCIDR": "0.0.0.0/0",
+			"serverAddress": "%s"
+		}
+	]
+}`, l.Addr().String())))
+			case "/apis":
+				w.Write([]byte(`{
+	"kind": "APIGroupList",
+	"apiVersion": "v1",
+	"groups": [
+		{
+			"name": "apiextensions.k8s.io",
+			"versions": [
+				{
+					"groupVersion": "apiextensions.k8s.io/v1beta1",
+					"version": "v1beta1"
+				}
+			],
+			"preferredVersion": {
+				"groupVersion": "apiextensions.k8s.io/v1beta1",
+				"version": "v1beta1"
+			}
+		}
+	]
+}`))
+			case "/apis/apiextensions.k8s.io/v1beta1":
+				w.Write([]byte(`{
+	"kind": "APIResourceList",
+	"apiVersion": "v1",
+	"groupVersion": "apiextensions.k8s.io/v1beta1",
+	"resources": [
+		{
+			"name": "customresourcedefinitions",
+			"singularName": "",
+			"namespaced": false,
+			"kind": "CustomResourceDefinition",
+			"verbs": [
+				"create",
+				"delete",
+				"deletecollection",
+				"get",
+				"list",
+				"patch",
+				"update",
+				"watch"
+			],
+			"shortNames": [
+				"crd",
+				"crds"
+			],
+			"storageVersionHash": "jfWCUB31mvA="
+		},
+		{
+			"name": "customresourcedefinitions/status",
+			"singularName": "",
+			"namespaced": false,
+			"kind": "CustomResourceDefinition",
+			"verbs": [
+				"get",
+				"patch",
+				"update"
+			]
+		}
+	]
+}`))
+			case "/apis/authorization.k8s.io/v1/selfsubjectaccessreviews":
+				w.Header().Add("Content-Type", "application/json")
+				w.Write([]byte(`{
+	"kind": "SelfSubjectAccessReview",
+	"apiVersion": "authorization.k8s.io/v1",
+	"metadata": {
+		"creationTimestamp": null
+	},
+	"spec": {
+		"resourceAttributes": {
+			"verb": "watch"
+		}
+	},
+	"status": {
+		"allowed": false
+	}
+}`))
+			}
+		}),
+	)
+	srv.Listener.Close()
+	srv.Listener = l
+	srv.Start()
+	return srv
+}
+
+func stubRiceBox(name string) {
+	_, callingGoFile, _, _ := runtime.Caller(0)
+	pkgDir := filepath.Dir(callingGoFile)
+	os.MkdirAll(filepath.Join(pkgDir, "../../web", name), 0755)
+}
+
+func readNextMessage(conn *websocket.Conn) ([]byte, error) {
+	_, reader, err := conn.NextReader()
+	if err != nil {
+		return nil, err
+	}
+	msgBytes, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return nil, err
+	}
+	return msgBytes, nil
 }

--- a/pkg/dash/dash_test.go
+++ b/pkg/dash/dash_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	ocontext "github.com/vmware-tanzu/octant/internal/context"
 	"github.com/vmware-tanzu/octant/internal/log"
 	"github.com/vmware-tanzu/octant/pkg/event"
 
@@ -205,11 +204,10 @@ func TestNewRunnerShutsDownPluginsWhenStoppedBeforeReceivingKubeConfig(t *testin
 	}
 	logger := log.NopLogger()
 	ctx, cancel := context.WithCancel(context.Background())
-	ctx = ocontext.WithKubeConfigCh(ctx)
 	runner, err := NewRunner(ctx, logger, options)
 	require.NoError(t, err)
 
-	go runner.Start(ctx, logger, options, make(chan bool), shutdownCh)
+	go runner.Start(options, make(chan bool), shutdownCh)
 	cancel()
 
 	select {
@@ -304,12 +302,11 @@ func tempFile(contents []byte) *os.File {
 
 func makeRunner(options Options, logger pkglog.Logger) (context.CancelFunc, error) {
 	ctx, cancel := context.WithCancel(context.Background())
-	ctx = ocontext.WithKubeConfigCh(ctx)
 	runner, err := NewRunner(ctx, logger, options)
 	if err != nil {
 		return cancel, err
 	}
-	go runner.Start(ctx, logger, options, make(chan bool), make(chan bool))
+	go runner.Start(options, make(chan bool), make(chan bool))
 	return cancel, nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**: Adds two simple integration tests for the two main startup flows (with and without a kubeconfig)

**Which issue(s) this PR fixes**
- Fixes #

**Special notes for your reviewer**: These tests require the test runner process to be able to create a directory, create/delete temporary files, and open TCP listeners (high-numbered random ports via `127.0.0.1:0`) on the host.

**Release note**:
```
release-note
```
