### PR TITLE
Fixed issue with broken links created from plugin

### DIFF
--- a/changelogs/unreleased/1723-mklanjsek
+++ b/changelogs/unreleased/1723-mklanjsek
@@ -1,0 +1,1 @@
+Fixed issue with broken links created from plugin (caused by angular 11 breaking change)

--- a/web/src/app/app-routing.module.ts
+++ b/web/src/app/app-routing.module.ts
@@ -25,6 +25,7 @@ export const appRoutes: Routes = [
   imports: [
     // routing must come last
     RouterModule.forRoot(appRoutes, {
+      relativeLinkResolution: 'legacy',
       useHash: true,
       enableTracing: false,
     }),


### PR DESCRIPTION
Angular bump to version 11 changed the router default behavior, causing links that were created inside the go plugins to be broken. Here is the description of the braking change form angular [update note](https://angular.io/guide/updating-to-version-11):  

`We changed the default value for relativeLinkResolution from 'legacy' to 'corrected' so that new applications are automatically opted-in to the corrected behavior from PR 22394`

This change manually configures the router ensuring Octant links behave the same way as before upgrade to Angular 11.

Signed-off-by: Milan Klanjsek <mklanjsek@pivotal.io>

**Which issue(s) this PR fixes**
- Fixes #1723
