### PR TITLE
Fix for security vulnerabilities

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -16621,9 +16621,9 @@
       "dev": true
     },
     "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
     },
     "inline-source-map": {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -4337,7 +4337,7 @@
         "loglevel": "^1.6.4",
         "loglevel-plugin-prefix": "^0.8.4",
         "lunr": "^2.3.6",
-        "marked": "^0.7.0",
+        "marked": "2.0.1",
         "minimist": "^1.2.0",
         "opencollective-postinstall": "^2.0.2",
         "os-name": "^3.1.0",
@@ -4372,9 +4372,9 @@
           }
         },
         "marked": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
-          "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.1.tgz",
+          "integrity": "sha512-5+/fKgMv2hARmMW7DOpykr2iLhl0NgjyELk5yn92iE7z8Se1IS9n3UsFm86hFXIkvMBmVxki8+ckcpjBeyo/hw==",
           "dev": true
         },
         "uuid": {
@@ -18887,9 +18887,10 @@
       }
     },
     "marked": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-1.2.9.tgz",
-      "integrity": "sha512-H8lIX2SvyitGX+TRdtS06m1jHMijKN/XjfH6Ooii9fvxMlh8QdqBfBDkGUpMWH2kQNrtixjzYUa3SH8ROTgRRw=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.1.tgz",
+      "integrity": "sha512-5+/fKgMv2hARmMW7DOpykr2iLhl0NgjyELk5yn92iE7z8Se1IS9n3UsFm86hFXIkvMBmVxki8+ckcpjBeyo/hw==",
+      "dev": true
     },
     "matcher": {
       "version": "3.0.0",

--- a/web/package.json
+++ b/web/package.json
@@ -33,7 +33,8 @@
     ],
     "docs:json": "compodoc -p tsconfig.compodoc.json -e json -d .",
     "storybook": "npm run docs:json && start-storybook -p 6006 -s src/assets",
-    "build-storybook": "npm run docs:json && node --max-old-space-size=8000 ./node_modules/@storybook/angular/bin/build.js build-storybook -c .storybook"
+    "build-storybook": "npm run docs:json && node --max-old-space-size=8000 ./node_modules/@storybook/angular/bin/build.js build-storybook -c .storybook",
+    "preinstall": "npx npm-force-resolutions"
   },
   "prettier": {
     "trailingComma": "es5",
@@ -78,7 +79,6 @@
     "karma-electron-launcher": "^0.3.0",
     "lodash": "^4.17.20",
     "lodash-es": "^4.17.15",
-    "marked": "^1.2.0",
     "monaco-editor": "^0.21.2",
     "ngx-highlightjs": "^4.1.2",
     "overlayscrollbars-ngx": "^0.2.2",
@@ -126,6 +126,7 @@
     "karma-jasmine": "^4.0.1",
     "karma-jasmine-html-reporter": "^1.5.4",
     "karma-spec-reporter": "0.0.32",
+    "marked": "^2.0.1",
     "prettier": "^2.2.1",
     "prettier-tslint": "^0.4.2",
     "protractor": "~7.0.0",
@@ -142,5 +143,8 @@
     "tslint-plugin-prettier": "^2.3.0",
     "typescript": "~4.1.5",
     "wait-on": "^5.2.0"
+  },
+  "resolutions": {
+    "marked": "2.0.1"
   }
 }


### PR DESCRIPTION
Addressed a couple of reported security vulnerabilities:
- Updated `marked` library to version 2.0.1 to address the  [marked security vulnerability]( https://github.com/vmware-tanzu/octant/security/dependabot/web/package.json/marked/open)
- Bumped the `ini` dependency to address the [ini prototype pollution vulnerability](https://www.npmjs.com/advisories/1589)

Note that the build process now has pre-install phase that performs dependency resolutions - that is the only way to update the nested dependencies with `npm`  
