### PR TITLE
Check for GroupDiscovery error for metrics endponit

### DIFF
--- a/internal/queryer/queryer.go
+++ b/internal/queryer/queryer.go
@@ -317,6 +317,7 @@ var allowed = []schema.GroupVersionKind{
 }
 
 func (osq *ObjectStoreQueryer) IsMetricsDiscoveryErr(err error) bool {
+	//TODO: determine the best way to handle these types of errors for all resources, not just metrics.
 	return discovery.IsGroupDiscoveryFailedError(err) && strings.Contains(err.Error(), "metrics")
 }
 


### PR DESCRIPTION
Signed-off-by: Wayne Witzel III <wayne@riotousliving.com>


**What this PR does / why we need it**:
This puts a band-aid over the current error in master when encountering metrics services that are unavailable. I think we need a better fix than this, but master is currently unusable on cluster that have metrics services that may be offline or otherwise unavailable.

**Which issue(s) this PR fixes**
- Fixes #1790 

**Special notes for your reviewer**:

**Release note**:
```
release-note
```
