### PR TITLE
Reduce tooltip size on label to avoid hidden tags on K8s object

### DIFF
--- a/changelogs/unreleased/2044-lenriquez
+++ b/changelogs/unreleased/2044-lenriquez
@@ -1,0 +1,1 @@
+Reduce tooltip size on label to avoid hidden tags on K8s object

--- a/web/src/app/modules/shared/components/presentation/datagrid/datagrid.component.scss
+++ b/web/src/app/modules/shared/components/presentation/datagrid/datagrid.component.scss
@@ -17,3 +17,7 @@
 app-button-group {
   float: right;
 }
+
+::ng-deep .datagrid-table {
+  position: static;
+}

--- a/web/src/app/modules/shared/components/presentation/overflow-labels/overflow-labels.component.scss
+++ b/web/src/app/modules/shared/components/presentation/overflow-labels/overflow-labels.component.scss
@@ -43,9 +43,14 @@
     padding: 0 0.2rem;
   }
 
+  ::ng-deep &-content {
+    max-width: min-content;
+  }
+
   // To avoid horizontal scroll-bar inside of the signpost content body.
   ::ng-deep .signpost-wrap .signpost-content-body {
     padding: 1rem;
+    max-height: 12.2rem;
 
     .label:not(:last-child) {
       margin-bottom: 0.2rem;


### PR DESCRIPTION
Signed-off-by: Luis Enriquez <luisenriquez@vmware.com>


**What this PR does / why we need it**: Is not posible to see all the tags on k8s object 

**Which issue(s) this PR fixes**
- Fixes #2044

**Special notes for your reviewer**:
**Solution 1**
The tooltip for the labels does not use "position: fixed" but "position: absolute" and since the datagrid also use "position: absolute" part of the tooltip hides since is bigger than its parent.

```
::ng-deep .datagrid-outer-wrapper, 
::ng-deep .datagrid-inner-wrapper,
::ng-deep .datagrid {
  // Allow tooltip to be shown completely event if translate push them outside 
  // the grid
  overflow-y: visible;
}
```
**Problem with solution 1** 
This solution could work but according to this article 
https://css-tricks.com/popping-hidden-overflow/
is not posible some combinations like overflow-y: visible; and overflow-x: auto; so it does not looks well on small screens

**Solution 2** 
so the size of the tooltip was reduce to make sure it fit the table

**Problem with solution 2:** It looks too small

![image](https://user-images.githubusercontent.com/6991432/109169699-16e20e00-774e-11eb-91fb-4059b425e449.png)

**Solution 3**
Found on https://github.com/vmware/clarity/issues/4891
remove position: relative from class datagrid-table

![image](https://user-images.githubusercontent.com/6991432/109170053-704a3d00-774e-11eb-9b47-83fa33b15a58.png)

**Release note**:
```
release-note
```
