### PR TITLE
Push windows and macos electron builds to GCS

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -5,7 +5,10 @@ on:
 jobs:
   nightly-build:
     name: Build nightly
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/setup-node@v2.1.4
         with:


### PR DESCRIPTION
Current nightlies: https://console.cloud.google.com/storage/browser/octant-nightlies/electron/release?pageState=(%22StorageObjectListTable%22:(%22f%22:%22%255B%255D%22))&prefix=&forceOnObjectsSortingFiltering=false

Missing pushed builds for macos and windows

Signed-off-by: GuessWhoSamFoo <foos@vmware.com>

