### PR TITLE
Fix streamer flake

### DIFF
--- a/changelogs/unreleased/1797-GuessWhoSamFoo
+++ b/changelogs/unreleased/1797-GuessWhoSamFoo
@@ -1,0 +1,1 @@
+Fix streamer test flake

--- a/internal/log/streamer.go
+++ b/internal/log/streamer.go
@@ -122,7 +122,6 @@ func (lm *Streamer) Stream(readyCh <-chan struct{}) (<-chan event.Event, func())
 		}
 
 		<-readyCh
-		ch <- lm.createEvent()
 	}()
 
 	lm.listeners[id] = ch


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a test flake which had two possible failures: timing out or a nil message.

If the go routine in the test fails before completion, the test would block indefinitely. Alternatively, `createEvent` is called twice - the handler and instantiation of the streamer. The unnecessary call is now removed.

Results of this test are now reproducible:
```
$ go test -run TestStreamer_Stream -count 1000
PASS
ok      github.com/vmware-tanzu/octant/internal/log     0.201s
```

**Which issue(s) this PR fixes**
- Fixes #1529 

Signed-off-by: GuessWhoSamFoo <foos@vmware.com>
Co-Authored-by: Wayne Witzel III <wayne@riotousliving.com>
