### PR TITLE
Consolidated preferences storage

### DIFF
--- a/web/electron-builder.json
+++ b/web/electron-builder.json
@@ -1,6 +1,6 @@
 {
   "appId": "com.vmware.tanzu.octant",
-  "productName": "octant",
+  "productName": "Octant",
   "directories": {
     "output": "release/"
   },

--- a/web/electron/store.ts
+++ b/web/electron/store.ts
@@ -9,21 +9,25 @@ import ElectronStore = require('electron-store');
 interface OctantStore {
   minimizeToTray: boolean;
   showDialogue: boolean;
+  theme: string;
+  navigation: {
+    collapsed: boolean;
+    labels: boolean;
+  }
+  windowBounds: Electron.Rectangle
 }
 
 
 export const electronStore = new ElectronStore<OctantStore>({
   defaults: {
     minimizeToTray: true,
-    showDialogue: true
+    showDialogue: true,
+    theme: 'light',
+    windowBounds: undefined,
+    navigation: {
+      collapsed: false,
+      labels: true,
+    },
   }
 });
 
-//
-// export class OctantConfig {
-//   constructor() {
-//   }
-//
-//   set() {}
-//   get() {}
-// }

--- a/web/electron/tray-menu.ts
+++ b/web/electron/tray-menu.ts
@@ -18,8 +18,7 @@ export class TrayMenu {
   createNativeImage(): Electron.NativeImage {
     const image = nativeImage.createFromPath(iconPath);
     image.setTemplateImage(true);
-    image.resize({ width: 16, height: 16 });
-    return image;
+    return image.resize({ width: 16, height: 16 });
   }
 
   createMenu(win: BrowserWindow): Menu {

--- a/web/main.ts
+++ b/web/main.ts
@@ -26,8 +26,6 @@ import * as fs from 'fs';
 
 let win: BrowserWindow = null;
 let serverPid: any = null;
-let state: any = {};
-let statePath: string = null;
 let closing = false;
 let tray = null;
 
@@ -39,22 +37,11 @@ Menu.setApplicationMenu(applicationMenu.menu);
 
 let saveBoundsCookie;
 
-function saveCurrentState() {
-  fs.writeFileSync(statePath, JSON.stringify(state, null, 2));
-}
-
-function loadSavedState() {
-  try {
-    state = JSON.parse(fs.readFileSync(statePath, 'utf8'));
-  } catch (e) {}
-}
-
 function saveBoundsSoon() {
   if (saveBoundsCookie) clearTimeout(saveBoundsCookie);
   saveBoundsCookie = setTimeout(() => {
     saveBoundsCookie = undefined;
-    state.bounds = win.getBounds();
-    saveCurrentState();
+    electronStore.set('windowBounds', win.getBounds());
   }, 1000);
 }
 
@@ -74,12 +61,11 @@ function createWindow(): BrowserWindow {
       allowRunningInsecureContent: true,
       contextIsolation: false, // false if you want to run 2e2 test with Spectron
       enableRemoteModule: true, // true if you want to run 2e2 test  with Spectron or use remote module in renderer context (ie. Angular)
-      // preload: path.join(__dirname, 'preload.js'),
     },
   };
 
-  if (state?.bounds) {
-    const bounds = state.bounds;
+  const bounds = electronStore.get('windowBounds');
+  if (bounds) {
     const area = electronScreen.getDisplayMatching(bounds).workArea;
     if (
       bounds.x >= area.x &&
@@ -206,9 +192,6 @@ try {
   });
 
   app.on('ready', async () => {
-    statePath = path.join(app.getPath('userData'), 'state.json');
-    loadSavedState();
-
     const getPort = require('get-port');
     const port = await getPort();
     startBinary(port);

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -7187,11 +7187,6 @@
       "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0=",
       "dev": true
     },
-    "astilectron": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/astilectron/-/astilectron-0.33.0.tgz",
-      "integrity": "sha512-7lH0yDIcY4U2HDXRTOMcuN43kze8uERY4+jb5+1/MVyBSUFbmc9QUZjk7/+nrQ5HXk6swEu4tIjipcASOPRoKA=="
-    },
     "async": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",

--- a/web/package.json
+++ b/web/package.json
@@ -62,7 +62,6 @@
     "@webcomponents/custom-elements": "^1.4.2",
     "angular-resizable-element": "^3.3.3",
     "ansi_up": "^4.0.4",
-    "astilectron": "^0.33.0",
     "core-js": "^3.6.5",
     "cytoscape": "^3.16.2",
     "cytoscape-cose-bilkent": "^4.1.0",

--- a/web/src/app/modules/shared/components/smart/editor/editor.component.ts
+++ b/web/src/app/modules/shared/components/smart/editor/editor.component.ts
@@ -3,12 +3,13 @@ Copyright (c) 2020 the Octant contributors. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-import { Component } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { EditorView } from '../../../models/content';
 import { NamespaceService } from '../../../services/namespace/namespace.service';
 import { ActionService } from '../../../services/action/action.service';
 import { AbstractViewComponent } from '../../abstract-view/abstract-view.component';
 import { ThemeService } from '../../../services/theme/theme.service';
+import { Subscription } from 'rxjs';
 
 interface Options {
   readOnly: boolean;
@@ -21,7 +22,9 @@ interface Options {
   templateUrl: './editor.component.html',
   styleUrls: ['./editor.component.scss'],
 })
-export class EditorComponent extends AbstractViewComponent<EditorView> {
+export class EditorComponent
+  extends AbstractViewComponent<EditorView>
+  implements OnInit, OnDestroy {
   set value(v: string) {
     if (v !== this.editorValue) {
       this.isModified = true;
@@ -33,6 +36,7 @@ export class EditorComponent extends AbstractViewComponent<EditorView> {
     return this.editorValue;
   }
 
+  private subscriptionTheme: Subscription;
   private syncMonacoTheme: () => void;
   private editorValue: string;
   private pristineValue: string;
@@ -61,8 +65,13 @@ export class EditorComponent extends AbstractViewComponent<EditorView> {
       this.options = { ...this.options, theme };
     };
 
-    this.themeService.onChange(this.syncMonacoTheme);
     this.syncMonacoTheme();
+  }
+
+  ngOnInit() {
+    this.subscriptionTheme = this.themeService.themeType.subscribe(() =>
+      this.syncMonacoTheme()
+    );
   }
 
   update() {
@@ -97,5 +106,9 @@ export class EditorComponent extends AbstractViewComponent<EditorView> {
 
   reset() {
     this.value = this.pristineValue;
+  }
+
+  ngOnDestroy() {
+    this.subscriptionTheme.unsubscribe();
   }
 }

--- a/web/src/app/modules/shared/services/electron/electron.service.ts
+++ b/web/src/app/modules/shared/services/electron/electron.service.ts
@@ -42,12 +42,7 @@ export class ElectronService {
    * Returns true if electron is detected
    */
   isElectron(): boolean {
-    if (typeof process === 'undefined') {
-      return false;
-    }
-    return (
-      process && process.versions && process.versions.electron !== undefined
-    );
+    return this.preferencesService.isElectron();
   }
 
   /**

--- a/web/src/app/modules/shared/services/preferences/preferences.service.spec.ts
+++ b/web/src/app/modules/shared/services/preferences/preferences.service.spec.ts
@@ -20,6 +20,7 @@ describe('PreferencesService', () => {
   });
 
   it('collapsed set properly', () => {
+    service.navCollapsed.next(false);
     const defaultPrefs = service.getPreferences();
     const defaultElement = defaultPrefs.panels[0].sections[1].elements[0];
     expect(defaultElement.name).toEqual('general.navigation');
@@ -30,5 +31,39 @@ describe('PreferencesService', () => {
     const newElement = newPrefs.panels[0].sections[1].elements[0];
     expect(newElement.name).toEqual('general.navigation');
     expect(newElement.value).toEqual('collapsed');
+  });
+
+  it('properties are persisted', () => {
+    // default values
+    service.navCollapsed.next(true);
+    service.showLabels.next(true);
+    expect(
+      JSON.parse(service.getStoredValue('navigation.labels', true))
+    ).toEqual(true);
+    expect(
+      JSON.parse(service.getStoredValue('navigation.collapsed', true))
+    ).toEqual(true);
+
+    // change through exposed variables
+    service.navCollapsed.next(false);
+    expect(
+      JSON.parse(service.getStoredValue('navigation.collapsed', true))
+    ).toEqual(false);
+
+    service.showLabels.next(false);
+    expect(
+      JSON.parse(service.getStoredValue('navigation.labels', true))
+    ).toEqual(false);
+
+    // change by modifying stored values
+    service.setStoredValue('navigation.collapsed', true);
+    expect(
+      JSON.parse(service.getStoredValue('navigation.collapsed', false))
+    ).toEqual(true);
+
+    service.setStoredValue('navigation.labels', true);
+    expect(
+      JSON.parse(service.getStoredValue('navigation.labels', false))
+    ).toEqual(true);
   });
 });

--- a/web/src/app/modules/shared/services/preferences/preferences.service.ts
+++ b/web/src/app/modules/shared/services/preferences/preferences.service.ts
@@ -3,28 +3,90 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable } from '@angular/core';
-import { BehaviorSubject } from 'rxjs';
+import { Injectable, OnDestroy } from '@angular/core';
+import { BehaviorSubject, Subscription } from 'rxjs';
 import { Preferences } from '../../models/preference';
 import { ThemeService } from '../theme/theme.service';
+import { skip } from 'rxjs/operators';
 
 @Injectable({
   providedIn: 'root',
 })
-export class PreferencesService {
+export class PreferencesService implements OnDestroy {
+  private subscriptionCollapsed: Subscription;
+  private subscriptionLabels: Subscription;
+  private subscriptionTheme: Subscription;
+  private electronStore: any;
+
   public preferencesOpened: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(
     false
   );
 
-  public navCollapsed: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(
-    false
-  );
+  public navCollapsed: BehaviorSubject<boolean>;
+  public showLabels: BehaviorSubject<boolean>;
 
-  public showLabels: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(
-    true
-  );
+  constructor(private themeService: ThemeService) {
+    if (this.isElectron()) {
+      const Store = window.require('electron-store');
+      this.electronStore = new Store();
+    }
 
-  constructor(private themeService: ThemeService) {}
+    this.navCollapsed = new BehaviorSubject<boolean>(
+      JSON.parse(this.getStoredValue('navigation.collapsed', false))
+    );
+    this.showLabels = new BehaviorSubject<boolean>(
+      JSON.parse(this.getStoredValue('navigation.labels', true))
+    );
+
+    this.subscriptionCollapsed = this.navCollapsed.subscribe(col => {
+      this.setStoredValue('navigation.collapsed', col);
+    });
+
+    this.subscriptionLabels = this.showLabels.subscribe(labels => {
+      this.setStoredValue('navigation.labels', labels);
+    });
+
+    this.subscriptionTheme = this.themeService.themeType
+      .pipe(skip(1))
+      .subscribe(theme => {
+        this.setStoredValue('theme', theme);
+      });
+
+    this.themeService.themeType.next(
+      this.getStoredValue('theme', this.themeService.themeType.value)
+    );
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptionCollapsed?.unsubscribe();
+    this.subscriptionLabels?.unsubscribe();
+    this.subscriptionTheme?.unsubscribe();
+  }
+
+  setStoredValue(key: string, value: any) {
+    if (this.isElectron()) {
+      this.electronStore.set(key, value);
+    } else {
+      localStorage.setItem(key, value);
+    }
+  }
+
+  getStoredValue(key: string, defaultValue: any) {
+    if (this.isElectron()) {
+      return this.electronStore.get(key, defaultValue);
+    } else {
+      return localStorage.getItem(key) || defaultValue;
+    }
+  }
+
+  isElectron(): boolean {
+    if (typeof process === 'undefined') {
+      return false;
+    }
+    return (
+      process && process.versions && process.versions.electron !== undefined
+    );
+  }
 
   public preferencesChanged(update: Preferences) {
     const collapsed = update['general.navigation'] === 'collapsed';

--- a/web/src/app/modules/sugarloaf/components/smart/container/container.component.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/container/container.component.ts
@@ -4,7 +4,7 @@
  *
  */
 
-import { Component, HostListener, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { Location } from '@angular/common';
 import { Navigation } from '../../../models/navigation';
 import { WebsocketService } from '../../../../../data/services/websocket/websocket.service';
@@ -14,20 +14,6 @@ import { NavigationService } from '../../../../shared/services/navigation/naviga
 import { ElectronService } from '../../../../shared/services/electron/electron.service';
 import { Subscription } from 'rxjs';
 import { PreferencesService } from '../../../../shared/services/preferences/preferences.service';
-
-// tslint:disable-next-line
-declare namespace astilectron {
-  export function onMessage(fn: (message: Message) => void);
-  export function sendMessage(
-    message: Message,
-    callback?: (message: Message) => void
-  );
-
-  export interface Message {
-    name: string;
-    payload: any;
-  }
-}
 
 @Component({
   selector: 'app-root',
@@ -65,11 +51,6 @@ export class ContainerComponent implements OnInit, OnDestroy {
     this.isElectron = this.electronService.isElectron();
   }
 
-  @HostListener('document:astilectron-ready', ['$event'])
-  onMessage(_: Event) {
-    astilectron.onMessage(message => this.handleMessage(message));
-  }
-
   ngOnInit(): void {
     this.subscriptionPreferencesOpened = this.preferencesService.preferencesOpened.subscribe(
       opened => {
@@ -85,22 +66,8 @@ export class ContainerComponent implements OnInit, OnDestroy {
     this.subscriptionPreferencesOpened.unsubscribe();
   }
 
-  private handleMessage = (message: astilectron.Message) => {
-    switch (message.name) {
-      case 'octant.cmd.preferences':
-        this.preferencesOpened = true;
-        this.preferences = message.payload as Preferences;
-        break;
-    }
-  };
-
   preferencesChanged(update: any) {
-    const m: astilectron.Message = {
-      name: 'octant.cmd.updatePreferences',
-      payload: update,
-    };
     this.preferencesService.preferencesChanged(update);
-    astilectron.sendMessage(m);
   }
 
   forward() {

--- a/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.scss
+++ b/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.scss
@@ -53,11 +53,13 @@
 }
 
 .navigation-top-collapsed {
-  width: 97px;
+  width: 89px;
+  overflow: hidden;
 }
 
 .navigation-top-collapsed-labels {
   width: 117px;
+  overflow: hidden;
 }
 
 .module-tabs {
@@ -230,20 +232,6 @@
     padding-top: 0.6rem;
     height: 100%;
     overflow-y: hidden;
-    border-left: 1px solid rgba(173, 187, 196, 0.3);
-  }
-
-  .top-level {
-    flex-grow: 1;
-    overflow-y: auto;
-  }
-
-  .top-level-collapsed {
-    display: flex;
-    flex-direction: column;
-    flex-grow: 1;
-    overflow-y: hidden;
-    padding-top: 16px;
     border-left: 1px solid rgba(173, 187, 196, 0.3);
   }
 

--- a/web/src/app/modules/sugarloaf/components/smart/theme-switch/theme-switch-button.component.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/theme-switch/theme-switch-button.component.ts
@@ -3,6 +3,7 @@
 //
 import { Component, Input, OnInit, OnDestroy } from '@angular/core';
 import { ThemeService } from '../../../../shared/services/theme/theme.service';
+import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-theme-switch-button',
@@ -12,6 +13,7 @@ import { ThemeService } from '../../../../shared/services/theme/theme.service';
 export class ThemeSwitchButtonComponent implements OnInit, OnDestroy {
   @Input() public collapsed: boolean;
 
+  private subscriptionTheme: Subscription;
   lightThemeEnabled: boolean;
 
   private onThemeChange: () => void;
@@ -25,11 +27,13 @@ export class ThemeSwitchButtonComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    this.themeService.onChange(this.onThemeChange);
+    this.subscriptionTheme = this.themeService.themeType.subscribe(() =>
+      this.onThemeChange()
+    );
   }
 
   ngOnDestroy() {
-    this.themeService.offChange(this.onThemeChange);
+    this.subscriptionTheme.unsubscribe();
   }
 
   switchTheme(): void {

--- a/web/src/app/testing/theme-service-stub.ts
+++ b/web/src/app/testing/theme-service-stub.ts
@@ -1,13 +1,16 @@
 // Copyright (c) 2019 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
-import { ThemeService } from '../modules/shared/services/theme/theme.service';
+import {
+  ThemeService,
+  ThemeType,
+} from '../modules/shared/services/theme/theme.service';
+import { BehaviorSubject } from 'rxjs';
 
 export const themeServiceStub: Partial<ThemeService> = {
   loadCSS: () => void 0,
   loadTheme: () => void 0,
   isLightThemeEnabled: () => true,
-  onChange: () => void 0,
-  offChange: () => void 0,
   switchTheme: () => void 0,
+  themeType: new BehaviorSubject<ThemeType>('light'),
 };


### PR DESCRIPTION
Added client side preference persistence and hooked up existing preferences to use it.

Details:
- Created general persistence mechanism in preferences service that works in both Electron (using `electron-store`) and browser (using localStorage), 
- Switched save/restore of Electron window bounds to use the new storage,
- Hooked up navigation state and theme to use the same mechanism,
- Removed `astilectron` from client side,
- Removed code that was syncing theme among all opened browser tabs, that would be too intrusive if applied to all preferences,
- Fixed problem with octant tray icon on Mac (#1947),  

Signed-off-by: Milan Klanjsek <mklanjsek@pivotal.io>
