### PR TITLE
Add official language for how we govern approver status

### DIFF
--- a/.github/ISSUE_TEMPLATE/become-an-octant-approver.md
+++ b/.github/ISSUE_TEMPLATE/become-an-octant-approver.md
@@ -1,0 +1,29 @@
+---
+name: Become an Octant approver
+about: Request approver status for the Octant repo
+title: Approver Request
+labels: community
+assignees: wwitzel3
+
+---
+### GitHub Username
+e.g. (at)example_user
+
+### Requirements
+- [ ] I have read the [contributor guide](https://github.com/vmware-tanzu/octant/blob/master/CONTRIBUTING.md)
+- [ ] I have enabled [2FA on my GitHub account](https://github.com/settings/security)
+- [ ] I have joined the [Kubernetes Slack workspace](slack.k8s.io) and the [#octant channel](https://kubernetes.slack.com/archives/CM37M9FCG)
+- [ ] I am actively contributing to Octant 
+- [ ] I have two sponsors that meet the sponsor requirements listed in the community membership guidelines
+- [ ] I have spoken to my sponsors ahead of this application, and they have agreed to sponsor my application
+
+### Sponsors
+- (at)sponsor-1
+- (at)sponsor-2
+
+### List of contributions to the Octant project
+- PRs reviewed / authored
+- Issues responded to
+
+
+

--- a/COMMUNITY_MEMBERSHIP.md
+++ b/COMMUNITY_MEMBERSHIP.md
@@ -1,0 +1,70 @@
+# Community Membership
+
+This document outlines the responsibilities of contributor roles in Octant.
+
+This is based on the [Kubernetes Community Membership](https://github.com/kubernetes/community/blob/master/community-membership.md).
+
+There are currently only one role for this project, but that may grow in the future.
+
+| Role     | Responsibilities                 | Requirements                                                     | Defined by                             |
+| -------- | -------------------------------- | ---------------------------------------------------------------- | -------------------------------------- |
+| approver | review and approve contributions | sponsored by 2 approvers. multiple contributions to the project. | Commit access to the Octant repository |
+
+## New contributors
+
+New contributors should be welcomed to the community by existing members,
+helped with PR workflow, and directed to relevant documentation and
+communication channels.
+
+## Established community members
+
+Established community members are expected to demonstrate their adherence to the
+principles in this document, familiarity with project organization, roles,
+policies, procedures, conventions, etc., and technical and/or writing ability.
+Role-specific expectations, responsibilities, and requirements are enumerated
+below.
+
+## Approvers
+
+Code approvers are able to both review and approve code contributions. While
+code review is focused on code quality and correctness, approval is focused on
+holistic acceptance of a contribution including: backwards / forwards
+compatibility, adhering to API and flag conventions, subtle performance and
+correctness issues, interactions with other parts of the system, etc.
+
+**Defined by:** Commit access to the Octant repository.
+
+**Note:** Acceptance of code contributions requires at least one approver.
+
+### Requirements
+
+- Enabled [two-factor authentication](https://help.github.com/articles/about-two-factor-authentication)
+  on their GitHub account
+- Have made multiple contributions to Octant. Contribution must include:
+  - Authored at least 3 PRs on GitHub
+  - Provided reviews on at least 4 PRs they did not author
+  - Filing or commenting on issues on GitHub
+- Have read the [contributor guide](./CONTRIBUTING.md)
+- Sponsored by 2 approvers. **Note the following requirements for sponsors**:
+  - Sponsors must have close interactions with the prospective member - e.g. code/design/proposal review, coordinating
+    on issues, etc.
+  - Sponsors must be from multiple companies to demonstrate integration across community.
+- **[Open an issue](./templates/membership.md) against the Octant repo**
+  - Ensure your sponsors are @mentioned on the issue
+  - Complete every item on the checklist ([preview the current version of the template](.github/ISSUE_TEMPLATE/become-an-octant-approver.md))
+  - Make sure that the list of contributions included is representative of your work on the project.
+- Have your sponsoring approvers reply confirmation of sponsorship: `+1`
+
+### Responsibilities and privileges
+
+- Responsible for project quality control via code reviews
+  - Focus on code quality and correctness, including testing and factoring
+  - May also review for more holistic issues, but not a requirement
+- Expected to be responsive to review requests in a timely manner
+- Assigned PRs to review related based on expertise
+- Granted commit access to Octant repo
+
+### Inactivity
+
+If an approver is inactive for a period of 12-months, they will be removed from the list of approvers and added to the list of
+emeritus approvers.

--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,13 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+    - bryanl
+    - GuessWhoSamFoo
+    - mklanjsek 
+    - scothis
+    - wwitzel3
+
+emeritus_approvers:
+    - ipsi
+    - mdaverde
+    - shomron


### PR DESCRIPTION
Signed-off-by: Wayne Witzel III <wayne@riotousliving.com>


**What this PR does / why we need it**:
Establish policy for how to officially become an approver on the Octant project.
