### PR TITLE
Fixed problem with preferences forcing app reload

### DIFF
--- a/web/src/app/modules/shared/services/preferences/preferences.service.ts
+++ b/web/src/app/modules/shared/services/preferences/preferences.service.ts
@@ -130,7 +130,9 @@ export class PreferencesService implements OnDestroy {
     const isLightTheme = update['general.theme'] === 'light';
     const frontendUrl = update['development.frontendUrl'];
     const verbose = update['development.verbose'] === 'debug';
-    const embedded = update['development.embedded'] === 'embedded';
+    const embedded = update['development.embedded']
+      ? update['development.embedded'] === 'embedded'
+      : true;
     let notificationRequired = false;
 
     if (this.showLabels.value !== showLabels) {
@@ -145,7 +147,7 @@ export class PreferencesService implements OnDestroy {
       this.themeService.switchTheme();
     }
 
-    if (this.frontendUrl.value !== frontendUrl) {
+    if (frontendUrl && this.frontendUrl.value !== frontendUrl) {
       notificationRequired = true;
       this.frontendUrl.next(frontendUrl);
     }


### PR DESCRIPTION
Changing a single preference was in some cases forcing unnecessary app reload. The reason is that sometimes, for example when certain fields were disabled in UI, form changes were not containing all values indicating the change happened.

This fix does extra validation to make sure provided values are present before assigning them to preferences.  

Signed-off-by: Milan Klanjsek <mklanjsek@pivotal.io>

