### PR TITLE
Fix build-electron, remove mkdir, not needed

### DIFF
--- a/build.go
+++ b/build.go
@@ -347,15 +347,6 @@ func webBuild() {
 }
 
 func webBuildElectron() {
-	dirCmd := newCmd("mkdir", nil, "-p", "dist/octant")
-	dirCmd.Stdout = os.Stdout
-	dirCmd.Stderr = os.Stderr
-	dirCmd.Stdin = os.Stdin
-	dirCmd.Dir = "./web"
-	if err := dirCmd.Run(); err != nil {
-		log.Fatalf("web-build-electron: create dist/octant/ : %s", err)
-	}
-
 	cleanCmd := newCmd("npm", nil, "run", "clean")
 	cleanCmd.Stdout = os.Stdout
 	cleanCmd.Stderr = os.Stderr


### PR DESCRIPTION
Signed-off-by: Wayne Witzel III <wayne@riotousliving.com>

Currently `go run build.go build-electron` is broken on Windows.
This removes the `webBuildElectron` function completely. After the recent changes to remove go-rice #1750 this is no longer neded.
