### PR TITLE
Add a node pods view

### DIFF
--- a/internal/printer/node.go
+++ b/internal/printer/node.go
@@ -8,8 +8,9 @@ package printer
 import (
 	"context"
 	"fmt"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"strings"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -383,7 +384,7 @@ func createNodePodsView(node *corev1.Node, options *Options) (*component.Table, 
 	for _, pod := range podList.Items {
 
 		row := component.TableRow{
-			"Name":     component.NewText(pod.Name),
+			"Name":      component.NewText(pod.Name),
 			"Namespace": component.NewText(pod.Namespace),
 		}
 

--- a/internal/printer/node_test.go
+++ b/internal/printer/node_test.go
@@ -277,12 +277,12 @@ func Test_createNodeImagesView(t *testing.T) {
 
 	expected := component.NewTableWithRows("Images", "There are no images!", nodeImagesColumns, []component.TableRow{
 		{
-			"Names": component.NewMarkdownText("a"),
-			"Size (GB)":  component.NewText("0.001"),
+			"Names":     component.NewMarkdownText("a"),
+			"Size (GB)": component.NewText("0.001"),
 		},
 		{
-			"Names": component.NewMarkdownText("b-1\nb-2"),
-			"Size (GB)":  component.NewText("0.001"),
+			"Names":     component.NewMarkdownText("b-1\nb-2"),
+			"Size (GB)": component.NewText("0.001"),
 		},
 	})
 

--- a/internal/printer/node_test.go
+++ b/internal/printer/node_test.go
@@ -264,11 +264,11 @@ func Test_createNodeImagesView(t *testing.T) {
 	node.Status.Images = []corev1.ContainerImage{
 		{
 			Names:     []string{"a"},
-			SizeBytes: 10,
+			SizeBytes: 1000000,
 		},
 		{
 			Names:     []string{"b-1", "b-2"},
-			SizeBytes: 10,
+			SizeBytes: 1000000,
 		},
 	}
 
@@ -278,11 +278,11 @@ func Test_createNodeImagesView(t *testing.T) {
 	expected := component.NewTableWithRows("Images", "There are no images!", nodeImagesColumns, []component.TableRow{
 		{
 			"Names": component.NewMarkdownText("a"),
-			"Size":  component.NewText("10"),
+			"Size (GB)":  component.NewText("0.001"),
 		},
 		{
 			"Names": component.NewMarkdownText("b-1\nb-2"),
-			"Size":  component.NewText("10"),
+			"Size (GB)":  component.NewText("0.001"),
 		},
 	})
 


### PR DESCRIPTION
Signed-off-by: Zach Arnold <me@zacharnold.org>


**What this PR does / why we need it**:
Adds a "Pods" table to the Node overview so that people can see which pods are scheduled onto the node

**Which issue(s) this PR fixes**
- Fixes #1540 

**Special notes for your reviewer**:
I'm not quite sure how to mock the Kubernetes Client to create a test for this, I'd need some help on that.

**Release note**:
```
Adds a "Pods" table to the Node overview so that people can see which pods are scheduled onto the node
```
