### PR TITLE
Added table page size preference

### DIFF
--- a/changelogs/unreleased/1850-lenriquez
+++ b/changelogs/unreleased/1850-lenriquez
@@ -1,0 +1,1 @@
+Added the table page size preference

--- a/web/src/app/modules/shared/components/presentation/datagrid/datagrid.component.html
+++ b/web/src/app/modules/shared/components/presentation/datagrid/datagrid.component.html
@@ -48,7 +48,7 @@
     </clr-dg-cell>
   </clr-dg-row>
   <clr-dg-footer>
-    <clr-dg-pagination #pagination [clrDgPageSize]="10">
+    <clr-dg-pagination #pagination [clrDgPageSize]="defaultPageSize">
       <clr-dg-page-size [clrPageSizeOptions]="[10, 20, 50, 100]">
         Items per page
       </clr-dg-page-size>

--- a/web/src/app/modules/shared/components/presentation/datagrid/datagrid.component.ts
+++ b/web/src/app/modules/shared/components/presentation/datagrid/datagrid.component.ts
@@ -74,10 +74,12 @@ export class DatagridComponent
     private readonly sanitizer: DomSanitizer
   ) {
     super();
-    this.sub = this.preferencesService.pageSize.asObservable().subscribe(e => {
-      this.defaultPageSize = +e;
-      this.cdr.markForCheck();
-    });
+    this.sub = this.preferencesService.preferences
+      .get('general.pageSize')
+      .subject.subscribe(e => {
+        this.defaultPageSize = +e;
+        this.cdr.markForCheck();
+      });
   }
 
   update() {

--- a/web/src/app/modules/shared/components/presentation/datagrid/datagrid.component.ts
+++ b/web/src/app/modules/shared/components/presentation/datagrid/datagrid.component.ts
@@ -7,6 +7,7 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
+  OnDestroy,
   SecurityContext,
 } from '@angular/core';
 import {
@@ -29,6 +30,8 @@ import { LoadingService } from '../../../services/loading/loading.service';
 import { ButtonGroupView } from '../../../models/content';
 import { DomSanitizer } from '@angular/platform-browser';
 import { parse } from 'marked';
+import { PreferencesService } from '../../../services/preferences/preferences.service';
+import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-view-datagrid',
@@ -36,7 +39,9 @@ import { parse } from 'marked';
   styleUrls: ['./datagrid.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class DatagridComponent extends AbstractViewComponent<TableView> {
+export class DatagridComponent
+  extends AbstractViewComponent<TableView>
+  implements OnDestroy {
   timeStampComparator = new TimestampComparator();
   sortOrder: ClrDatagridSortOrder = ClrDatagridSortOrder.UNSORTED;
 
@@ -48,6 +53,7 @@ export class DatagridComponent extends AbstractViewComponent<TableView> {
   filters: TableFilters;
   buttonGroup?: ButtonGroupView;
   isModalOpen = false;
+  defaultPageSize: number;
 
   actionDialogOptions: ActionDialogOptions = undefined;
 
@@ -57,15 +63,21 @@ export class DatagridComponent extends AbstractViewComponent<TableView> {
 
   loading: boolean;
   loading$: Observable<boolean>;
+  sub: Subscription;
 
   constructor(
     private viewService: ViewService,
     private actionService: ActionService,
     private loadingService: LoadingService,
+    private preferencesService: PreferencesService,
     private cdr: ChangeDetectorRef,
     private readonly sanitizer: DomSanitizer
   ) {
     super();
+    this.sub = this.preferencesService.pageSize.asObservable().subscribe(e => {
+      this.defaultPageSize = +e;
+      this.cdr.markForCheck();
+    });
   }
 
   update() {
@@ -163,6 +175,10 @@ export class DatagridComponent extends AbstractViewComponent<TableView> {
   private resetModal() {
     this.isModalOpen = false;
     this.actionDialogOptions = undefined;
+  }
+
+  ngOnDestroy() {
+    this.sub.unsubscribe();
   }
 }
 

--- a/web/src/app/modules/shared/components/presentation/dropdown/dropdown.component.ts
+++ b/web/src/app/modules/shared/components/presentation/dropdown/dropdown.component.ts
@@ -2,7 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { Component, Input, isDevMode } from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  isDevMode,
+  Output,
+} from '@angular/core';
 import {
   DropdownItem,
   DropdownView,
@@ -34,6 +40,8 @@ export class DropdownComponent extends AbstractViewComponent<DropdownView> {
   @Input() public type: string;
 
   @Input() public items: DropdownItem[];
+
+  @Output() public selectedValue = new EventEmitter<string>();
 
   constructor(
     private viewService: ViewService,
@@ -80,6 +88,7 @@ export class DropdownComponent extends AbstractViewComponent<DropdownView> {
   openLink(index): void {
     const item = this.items[index];
     this.selectedItem = item.name;
+    this.selectedValue.emit(item.name);
     if (this.useSelection && this.type !== 'icon') {
       this.title = item.label;
     }

--- a/web/src/app/modules/shared/components/presentation/preferences/preferences.component.html
+++ b/web/src/app/modules/shared/components/presentation/preferences/preferences.component.html
@@ -60,6 +60,11 @@
                         </div>
                       </div>
                     </ng-container>
+                    <ng-container *ngSwitchCase="'dropdown'">
+                      <label>{{ element.label }}</label>
+                      <app-view-dropdown [view]="element" (selectedValue)="onDropDownValueChange($event, element.name)">
+                      </app-view-dropdown>
+                    </ng-container>
                     <div *ngSwitchDefault>
                       <p>not sure what to do with {{ element.type }}</p>
                     </div>
@@ -73,7 +78,10 @@
     </form>
   </div>
   <div class="modal-footer">
-    <button class="btn btn-outline" type="button" (click)="onCancel()">
+    <button class="btn btn-outline" type="button" (click)="onReset()">
+      Reset
+    </button>
+    <button class="btn btn-outline btn-cancel" type="button" (click)="onCancel()">
       Cancel
     </button>
     <button class="btn btn-primary" type="button" (click)="onSubmit()">

--- a/web/src/app/modules/shared/components/presentation/preferences/preferences.component.html
+++ b/web/src/app/modules/shared/components/presentation/preferences/preferences.component.html
@@ -61,9 +61,16 @@
                       </div>
                     </ng-container>
                     <ng-container *ngSwitchCase="'dropdown'">
-                      <label>{{ element.label }}</label>
-                      <app-view-dropdown [view]="element" (selectedValue)="onDropDownValueChange($event, element.name)">
-                      </app-view-dropdown>
+                      <clr-select-container>
+                        <label>{{ element.label }}</label>
+                        <select clrSelect name="options"
+                          [formControlName]="element.name">
+                          <option 
+                            *ngFor="let r of element.config.items; 
+                              trackBy: trackByIdentity" [value]="r.name"
+                            >{{ r.label }}</option>
+                        </select>
+                      </clr-select-container>
                     </ng-container>
                     <div *ngSwitchDefault>
                       <p>not sure what to do with {{ element.type }}</p>

--- a/web/src/app/modules/shared/components/presentation/preferences/preferences.component.scss
+++ b/web/src/app/modules/shared/components/presentation/preferences/preferences.component.scss
@@ -13,18 +13,21 @@
   }
 }
 
-:host ::ng-deep section app-view-dropdown .dropdown {
-  margin-top: 0px;
-
-  clr-dropdown {
-    margin-top: 4px;
-  }
-}
 section {
   margin-block-end: 1.33em;
   width: 100%;
 
   h4 {
     margin: 0 0 0.33em 0;
+  }
+}
+
+clr-select-container {
+  display: flex;
+  flex-direction: row;
+
+  ::ng-deep .clr-control-container {
+    margin-left: 1.0em;
+    margin-top: -0.5em;
   }
 }

--- a/web/src/app/modules/shared/components/presentation/preferences/preferences.component.scss
+++ b/web/src/app/modules/shared/components/presentation/preferences/preferences.component.scss
@@ -5,6 +5,21 @@
   overflow-y: auto;
 }
 
+.modal-footer {
+  justify-content: flex-start;
+
+  .btn-cancel {
+    margin-left: auto;
+  }
+}
+
+:host ::ng-deep section app-view-dropdown .dropdown {
+  margin-top: 0px;
+
+  clr-dropdown {
+    margin-top: 4px;
+  }
+}
 section {
   margin-block-end: 1.33em;
   width: 100%;

--- a/web/src/app/modules/shared/components/presentation/preferences/preferences.component.ts
+++ b/web/src/app/modules/shared/components/presentation/preferences/preferences.component.ts
@@ -80,6 +80,9 @@ export class PreferencesComponent implements OnChanges {
   @Output()
   isOpenChange = new EventEmitter<boolean>();
 
+  @Output()
+  reset = new EventEmitter<void>();
+
   form: FormGroup = new FormGroup({});
 
   controls: { [key: string]: AbstractControl } = {};
@@ -125,11 +128,20 @@ export class PreferencesComponent implements OnChanges {
     this.isOpen = false;
   }
 
+  onDropDownValueChange(event, name) {
+    this.form.value[name] = event;
+  }
+
   onSubmit(): void {
     if (this.form.valid) {
       this.preferencesChanged.emit(this.form.value);
       this.isOpen = false;
     }
+  }
+
+  onReset(): void {
+    this.reset.emit();
+    this.isOpen = false;
   }
 
   private onValueChanged(update: StringDict) {

--- a/web/src/app/modules/shared/models/preference.ts
+++ b/web/src/app/modules/shared/models/preference.ts
@@ -1,4 +1,4 @@
-export type PreferenceElement = RadioElement | TextElement;
+export type PreferenceElement = RadioElement | TextElement | LabelDropDown;
 
 export enum Operation {
   Equal = 'Equal',
@@ -24,6 +24,31 @@ export interface RadioElement extends Element {
   type: 'radio';
   config: {
     values: { label: string; value: string }[];
+  };
+}
+
+export interface LabelDropDown extends Element {
+  type: 'dropdown';
+  label: string;
+  metadata: {
+    type: string;
+    title: [
+      {
+        metadata: {
+          type: string;
+        };
+        config: {
+          value: string;
+        };
+      }
+    ];
+  };
+  config: {
+    position?: string;
+    type: string;
+    selection: string;
+    useSelection: boolean;
+    items: { name: string; type: string; label: string }[];
   };
 }
 

--- a/web/src/app/modules/shared/services/preferences/preferences.entry.ts
+++ b/web/src/app/modules/shared/services/preferences/preferences.entry.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2021 the Octant contributors. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { BehaviorSubject, Subscription } from 'rxjs';
+import { PreferencesService } from './preferences.service';
+import { Preferences } from '../../models/preference';
+
+export class PreferencesEntry<T> {
+  private subscription: Subscription;
+  public subject: BehaviorSubject<T>;
+
+  constructor(
+    private preferencesService: PreferencesService,
+    public id: string,
+    private defaultValue: T,
+    private defaultText: string,
+    public updatesElectron: boolean = false
+  ) {
+    if (typeof this.defaultValue !== 'string') {
+      this.subject = new BehaviorSubject<T>(
+        JSON.parse(
+          preferencesService.getStoredValue(this.id, this.defaultValue)
+        )
+      );
+    } else {
+      this.subject = new BehaviorSubject<T>(
+        preferencesService.getStoredValue(this.id, this.defaultValue)
+      );
+    }
+
+    this.subscription = this.subject.subscribe(val => {
+      preferencesService.setStoredValue(this.id, val);
+    });
+  }
+
+  public preferencesChanged(update: Preferences) {
+    switch (typeof this.defaultValue) {
+      case 'boolean':
+        const val = (update[this.id] === this.defaultText) as unknown;
+        if (this.subject.value !== (val as T)) {
+          this.subject.next(val as T);
+          return true;
+        }
+        break;
+      default:
+        const newValue = update[this.id];
+        if (newValue && this.subject.value !== newValue) {
+          this.subject.next(newValue);
+          return true;
+        }
+        break;
+    }
+    return false;
+  }
+
+  public setDefaultValue() {
+    this.subject.next(this.defaultValue);
+  }
+
+  public destroy() {
+    this.subscription?.unsubscribe();
+  }
+}

--- a/web/src/app/modules/shared/services/preferences/preferences.service.spec.ts
+++ b/web/src/app/modules/shared/services/preferences/preferences.service.spec.ts
@@ -33,16 +33,34 @@ describe('PreferencesService', () => {
     expect(newElement.value).toEqual('collapsed');
   });
 
+  it('table pagination set properly', () => {
+    service.pageSize.next(50);
+    const defaultPrefs = service.getPreferences();
+    const defaultElement = defaultPrefs.panels[0].sections[3].elements[0];
+    expect(defaultElement.name).toEqual('general.pageSize');
+    expect(defaultElement.value).toEqual('50');
+
+    service.pageSize.next(100);
+    const newPrefs = service.getPreferences();
+    const newElement = newPrefs.panels[0].sections[3].elements[0];
+    expect(newElement.name).toEqual('general.pageSize');
+    expect(newElement.value).toEqual('100');
+  });
+
   it('properties are persisted', () => {
     // default values
     service.navCollapsed.next(true);
     service.showLabels.next(true);
+    service.pageSize.next(50);
     expect(
       JSON.parse(service.getStoredValue('navigation.labels', true))
     ).toEqual(true);
     expect(
       JSON.parse(service.getStoredValue('navigation.collapsed', true))
     ).toEqual(true);
+    expect(
+      JSON.parse(service.getStoredValue('development.pageSize', 10))
+    ).toEqual(50);
 
     // change through exposed variables
     service.navCollapsed.next(false);
@@ -55,6 +73,11 @@ describe('PreferencesService', () => {
       JSON.parse(service.getStoredValue('navigation.labels', true))
     ).toEqual(false);
 
+    service.pageSize.next(20);
+    expect(
+      JSON.parse(service.getStoredValue('development.pageSize', 10))
+    ).toEqual(20);
+
     // change by modifying stored values
     service.setStoredValue('navigation.collapsed', true);
     expect(
@@ -65,5 +88,10 @@ describe('PreferencesService', () => {
     expect(
       JSON.parse(service.getStoredValue('navigation.labels', false))
     ).toEqual(true);
+
+    service.setStoredValue('development.pageSize', 100);
+    expect(
+      JSON.parse(service.getStoredValue('development.pageSize', 10))
+    ).toEqual(100);
   });
 });

--- a/web/src/app/modules/shared/services/preferences/preferences.service.spec.ts
+++ b/web/src/app/modules/shared/services/preferences/preferences.service.spec.ts
@@ -13,6 +13,7 @@ describe('PreferencesService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({});
     service = TestBed.inject(PreferencesService);
+    service.reset();
   });
 
   it('should be created', () => {
@@ -20,63 +21,63 @@ describe('PreferencesService', () => {
   });
 
   it('collapsed set properly', () => {
-    service.navCollapsed.next(false);
+    service.preferences.get('navigation.collapsed').subject.next(false);
     const defaultPrefs = service.getPreferences();
-    const defaultElement = defaultPrefs.panels[0].sections[1].elements[0];
-    expect(defaultElement.name).toEqual('general.navigation');
+    const defaultElement = defaultPrefs.panels[1].sections[0].elements[0];
+    expect(defaultElement.name).toEqual('navigation.collapsed');
     expect(defaultElement.value).toEqual('expanded');
 
-    service.navCollapsed.next(true);
+    service.preferences.get('navigation.collapsed').subject.next(true);
     const newPrefs = service.getPreferences();
-    const newElement = newPrefs.panels[0].sections[1].elements[0];
-    expect(newElement.name).toEqual('general.navigation');
+    const newElement = newPrefs.panels[1].sections[0].elements[0];
+    expect(newElement.name).toEqual('navigation.collapsed');
     expect(newElement.value).toEqual('collapsed');
   });
 
   it('table pagination set properly', () => {
-    service.pageSize.next(50);
+    service.preferences.get('general.pageSize').subject.next(50);
     const defaultPrefs = service.getPreferences();
-    const defaultElement = defaultPrefs.panels[0].sections[3].elements[0];
+    const defaultElement = defaultPrefs.panels[0].sections[1].elements[0];
     expect(defaultElement.name).toEqual('general.pageSize');
-    expect(defaultElement.value).toEqual('50');
+    expect(defaultElement.value.toString()).toEqual('50');
 
-    service.pageSize.next(100);
+    service.preferences.get('general.pageSize').subject.next(100);
     const newPrefs = service.getPreferences();
-    const newElement = newPrefs.panels[0].sections[3].elements[0];
+    const newElement = newPrefs.panels[0].sections[1].elements[0];
     expect(newElement.name).toEqual('general.pageSize');
-    expect(newElement.value).toEqual('100');
+    expect(newElement.value.toString()).toEqual('100');
   });
 
   it('properties are persisted', () => {
     // default values
-    service.navCollapsed.next(true);
-    service.showLabels.next(true);
-    service.pageSize.next(50);
+    service.preferences.get('navigation.collapsed').subject.next(true);
+    service.preferences.get('navigation.labels').subject.next(true);
+    service.preferences.get('general.pageSize').subject.next(10);
     expect(
       JSON.parse(service.getStoredValue('navigation.labels', true))
     ).toEqual(true);
     expect(
       JSON.parse(service.getStoredValue('navigation.collapsed', true))
     ).toEqual(true);
-    expect(
-      JSON.parse(service.getStoredValue('development.pageSize', 10))
-    ).toEqual(50);
+    expect(JSON.parse(service.getStoredValue('general.pageSize', 10))).toEqual(
+      10
+    );
 
     // change through exposed variables
-    service.navCollapsed.next(false);
+    service.preferences.get('navigation.collapsed').subject.next(false);
     expect(
       JSON.parse(service.getStoredValue('navigation.collapsed', true))
     ).toEqual(false);
 
-    service.showLabels.next(false);
+    service.preferences.get('navigation.labels').subject.next(false);
     expect(
       JSON.parse(service.getStoredValue('navigation.labels', true))
     ).toEqual(false);
 
-    service.pageSize.next(20);
-    expect(
-      JSON.parse(service.getStoredValue('development.pageSize', 10))
-    ).toEqual(20);
+    service.preferences.get('general.pageSize').subject.next(20);
+    expect(JSON.parse(service.getStoredValue('general.pageSize', 10))).toEqual(
+      20
+    );
 
     // change by modifying stored values
     service.setStoredValue('navigation.collapsed', true);
@@ -89,9 +90,9 @@ describe('PreferencesService', () => {
       JSON.parse(service.getStoredValue('navigation.labels', false))
     ).toEqual(true);
 
-    service.setStoredValue('development.pageSize', 100);
-    expect(
-      JSON.parse(service.getStoredValue('development.pageSize', 10))
-    ).toEqual(100);
+    service.setStoredValue('general.pageSize', 100);
+    expect(JSON.parse(service.getStoredValue('general.pageSize', 10))).toEqual(
+      100
+    );
   });
 });

--- a/web/src/app/modules/sugarloaf/components/smart/container/container.component.html
+++ b/web/src/app/modules/sugarloaf/components/smart/container/container.component.html
@@ -50,5 +50,6 @@
     [preferences]="preferences"
     (preferencesChanged)="preferencesChanged($event)"
     (isOpenChange)="preferencesOpenChanged($event)"
-  ></app-preferences>
+    (reset)="onReset()"
+></app-preferences>
 </div>

--- a/web/src/app/modules/sugarloaf/components/smart/container/container.component.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/container/container.component.ts
@@ -78,6 +78,10 @@ export class ContainerComponent implements OnInit, OnDestroy {
     this.location.back();
   }
 
+  onReset() {
+    this.preferencesService.reset();
+  }
+
   preferencesOpenChanged(opened: boolean) {
     this.preferencesService.preferencesOpened.next(opened);
   }

--- a/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.ts
@@ -77,23 +77,23 @@ export class NavigationComponent implements OnInit, OnDestroy {
       }
     );
 
-    this.subscriptionCollapsed = this.preferencesService.navCollapsed.subscribe(
-      col => {
+    this.subscriptionCollapsed = this.preferencesService.preferences
+      .get('navigation.collapsed')
+      .subject.subscribe(col => {
         if (this.collapsed !== col) {
           this.collapsed = col;
           this.cd.markForCheck();
         }
-      }
-    );
+      });
 
-    this.subscriptionShowLabels = this.preferencesService.showLabels.subscribe(
-      col => {
+    this.subscriptionShowLabels = this.preferencesService.preferences
+      .get('navigation.labels')
+      .subject.subscribe(col => {
         if (this.showLabels !== col) {
           this.showLabels = col;
           this.cd.markForCheck();
         }
-      }
-    );
+      });
   }
 
   @HostListener('window:keyup', ['$event'])
@@ -109,7 +109,9 @@ export class NavigationComponent implements OnInit, OnDestroy {
     } else if (event.key === 'L' && event.ctrlKey) {
       event.preventDefault();
       event.cancelBubble = true;
-      this.preferencesService.showLabels.next(!this.showLabels);
+      this.preferencesService.preferences
+        .get('navigation.labels')
+        .subject.next(!this.showLabels);
     }
   }
 
@@ -169,7 +171,9 @@ export class NavigationComponent implements OnInit, OnDestroy {
   }
 
   updateNavCollapsed(value: boolean): void {
-    this.preferencesService.navCollapsed.next(value);
+    this.preferencesService.preferences
+      .get('navigation.collapsed')
+      .subject.next(value);
   }
 
   setLastSelection(index) {


### PR DESCRIPTION

- Added a new preference to set table page size with default value of 10,
- Added Reset button so the preferences can be restored to default state,
- Rearranged the panels - moved the navigation preferences to separate panel, 
- Refactored preferences handling to make it easier to add new and maintain existing 

Luis and Milan
