### PR TITLE
Fixed issue with clusterless configuration 

### DIFF
--- a/changelogs/unreleased/2058-mklanjsek
+++ b/changelogs/unreleased/2058-mklanjsek
@@ -1,0 +1,1 @@
+Fixed issue with clusterless configuration specified at startup (#2058)

--- a/internal/kubeconfig/kubeconfig.go
+++ b/internal/kubeconfig/kubeconfig.go
@@ -62,8 +62,10 @@ func NewKubeConfigContextManager(ctx context.Context, opts ...KubeConfigOption) 
 	options := kubeConfigOptions{}
 	clusterOptions := []cluster.ClusterOption{}
 	for _, opt := range opts {
-		opt.kubeConfigOption(&options)
-		clusterOptions = append(clusterOptions, opt.clusterOption)
+		if opt.kubeConfigOption != nil {
+			opt.kubeConfigOption(&options)
+			clusterOptions = append(clusterOptions, opt.clusterOption)
+		}
 	}
 	chain := strings.Deduplicate(filepath.SplitList(options.KubeConfigList))
 	rules := &clientcmd.ClientConfigLoadingRules{

--- a/internal/kubeconfig/kubeconfig_test.go
+++ b/internal/kubeconfig/kubeconfig_test.go
@@ -97,3 +97,15 @@ func TestFSLoader_Load(t *testing.T) {
 		{Name: "exp-scratch"},
 	}, kc.Contexts())
 }
+
+func Test_NewKubeConfigNoCluster(t *testing.T) {
+	noClusterOptions := KubeConfigOption{nil, nil}
+
+	_, err := NewKubeConfigContextManager(
+		context.TODO(),
+		WithKubeConfigList(filepath.Join("testdata", "kubeconfig.yaml")),
+		FromClusterOption(cluster.WithRESTConfigOptions(cluster.RESTConfigOptions{})),
+		noClusterOptions,
+	)
+	require.NoError(t, err)
+}

--- a/pkg/dash/dash.go
+++ b/pkg/dash/dash.go
@@ -75,6 +75,7 @@ type RunnerOption struct {
 
 func WithOpenCensus() RunnerOption {
 	return RunnerOption{
+		kubeConfigOption: kubeconfig.Noop(),
 		nonClusterOption: func(o *Options) {
 			o.EnableOpenCensus = true
 		},
@@ -83,6 +84,7 @@ func WithOpenCensus() RunnerOption {
 
 func WithoutClusterOverview() RunnerOption {
 	return RunnerOption{
+		kubeConfigOption: kubeconfig.Noop(),
 		nonClusterOption: func(o *Options) {
 			o.DisableClusterOverview = true
 		},


### PR DESCRIPTION
After recent dash refactor, we lost ability to run with `--disable-cluster-overview` option. Added extra checks to  prevent the Panic error and verified that fixed the issue.

Signed-off-by: Milan Klanjsek <mklanjsek@pivotal.io>

**Which issue(s) this PR fixes**
- Fixes #2058 
