### PR TITLE
Show tabs in log output

### DIFF
--- a/web/src/app/modules/shared/pod-logs/pod-logs.service.ts
+++ b/web/src/app/modules/shared/pod-logs/pod-logs.service.ts
@@ -40,6 +40,7 @@ export class PodLogsStreamer {
 
     this.wss.registerHandler(this.streamUrl(), data => {
       const update = data as LogEntry;
+      update.message = update.message.replace(/\t/, '&nbsp;'.repeat(4));
       this.logEntry.next(update);
     });
   }


### PR DESCRIPTION
**What this PR does / why we need it**:

This change shows tabs in log outputs. It replaces the tab character with four non-blocking spaces.

**Special notes for your reviewer**:

Original
<img width="1285" alt="Screen Shot 2020-12-09 at 8 39 14 AM" src="https://user-images.githubusercontent.com/240/101637139-5a07cd00-39fa-11eb-8a71-36d08eacd51f.png">

With non-blocking spaces
<img width="1285" alt="Screen Shot 2020-12-09 at 8 39 38 AM" src="https://user-images.githubusercontent.com/240/101637183-6b50d980-39fa-11eb-81a1-eca5269047a0.png">


**Release note**:
```
Support showing tabs in log output.
```
