### PR TITLE
Use random port when running as electron

### DIFF
--- a/changelogs/unreleased/1852-GuessWhoSamFoo
+++ b/changelogs/unreleased/1852-GuessWhoSamFoo
@@ -1,0 +1,1 @@
+Changed to use random port when running as electron

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -13192,6 +13192,11 @@
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
       "dev": true
     },
+    "get-port": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
+      "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ=="
+    },
     "get-stream": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",

--- a/web/package.json
+++ b/web/package.json
@@ -70,6 +70,7 @@
     "d3-graphviz": "^2.6.1",
     "d3-zoom": "^2.0.0",
     "dagre-d3": "^0.6.4",
+    "get-port": "^5.1.1",
     "highlight.js": "^10.2.1",
     "lodash": "^4.17.20",
     "lodash-es": "^4.17.15",

--- a/web/src/app/data/services/websocket/websocket.service.ts
+++ b/web/src/app/data/services/websocket/websocket.service.ts
@@ -203,9 +203,9 @@ export class WebsocketService implements BackendService {
   }
 
   websocketURI(): string {
-    // TODO: https://github.com/vmware-tanzu/octant/issues/944
     if (this.electronService.isElectron()) {
-      return 'ws://localhost:7777/api/v1/stream';
+      const port = this.electronService.port();
+      return 'ws://localhost:' + port + '/api/v1/stream';
     }
 
     const loc = this.window.location;

--- a/web/src/app/modules/shared/services/electron/electron.service.ts
+++ b/web/src/app/modules/shared/services/electron/electron.service.ts
@@ -4,12 +4,32 @@
  */
 
 import { Injectable } from '@angular/core';
+import { ipcRenderer, webFrame } from 'electron';
+import * as childProcess from 'child_process';
+import * as fs from 'fs';
 
 @Injectable({
   providedIn: 'root',
 })
 export class ElectronService {
-  constructor() {}
+  ipcRenderer: typeof ipcRenderer;
+  webFrame: typeof webFrame;
+  childProcess: typeof childProcess;
+  fs: typeof fs;
+
+  public portNumber: number;
+  constructor() {
+    if (this.isElectron()) {
+      this.ipcRenderer = window.require('electron').ipcRenderer;
+      this.webFrame = window.require('electron').webFrame;
+      this.childProcess = window.require('child_process');
+      this.fs = window.require('fs');
+
+      this.ipcRenderer.once('port-message', (event, message) => {
+        this.portNumber = message;
+      });
+    }
+  }
 
   /**
    * Returns true if electron is detected
@@ -21,6 +41,13 @@ export class ElectronService {
     return (
       process && process.versions && process.versions.electron !== undefined
     );
+  }
+
+  /**
+   * Returns the random port number from electron main process
+   */
+  port(): number {
+    return this.portNumber;
   }
 
   /**


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR uses IPC to send the port number from main to render. Imports such as `fs` and `path` are node-only modules so there is some import trickery when used in renderer (see https://github.com/maximegris/angular-electron/blob/master/src/app/core/services/electron/electron.service.ts).

**Which issue(s) this PR fixes**
- Fixes #944 

Signed-off-by: GuessWhoSamFoo <foos@vmware.com>

