### PR TITLE
Developer Preferences

### DIFF
--- a/web/electron/store.ts
+++ b/web/electron/store.ts
@@ -14,6 +14,11 @@ interface OctantStore {
     collapsed: boolean;
     labels: boolean;
   }
+  development: {
+    embedded: boolean;
+    frontendUrl: string;
+    verbose: boolean;
+  }
   windowBounds: Electron.Rectangle
 }
 
@@ -28,6 +33,11 @@ export const electronStore = new ElectronStore<OctantStore>({
       collapsed: false,
       labels: true,
     },
+    development: {
+      embedded: true,
+      frontendUrl: 'http://localhost:4200',
+      verbose: false,
+    }
   }
 });
 

--- a/web/src/app/modules/shared/components/presentation/preferences/preferences.component.ts
+++ b/web/src/app/modules/shared/components/presentation/preferences/preferences.component.ts
@@ -14,6 +14,7 @@ import {
   Preferences,
 } from '../../../models/preference';
 import trackByIdentity from 'src/app/util/trackBy/trackByIdentity';
+import { startWith } from 'rxjs/operators';
 
 interface StringDict {
   [key: string]: string;
@@ -113,9 +114,11 @@ export class PreferencesComponent implements OnChanges {
 
     this.form = this.fb.group(this.controls);
 
-    this.form.valueChanges.subscribe((update: StringDict) => {
-      this.onValueChanged(update);
-    });
+    this.form.valueChanges
+      .pipe(startWith(this.form.getRawValue()))
+      .subscribe((update: StringDict) => {
+        this.onValueChanged(update);
+      });
   }
 
   onCancel() {

--- a/web/src/app/modules/shared/services/preferences/preferences.service.ts
+++ b/web/src/app/modules/shared/services/preferences/preferences.service.ts
@@ -129,7 +129,7 @@ export class PreferencesService implements OnDestroy {
     const showLabels = update['general.labels'] === 'show';
     const isLightTheme = update['general.theme'] === 'light';
     const frontendUrl = update['development.frontendUrl'];
-    const verbose = update['development.verbose'] === 'high';
+    const verbose = update['development.verbose'] === 'debug';
     const embedded = update['development.embedded'] === 'embedded';
     let notificationRequired = false;
 
@@ -224,16 +224,16 @@ export class PreferencesService implements OnDestroy {
             {
               name: 'development.verbose',
               type: 'radio',
-              value: this.verbose.value ? 'high' : 'low',
+              value: this.verbose.value ? 'debug' : 'normal',
               config: {
                 values: [
                   {
-                    label: 'High',
-                    value: 'high',
+                    label: 'Debug',
+                    value: 'debug',
                   },
                   {
-                    label: 'Low',
-                    value: 'low',
+                    label: 'Normal',
+                    value: 'normal',
                   },
                 ],
               },

--- a/web/src/app/modules/shared/services/preferences/preferences.service.ts
+++ b/web/src/app/modules/shared/services/preferences/preferences.service.ts
@@ -5,7 +5,11 @@
 
 import { Injectable, OnDestroy } from '@angular/core';
 import { BehaviorSubject, Subscription } from 'rxjs';
-import { Preferences } from '../../models/preference';
+import {
+  Operation,
+  PreferencePanel,
+  Preferences,
+} from '../../models/preference';
 import { ThemeService } from '../theme/theme.service';
 import { skip } from 'rxjs/operators';
 
@@ -16,6 +20,9 @@ export class PreferencesService implements OnDestroy {
   private subscriptionCollapsed: Subscription;
   private subscriptionLabels: Subscription;
   private subscriptionTheme: Subscription;
+  private subscriptionFrontendUrl: Subscription;
+  private subscriptionVerbose: Subscription;
+  private subscriptionEmbedded: Subscription;
   private electronStore: any;
 
   public preferencesOpened: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(
@@ -24,6 +31,9 @@ export class PreferencesService implements OnDestroy {
 
   public navCollapsed: BehaviorSubject<boolean>;
   public showLabels: BehaviorSubject<boolean>;
+  public frontendUrl: BehaviorSubject<string>;
+  public verbose: BehaviorSubject<boolean>;
+  public embedded: BehaviorSubject<boolean>;
 
   constructor(private themeService: ThemeService) {
     if (this.isElectron()) {
@@ -37,6 +47,17 @@ export class PreferencesService implements OnDestroy {
     this.showLabels = new BehaviorSubject<boolean>(
       JSON.parse(this.getStoredValue('navigation.labels', true))
     );
+    this.frontendUrl = new BehaviorSubject<string>(
+      this.getStoredValue('development.frontendUrl', 'http://localhost:4200')
+    );
+
+    this.verbose = new BehaviorSubject<boolean>(
+      this.getStoredValue('development.verbose', false)
+    );
+
+    this.embedded = new BehaviorSubject<boolean>(
+      this.getStoredValue('development.embedded', true)
+    );
 
     this.subscriptionCollapsed = this.navCollapsed.subscribe(col => {
       this.setStoredValue('navigation.collapsed', col);
@@ -44,6 +65,18 @@ export class PreferencesService implements OnDestroy {
 
     this.subscriptionLabels = this.showLabels.subscribe(labels => {
       this.setStoredValue('navigation.labels', labels);
+    });
+
+    this.subscriptionFrontendUrl = this.frontendUrl.subscribe(url => {
+      this.setStoredValue('development.frontendUrl', url);
+    });
+
+    this.subscriptionVerbose = this.verbose.subscribe(verbose => {
+      this.setStoredValue('development.verbose', verbose);
+    });
+
+    this.subscriptionEmbedded = this.embedded.subscribe(embedded => {
+      this.setStoredValue('development.embedded', embedded);
     });
 
     this.subscriptionTheme = this.themeService.themeType
@@ -61,6 +94,9 @@ export class PreferencesService implements OnDestroy {
     this.subscriptionCollapsed?.unsubscribe();
     this.subscriptionLabels?.unsubscribe();
     this.subscriptionTheme?.unsubscribe();
+    this.subscriptionFrontendUrl?.unsubscribe();
+    this.subscriptionVerbose?.unsubscribe();
+    this.subscriptionEmbedded?.unsubscribe();
   }
 
   setStoredValue(key: string, value: any) {
@@ -92,6 +128,10 @@ export class PreferencesService implements OnDestroy {
     const collapsed = update['general.navigation'] === 'collapsed';
     const showLabels = update['general.labels'] === 'show';
     const isLightTheme = update['general.theme'] === 'light';
+    const frontendUrl = update['development.frontendUrl'];
+    const verbose = update['development.verbose'] === 'high';
+    const embedded = update['development.embedded'] === 'embedded';
+    let notificationRequired = false;
 
     if (this.showLabels.value !== showLabels) {
       this.showLabels.next(showLabels);
@@ -104,83 +144,173 @@ export class PreferencesService implements OnDestroy {
     if (this.themeService.isLightThemeEnabled() !== isLightTheme) {
       this.themeService.switchTheme();
     }
+
+    if (this.frontendUrl.value !== frontendUrl) {
+      notificationRequired = true;
+      this.frontendUrl.next(frontendUrl);
+    }
+
+    if (this.embedded.value !== embedded) {
+      notificationRequired = true;
+      this.embedded.next(embedded);
+    }
+
+    if (this.verbose.value !== verbose) {
+      this.verbose.next(verbose);
+    }
+
+    if (this.isElectron() && notificationRequired) {
+      const ipcRenderer = window.require('electron').ipcRenderer;
+      ipcRenderer.send('preferences', 'changed');
+    }
   }
 
-  // TODO move to better place and merge with server side prefs.
   public getPreferences(): Preferences {
+    const panels: PreferencePanel[] = this.isElectron()
+      ? [this.getGeneralPanels(), this.getDeveloperPanels()]
+      : [this.getGeneralPanels()];
+
     return {
       updateName: 'generalPreferences',
-      panels: [
+      panels,
+    };
+  }
+
+  private getDeveloperPanels(): PreferencePanel {
+    return {
+      name: 'Development',
+      sections: [
         {
-          name: 'General',
-          sections: [
+          name: 'Frontend Source',
+          elements: [
             {
-              name: 'Color Theme',
-              elements: [
-                {
-                  name: 'general.theme',
-                  type: 'radio',
-                  value: this.themeService.isLightThemeEnabled()
-                    ? 'light'
-                    : 'dark',
-                  config: {
-                    values: [
-                      {
-                        label: 'Dark',
-                        value: 'dark',
-                      },
-                      {
-                        label: 'Light',
-                        value: 'light',
-                      },
-                    ],
+              name: 'development.embedded',
+              type: 'radio',
+              value: this.embedded.value ? 'embedded' : 'proxied',
+              config: {
+                values: [
+                  {
+                    label: 'Embedded',
+                    value: 'embedded',
                   },
-                },
-              ],
+                  {
+                    label: 'Proxied',
+                    value: 'proxied',
+                  },
+                ],
+              },
             },
             {
-              name: 'Navigation',
-              elements: [
+              name: 'development.frontendUrl',
+              type: 'text',
+              value: this.frontendUrl.value,
+              disableConditions: [
                 {
-                  name: 'general.navigation',
-                  type: 'radio',
-                  value: this.navCollapsed.value ? 'collapsed' : 'expanded',
-                  config: {
-                    values: [
-                      {
-                        label: 'Expanded',
-                        value: 'expanded',
-                      },
-                      {
-                        label: 'Collapsed',
-                        value: 'collapsed',
-                      },
-                    ],
-                  },
+                  lhs: 'development.embedded',
+                  op: Operation.Equal,
+                  rhs: 'proxied',
                 },
               ],
+              config: {
+                label: 'Frontend Proxy Url',
+                placeholder: 'http://example.com',
+              },
             },
+          ],
+        },
+        {
+          name: 'Logging verbosity (requires restart)',
+          elements: [
             {
-              name: 'Navigation labels',
-              elements: [
-                {
-                  name: 'general.labels',
-                  type: 'radio',
-                  value: this.showLabels.value ? 'show' : 'hide',
-                  config: {
-                    values: [
-                      {
-                        label: 'Show Labels',
-                        value: 'show',
-                      },
-                      {
-                        label: 'Hide Labels',
-                        value: 'hide',
-                      },
-                    ],
+              name: 'development.verbose',
+              type: 'radio',
+              value: this.verbose.value ? 'high' : 'low',
+              config: {
+                values: [
+                  {
+                    label: 'High',
+                    value: 'high',
                   },
-                },
-              ],
+                  {
+                    label: 'Low',
+                    value: 'low',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    };
+  }
+
+  private getGeneralPanels(): PreferencePanel {
+    return {
+      name: 'General',
+      sections: [
+        {
+          name: 'Color Theme',
+          elements: [
+            {
+              name: 'general.theme',
+              type: 'radio',
+              value: this.themeService.isLightThemeEnabled() ? 'light' : 'dark',
+              config: {
+                values: [
+                  {
+                    label: 'Dark',
+                    value: 'dark',
+                  },
+                  {
+                    label: 'Light',
+                    value: 'light',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        {
+          name: 'Navigation',
+          elements: [
+            {
+              name: 'general.navigation',
+              type: 'radio',
+              value: this.navCollapsed.value ? 'collapsed' : 'expanded',
+              config: {
+                values: [
+                  {
+                    label: 'Expanded',
+                    value: 'expanded',
+                  },
+                  {
+                    label: 'Collapsed',
+                    value: 'collapsed',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        {
+          name: 'Navigation labels',
+          elements: [
+            {
+              name: 'general.labels',
+              type: 'radio',
+              value: this.showLabels.value ? 'show' : 'hide',
+              config: {
+                values: [
+                  {
+                    label: 'Show Labels',
+                    value: 'show',
+                  },
+                  {
+                    label: 'Hide Labels',
+                    value: 'hide',
+                  },
+                ],
+              },
             },
           ],
         },

--- a/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.html
+++ b/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.html
@@ -40,7 +40,7 @@
       </clr-tab>
       </clr-tabs>
     <div class="prefs-button">
-      <div (click)="showPrefs()" class="btn-icon btn-link nav-link"
+      <div (click)="showPrefs()" class="btn-icon btn btn-link nav-link"
            [ngClass]="{
             'button-tool': !showLabels,
             'button-tool-labels': showLabels
@@ -51,7 +51,7 @@
             <div class="button-text">Preferences</div>
           </div>
         </div>
-        <app-octant-tooltip *ngIf="!showLabels" tooltipText="Preferences">
+        <app-octant-tooltip class= "prefs-tooltip" *ngIf="!showLabels" tooltipText="Preferences">
           <clr-icon class="icon-nav" shape="cog"></clr-icon>
         </app-octant-tooltip>
       </div>

--- a/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.scss
+++ b/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.scss
@@ -135,8 +135,11 @@
   width: 64px;
   padding-left: 0px;
   font-size: 10px;
+  font-weight: 400;
   line-height:  12px;
+  letter-spacing: normal;
   text-align: center;
+  text-transform: none;
   white-space: normal;
 }
 
@@ -167,6 +170,10 @@
 
   .nav-item-text {
     line-height: 1.5rem;
+  }
+
+  .prefs-tooltip {
+    text-transform: none;
   }
 
   .nav-item-padded {


### PR DESCRIPTION
This change adds the Developer preferences, available only in Electron build. More precisely, it adds developers ability to change the logging verbosity and specify the Frontend Url.

Additional info:
- Also fixed small css issues with `Preferences` button,
- Fixed problem where validation was not running on Preferences form load,

Signed-off-by: Milan Klanjsek <mklanjsek@pivotal.io>

**Which issue(s) this PR fixes**
- Fixes #1923

