### PR TITLE
Add mutex to counter for runner test

### DIFF
--- a/pkg/plugin/runner_test.go
+++ b/pkg/plugin/runner_test.go
@@ -7,6 +7,7 @@ package plugin_test
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -25,9 +26,11 @@ import (
 
 func TestDefaultRunner(t *testing.T) {
 	counter := 0
-
+	var m sync.Mutex
 	pr := plugin.DefaultRunner{
 		RunFunc: func(ctx context.Context, name string, gvk schema.GroupVersionKind, object runtime.Object) error {
+			m.Lock()
+			defer m.Unlock()
 			counter++
 			return nil
 		},


### PR DESCRIPTION
Fixes race condition when testing for the counts of runners during test.

Signed-off-by: GuessWhoSamFoo <foos@vmware.com>

