### PR TITLE
Keep trying to sync informer until it success or done message

### DIFF
--- a/changelogs/unreleased/1944-lenriquez
+++ b/changelogs/unreleased/1944-lenriquez
@@ -1,0 +1,1 @@
+Keep trying to sync informer until it success or done message


### PR DESCRIPTION
Signed-off-by: Luis Enriquez <felipe096@gmail.com>


**What this PR does / why we need it**: While loading some services the dynamic cache could return an empty array, this could make the resource viewer to update twice, the main idea is to avoid this behaviour 

**Which issue(s) this PR fixes**
- Fixes #1944 

**Special notes for your reviewer**:
The git issue explains why I believed this was not a race condition problem between typedVisitors

In order to replicate the issue is necessary to shut down octant and use a GKE cluster or any cluster that takes some time to responde 

**Release note**:
```
release-note
```
