### PR TITLE
Create ServerPreferredResources helper

### DIFF
--- a/internal/config/fake/mock_dash.go
+++ b/internal/config/fake/mock_dash.go
@@ -9,6 +9,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	cluster "github.com/vmware-tanzu/octant/internal/cluster"
 	config "github.com/vmware-tanzu/octant/internal/config"
@@ -226,6 +227,21 @@ func (m *MockDash) PortForwarder() portforward.PortForwarder {
 func (mr *MockDashMockRecorder) PortForwarder() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PortForwarder", reflect.TypeOf((*MockDash)(nil).PortForwarder))
+}
+
+// ServerPreferredResources mocks base method
+func (m *MockDash) ServerPreferredResources() ([]*v1.APIResourceList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ServerPreferredResources")
+	ret0, _ := ret[0].([]*v1.APIResourceList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ServerPreferredResources indicates an expected call of ServerPreferredResources
+func (mr *MockDashMockRecorder) ServerPreferredResources() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServerPreferredResources", reflect.TypeOf((*MockDash)(nil).ServerPreferredResources))
 }
 
 // UseContext mocks base method

--- a/internal/modules/applications/application_describer.go
+++ b/internal/modules/applications/application_describer.go
@@ -117,12 +117,7 @@ func loadAppObjects(ctx context.Context, dashConfig config.Dash, namespace, name
 		childrenProcessed <- true
 	}()
 
-	discoveryClient, err := dashConfig.ClusterClient().DiscoveryClient()
-	if err != nil {
-		return nil, err
-	}
-
-	resourceLists, err := discoveryClient.ServerPreferredResources()
+	resourceLists, err := dashConfig.ServerPreferredResources()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/modules/clusteroverview/clusteroverview.go
+++ b/internal/modules/clusteroverview/clusteroverview.go
@@ -135,15 +135,14 @@ func (co *ClusterOverview) Content(ctx context.Context, contentPath string, opts
 		return component.EmptyContentResponse, err
 	}
 
-	clusterClient := co.DashConfig.ClusterClient()
 	objectStore := co.DashConfig.ObjectStore()
 
-	discoveryInterface, err := clusterClient.DiscoveryClient()
+	discoveryClient, err := co.DashConfig.ClusterClient().DiscoveryClient()
 	if err != nil {
 		return component.EmptyContentResponse, err
-	}
 
-	q := queryer.New(objectStore, discoveryInterface)
+	}
+	q := queryer.New(objectStore, discoveryClient)
 
 	p := printer.NewResource(co.DashConfig)
 	if err := printer.AddHandlers(p); err != nil {

--- a/internal/printer/customresourcedefinition.go
+++ b/internal/printer/customresourcedefinition.go
@@ -103,12 +103,7 @@ func CustomResourceDefinitionVersionList(
 		return nil, err
 	}
 
-	discoveryClient, err := options.DashConfig.ClusterClient().DiscoveryClient()
-	if err != nil {
-		return nil, fmt.Errorf("discovery client: %w", err)
-	}
-
-	resourceLists, err := discoveryClient.ServerPreferredResources()
+	resourceLists, err := options.DashConfig.ServerPreferredResources()
 	if err != nil {
 		return nil, fmt.Errorf("preferred resources: %w", err)
 	}

--- a/internal/queryer/queryer.go
+++ b/internal/queryer/queryer.go
@@ -33,7 +33,9 @@ import (
 	"k8s.io/client-go/discovery"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 
+	"github.com/vmware-tanzu/octant/internal/config"
 	"github.com/vmware-tanzu/octant/internal/gvk"
+	"github.com/vmware-tanzu/octant/internal/log"
 	"github.com/vmware-tanzu/octant/internal/util/kubernetes"
 	dashstrings "github.com/vmware-tanzu/octant/internal/util/strings"
 	"github.com/vmware-tanzu/octant/pkg/navigation"
@@ -211,8 +213,9 @@ func (osq *ObjectStoreQueryer) Children(ctx context.Context, owner *unstructured
 		}
 	}
 
-	resourceLists, err := osq.discoveryClient.ServerPreferredResources()
-	if err != nil && !osq.IsMetricsDiscoveryErr(err) {
+	logger := log.From(ctx)
+	resourceLists, err := config.ServerPreferredResources(osq.discoveryClient, logger)
+	if err != nil {
 		return nil, fmt.Errorf("objectStoreQueryer children: %w", err)
 	}
 


### PR DESCRIPTION
Signed-off-by: Wayne Witzel III <wayne@riotousliving.com>


**What this PR does / why we need it**:
Fixes an issues that prevents the UI from loading if the discovery client fails to discovery the prefer resource for a known group. This can happen when a service backing a resource is misconfigured or temporarily gone away.

**Which issue(s) this PR fixes**
- Fixes #1790 