### PR TITLE
Fix mock visitor test race condition

### DIFF
--- a/internal/objectvisitor/service_test.go
+++ b/internal/objectvisitor/service_test.go
@@ -2,6 +2,7 @@ package objectvisitor_test
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -65,10 +66,13 @@ func TestService_Visit(t *testing.T) {
 		Return(nil)
 
 	var visited []unstructured.Unstructured
+	var m sync.Mutex
 	visitor := fake.NewMockVisitor(controller)
 	visitor.EXPECT().
 		Visit(gomock.Any(), gomock.Any(), handler, gomock.Any()).
 		DoAndReturn(func(ctx context.Context, object *unstructured.Unstructured, handler objectvisitor.ObjectHandler, _ bool) error {
+			m.Lock()
+			defer m.Unlock()
 			visited = append(visited, *object)
 			return nil
 		}).


### PR DESCRIPTION
The order appended to `visited` does not matter since it will be sorted later. However, visited still needs to be locked when appending otherwise not all objects are reliably added to the array.

xref: https://github.com/vmware-tanzu/octant/pull/1867/checks?check_run_id=1764506539#step:6:775

This can be reproduced by going to `/internal/objectvisitor` and running `go test -run TestService_Visit -race -count 300`

Signed-off-by: GuessWhoSamFoo <foos@vmware.com>
