### PR TITLE
use a consistent and known temp sub folder in the loading handler

### DIFF
--- a/internal/api/loading_state.go
+++ b/internal/api/loading_state.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path"
 	"sync/atomic"
 	"time"
 
@@ -104,7 +105,12 @@ func (l *LoadingManager) UploadKubeConfig(state octant.State, payload action.Pay
 		return err
 	}
 
-	tempFile, err := ioutil.TempFile(os.TempDir(), "kubeconfig")
+	tempDir := path.Join(os.TempDir(), "octant")
+	if err := os.MkdirAll(tempDir, 0755); err != nil {
+		return err
+	}
+
+	tempFile, err := ioutil.TempFile(tempDir, "kubeconfig")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: Wayne Witzel III <wayne@riotousliving.com>


**What this PR does / why we need it**:
Makes finding a kubeconfig uploaded via the loading handler a little easier. This doesn't fix the issues originally raised in #1893 but it does make it more discoverable for now.