### PR TITLE
Enable dynamic resisizing of header contents

### DIFF
--- a/web/main.ts
+++ b/web/main.ts
@@ -65,6 +65,8 @@ function createWindow(): BrowserWindow {
   const options = {
     x: null,
     y: null,
+    minWidth: 400,
+    minHeight: 400,
     width: size.width,
     height: size.height,
     title: '',

--- a/web/src/app/modules/sugarloaf/components/smart/apply-yaml/apply-yaml.component.scss
+++ b/web/src/app/modules/sugarloaf/components/smart/apply-yaml/apply-yaml.component.scss
@@ -19,6 +19,12 @@
 
   cursor: pointer;
 
+  @media (max-width: 700px) {
+    span {
+      display: none;
+    }
+  }
+
   clr-icon {
     margin-right: 0.2rem;
   }

--- a/web/src/app/modules/sugarloaf/components/smart/container/container.component.scss
+++ b/web/src/app/modules/sugarloaf/components/smart/container/container.component.scss
@@ -66,6 +66,12 @@
       }
     }
 
+    @media (max-width: 1100px) {
+      .header-nav {
+        padding-left: 0.5rem !important;
+      }
+    }
+
     .header-centered {
       &:hover {
         cursor: pointer;
@@ -74,7 +80,6 @@
 
     .input-filter {
       margin-left: 0.8rem;
-      width: 10rem!important;
     }
   }
 
@@ -98,6 +103,12 @@
       }
     }
 
+    @media (max-width: 1000px) {
+      .branding {
+        display: none;
+      }
+    }
+
     .header-nav {
       padding-left: 1rem;
 
@@ -116,7 +127,7 @@
 
       .input-filter {
         z-index: 999; // clarity's data-grid beats this
-        width: 300px;
+        width: calc(150px + (300 - 150) * ((100vw - 500px) / (1920 - 500)));
       }
     }
   }


### PR DESCRIPTION
This PR allows dynamic resizing of the input filter based on viewport width. Additionally, media queries are used to hide extraneous items to prevent flex wrapping. Although the minimum window size is 400x400px, this method works until 600px (any smaller requires a different design approach).

![image](https://user-images.githubusercontent.com/10288252/107054978-a024a700-6785-11eb-93e2-05a319d0ae9b.png)


![image](https://user-images.githubusercontent.com/10288252/107054881-84210580-6785-11eb-9ff1-d06a36a51871.png)

cc @ibagha 

Signed-off-by: GuessWhoSamFoo <foos@vmware.com>
