### PR TITLE
Go plugins context

### DIFF
--- a/changelogs/unreleased/2099-xtreme-vikram-yadav
+++ b/changelogs/unreleased/2099-xtreme-vikram-yadav
@@ -1,0 +1,1 @@
+Add lookup for additional metadata from JS plugins

--- a/pkg/plugin/javascript/dashboard_client.go
+++ b/pkg/plugin/javascript/dashboard_client.go
@@ -16,6 +16,15 @@ import (
 	"github.com/vmware-tanzu/octant/internal/octant"
 )
 
+// DashboardMetadataKey is a type used for metadata keys passed by plugins
+type DashboardMetadataKey string
+
+//DashboardMetadataSentinel is a type for CloneKey
+type DashboardMetadataSentinel string
+
+//CloneKey is a dummy key used to clone context.Context
+var CloneKey DashboardMetadataSentinel = ""
+
 // ModularDashboardClientFactory is a modular octant.DashboardClientFactory. It configures
 // itself based on functions passed when it is initialized.
 type ModularDashboardClientFactory struct {

--- a/pkg/plugin/javascript/dashboard_client.go
+++ b/pkg/plugin/javascript/dashboard_client.go
@@ -19,12 +19,6 @@ import (
 // DashboardMetadataKey is a type used for metadata keys passed by plugins
 type DashboardMetadataKey string
 
-//DashboardMetadataSentinel is a type for CloneKey
-type DashboardMetadataSentinel string
-
-//CloneKey is a dummy key used to clone context.Context
-var CloneKey DashboardMetadataSentinel = ""
-
 // ModularDashboardClientFactory is a modular octant.DashboardClientFactory. It configures
 // itself based on functions passed when it is initialized.
 type ModularDashboardClientFactory struct {

--- a/pkg/plugin/javascript/dashboard_client.go
+++ b/pkg/plugin/javascript/dashboard_client.go
@@ -75,3 +75,18 @@ func panicMessage(vm *goja.Runtime, err error, reason string) goja.Value {
 
 	return vm.ToValue(fmt.Sprintf("%s: %s", reason, err.Error()))
 }
+
+// extract out the key/values sent by the plugin to add context for object store requests.
+func setObjectStoreContext(ctx context.Context, jsObj goja.Value, vm *goja.Runtime) context.Context {
+	var metadata map[string]string
+	metadataObj := jsObj.ToObject(vm)
+
+	// This will not error as js plugins restrict this type
+	// and we handle the case of having undefined value
+	_ = vm.ExportTo(metadataObj, &metadata)
+	for k, val := range metadata {
+		ctx = context.WithValue(ctx, DashboardMetadataKey(k), val)
+	}
+
+	return ctx
+}

--- a/pkg/plugin/javascript/dashboard_client.go
+++ b/pkg/plugin/javascript/dashboard_client.go
@@ -10,14 +10,12 @@ import (
 	"fmt"
 
 	"github.com/vmware-tanzu/octant/pkg/event"
+	"github.com/vmware-tanzu/octant/pkg/plugin/api"
 
 	"github.com/dop251/goja"
 
 	"github.com/vmware-tanzu/octant/internal/octant"
 )
-
-// DashboardMetadataKey is a type used for metadata keys passed by plugins
-type DashboardMetadataKey string
 
 // ModularDashboardClientFactory is a modular octant.DashboardClientFactory. It configures
 // itself based on functions passed when it is initialized.
@@ -85,7 +83,7 @@ func setObjectStoreContext(ctx context.Context, jsObj goja.Value, vm *goja.Runti
 	// and we handle the case of having undefined value
 	_ = vm.ExportTo(metadataObj, &metadata)
 	for k, val := range metadata {
-		ctx = context.WithValue(ctx, DashboardMetadataKey(k), val)
+		ctx = context.WithValue(ctx, api.DashboardMetadataKey(k), val)
 	}
 
 	return ctx

--- a/pkg/plugin/javascript/dashboard_delete.go
+++ b/pkg/plugin/javascript/dashboard_delete.go
@@ -49,15 +49,7 @@ func (d *DashboardDelete) Call(ctx context.Context, vm *goja.Runtime) func(c goj
 
 		metadataArg := c.Argument(1)
 		if !goja.IsUndefined(metadataArg) {
-			var metadata map[string]string
-			metadataObj := metadataArg.ToObject(vm)
-
-			// This will not error as js plugins restrict this type
-			// and we handle both cases
-			_ = vm.ExportTo(metadataObj, &metadata)
-			for k, val := range metadata {
-				newCtx = context.WithValue(newCtx, DashboardMetadataKey(k), val)
-			}
+			newCtx = setObjectStoreContext(newCtx, metadataArg, vm)
 		}
 
 		if err := d.storage.ObjectStore().Delete(newCtx, key); err != nil {

--- a/pkg/plugin/javascript/dashboard_delete.go
+++ b/pkg/plugin/javascript/dashboard_delete.go
@@ -44,6 +44,16 @@ func (d *DashboardDelete) Call(ctx context.Context, vm *goja.Runtime) func(c goj
 		// This will never error since &key is a pointer to a type.
 		_ = vm.ExportTo(obj, &key)
 
+		if len(c.Arguments) > 1 {
+			var metadata map[string]interface{}
+			metadataObj := c.Argument(1).ToObject(vm)
+
+			_ = vm.ExportTo(metadataObj, &metadata)
+			for key, val := range metadata {
+				ctx = context.WithValue(ctx, key, val)
+			}
+		}
+
 		if err := d.storage.ObjectStore().Delete(ctx, key); err != nil {
 			panic(panicMessage(vm, err, ""))
 		}

--- a/pkg/plugin/javascript/dashboard_delete.go
+++ b/pkg/plugin/javascript/dashboard_delete.go
@@ -38,17 +38,22 @@ func (d *DashboardDelete) Name() string {
 // delete is unsuccessful, it will throw a javascript exception.
 func (d *DashboardDelete) Call(ctx context.Context, vm *goja.Runtime) func(c goja.FunctionCall) goja.Value {
 	return func(c goja.FunctionCall) goja.Value {
-		var newCtx context.Context = context.WithValue(ctx, CloneKey, nil)
+		newCtx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
 		var key store.Key
 		obj := c.Argument(0).ToObject(vm)
 
 		// This will never error since &key is a pointer to a type.
 		_ = vm.ExportTo(obj, &key)
 
-		if len(c.Arguments) > 1 {
-			var metadata map[string]interface{}
-			metadataObj := c.Argument(1).ToObject(vm)
+		metadataArg := c.Argument(1)
+		if !goja.IsUndefined(metadataArg) {
+			var metadata map[string]string
+			metadataObj := metadataArg.ToObject(vm)
 
+			// This will not error as js plugins restrict this type
+			// and we handle both cases
 			_ = vm.ExportTo(metadataObj, &metadata)
 			for k, val := range metadata {
 				newCtx = context.WithValue(newCtx, DashboardMetadataKey(k), val)

--- a/pkg/plugin/javascript/dashboard_delete_test.go
+++ b/pkg/plugin/javascript/dashboard_delete_test.go
@@ -47,6 +47,28 @@ func TestDashboardDelete_Call(t *testing.T) {
 			ctorArgs: ctorArgs{
 				storage: func(ctx context.Context, ctrl *gomock.Controller) octant.Storage {
 					objectStore := fake2.NewMockStore(ctrl)
+
+					objectStore.EXPECT().
+						Delete(ContextType, store.Key{
+							Namespace:  "test",
+							APIVersion: "v1",
+							Kind:       "ReplicaSet",
+							Name:       "my-replica-set"}).
+						Return(nil)
+
+					storage := fake.NewMockStorage(ctrl)
+					storage.EXPECT().ObjectStore().Return(objectStore).AnyTimes()
+
+					return storage
+				},
+			},
+			call: `dashClient.Delete({namespace:'test', apiVersion: 'v1', kind:'ReplicaSet', name: 'my-replica-set'})`,
+		},
+		{
+			name: "with arbitrary metadata",
+			ctorArgs: ctorArgs{
+				storage: func(ctx context.Context, ctrl *gomock.Controller) octant.Storage {
+					objectStore := fake2.NewMockStore(ctrl)
 					ctx = context.WithValue(ctx, DashboardMetadataKey("foo"), "baz")
 					ctx = context.WithValue(ctx, DashboardMetadataKey("foo"), "bar")
 					ctx = context.WithValue(ctx, DashboardMetadataKey("qux"), "quuux")

--- a/pkg/plugin/javascript/dashboard_delete_test.go
+++ b/pkg/plugin/javascript/dashboard_delete_test.go
@@ -46,7 +46,9 @@ func TestDashboardDelete_Call(t *testing.T) {
 			name: "in general",
 			ctorArgs: ctorArgs{
 				storage: func(ctx context.Context, ctrl *gomock.Controller) octant.Storage {
+					ctx = context.WithValue(ctx, "accessToken", "secret")
 					objectStore := fake2.NewMockStore(ctrl)
+
 					objectStore.EXPECT().
 						Delete(ctx, store.Key{
 							Namespace:  "test",
@@ -61,7 +63,7 @@ func TestDashboardDelete_Call(t *testing.T) {
 					return storage
 				},
 			},
-			call: `dashClient.Delete({namespace:'test', apiVersion: 'v1', kind:'ReplicaSet', name: 'my-replica-set'})`,
+			call: `dashClient.Delete({namespace:'test', apiVersion: 'v1', kind:'ReplicaSet', name: 'my-replica-set'},{"accessToken": "secret"})`,
 		},
 		{
 			name: "delete fails",

--- a/pkg/plugin/javascript/dashboard_delete_test.go
+++ b/pkg/plugin/javascript/dashboard_delete_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
+	"github.com/vmware-tanzu/octant/pkg/plugin/api"
 
 	"github.com/vmware-tanzu/octant/internal/octant"
 	"github.com/vmware-tanzu/octant/internal/octant/fake"
@@ -69,10 +70,10 @@ func TestDashboardDelete_Call(t *testing.T) {
 			ctorArgs: ctorArgs{
 				storage: func(ctx context.Context, ctrl *gomock.Controller) octant.Storage {
 					objectStore := fake2.NewMockStore(ctrl)
-					ctx = context.WithValue(ctx, DashboardMetadataKey("foo"), "baz")
-					ctx = context.WithValue(ctx, DashboardMetadataKey("foo"), "bar")
-					ctx = context.WithValue(ctx, DashboardMetadataKey("qux"), "quuux")
-					ctx = context.WithValue(ctx, DashboardMetadataKey("qux"), "quux")
+					ctx = context.WithValue(ctx, api.DashboardMetadataKey("foo"), "baz")
+					ctx = context.WithValue(ctx, api.DashboardMetadataKey("foo"), "bar")
+					ctx = context.WithValue(ctx, api.DashboardMetadataKey("qux"), "quuux")
+					ctx = context.WithValue(ctx, api.DashboardMetadataKey("qux"), "quux")
 
 					objectStore.EXPECT().
 						Delete(ContextType, store.Key{
@@ -82,8 +83,8 @@ func TestDashboardDelete_Call(t *testing.T) {
 							Name:       "my-replica-set"}).
 						Return(nil).
 						Do(func(c context.Context, _ store.Key) {
-							require.Equal(t, "bar", c.Value(DashboardMetadataKey("foo")))
-							require.Equal(t, "quux", c.Value(DashboardMetadataKey("qux")))
+							require.Equal(t, "bar", c.Value(api.DashboardMetadataKey("foo")))
+							require.Equal(t, "quux", c.Value(api.DashboardMetadataKey("qux")))
 						})
 
 					storage := fake.NewMockStorage(ctrl)

--- a/pkg/plugin/javascript/dashboard_get.go
+++ b/pkg/plugin/javascript/dashboard_get.go
@@ -48,16 +48,8 @@ func (d *DashboardGet) Call(ctx context.Context, vm *goja.Runtime) func(c goja.F
 		_ = vm.ExportTo(obj, &key)
 
 		metadataArg := c.Argument(1)
-		if !goja.IsUndefined(metadataArg) && !goja.IsNull(metadataArg) {
-			var metadata map[string]string
-			metadataObj := metadataArg.ToObject(vm)
-
-			// This will not error as js plugins restrict this type
-			// and we handle both cases
-			_ = vm.ExportTo(metadataObj, &metadata)
-			for k, val := range metadata {
-				newCtx = context.WithValue(newCtx, DashboardMetadataKey(k), val)
-			}
+		if !goja.IsUndefined(metadataArg) {
+			newCtx = setObjectStoreContext(newCtx, metadataArg, vm)
 		}
 
 		u, err := d.storage.ObjectStore().Get(newCtx, key)

--- a/pkg/plugin/javascript/dashboard_get.go
+++ b/pkg/plugin/javascript/dashboard_get.go
@@ -38,6 +38,7 @@ func (d *DashboardGet) Name() string {
 // get is unsuccessful, it will throw a javascript exception.
 func (d *DashboardGet) Call(ctx context.Context, vm *goja.Runtime) func(c goja.FunctionCall) goja.Value {
 	return func(c goja.FunctionCall) goja.Value {
+		var newCtx context.Context = context.WithValue(ctx, CloneKey, nil)
 		var key store.Key
 		obj := c.Argument(0).ToObject(vm)
 
@@ -49,12 +50,12 @@ func (d *DashboardGet) Call(ctx context.Context, vm *goja.Runtime) func(c goja.F
 			metadataObj := c.Argument(1).ToObject(vm)
 
 			_ = vm.ExportTo(metadataObj, &metadata)
-			for key, val := range metadata {
-				ctx = context.WithValue(ctx, key, val)
+			for k, val := range metadata {
+				newCtx = context.WithValue(newCtx, DashboardMetadataKey(k), val)
 			}
 		}
 
-		u, err := d.storage.ObjectStore().Get(ctx, key)
+		u, err := d.storage.ObjectStore().Get(newCtx, key)
 		if err != nil {
 			panic(panicMessage(vm, err, ""))
 		}

--- a/pkg/plugin/javascript/dashboard_get.go
+++ b/pkg/plugin/javascript/dashboard_get.go
@@ -44,6 +44,16 @@ func (d *DashboardGet) Call(ctx context.Context, vm *goja.Runtime) func(c goja.F
 		// This will never error since &key is a pointer to a type.
 		_ = vm.ExportTo(obj, &key)
 
+		if len(c.Arguments) > 1 {
+			var metadata map[string]interface{}
+			metadataObj := c.Argument(1).ToObject(vm)
+
+			_ = vm.ExportTo(metadataObj, &metadata)
+			for key, val := range metadata {
+				ctx = context.WithValue(ctx, key, val)
+			}
+		}
+
 		u, err := d.storage.ObjectStore().Get(ctx, key)
 		if err != nil {
 			panic(panicMessage(vm, err, ""))

--- a/pkg/plugin/javascript/dashboard_get_test.go
+++ b/pkg/plugin/javascript/dashboard_get_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/vmware-tanzu/octant/internal/octant"
 	"github.com/vmware-tanzu/octant/internal/octant/fake"
 	"github.com/vmware-tanzu/octant/internal/testutil"
+	"github.com/vmware-tanzu/octant/pkg/plugin/api"
 	"github.com/vmware-tanzu/octant/pkg/store"
 	fake2 "github.com/vmware-tanzu/octant/pkg/store/fake"
 )
@@ -70,10 +71,10 @@ func TestDashboardGet_Call(t *testing.T) {
 			ctorArgs: ctorArgs{
 				storage: func(ctx context.Context, ctrl *gomock.Controller) octant.Storage {
 					objectStore := fake2.NewMockStore(ctrl)
-					ctx = context.WithValue(ctx, DashboardMetadataKey("foo"), "baz")
-					ctx = context.WithValue(ctx, DashboardMetadataKey("foo"), "bar")
-					ctx = context.WithValue(ctx, DashboardMetadataKey("qux"), "quuux")
-					ctx = context.WithValue(ctx, DashboardMetadataKey("qux"), "quux")
+					ctx = context.WithValue(ctx, api.DashboardMetadataKey("foo"), "baz")
+					ctx = context.WithValue(ctx, api.DashboardMetadataKey("foo"), "bar")
+					ctx = context.WithValue(ctx, api.DashboardMetadataKey("qux"), "quuux")
+					ctx = context.WithValue(ctx, api.DashboardMetadataKey("qux"), "quux")
 
 					objectStore.EXPECT().
 						Get(ContextType, store.Key{
@@ -83,8 +84,8 @@ func TestDashboardGet_Call(t *testing.T) {
 							Name:       "pod"}).
 						Return(testutil.ToUnstructured(t, testutil.CreatePod("pod")), nil).
 						Do(func(c context.Context, _ store.Key) {
-							require.Equal(t, "bar", c.Value(DashboardMetadataKey("foo")))
-							require.Equal(t, "quux", c.Value(DashboardMetadataKey("qux")))
+							require.Equal(t, "bar", c.Value(api.DashboardMetadataKey("foo")))
+							require.Equal(t, "quux", c.Value(api.DashboardMetadataKey("qux")))
 						})
 
 					storage := fake.NewMockStorage(ctrl)

--- a/pkg/plugin/javascript/dashboard_get_test.go
+++ b/pkg/plugin/javascript/dashboard_get_test.go
@@ -47,6 +47,7 @@ func TestDashboardGet_Call(t *testing.T) {
 			name: "in general",
 			ctorArgs: ctorArgs{
 				storage: func(ctx context.Context, ctrl *gomock.Controller) octant.Storage {
+					ctx = context.WithValue(ctx, "accessToken", "secret")
 					objectStore := fake2.NewMockStore(ctrl)
 					objectStore.EXPECT().
 						Get(ctx, store.Key{
@@ -62,7 +63,7 @@ func TestDashboardGet_Call(t *testing.T) {
 					return storage
 				},
 			},
-			call: `dashClient.Get({namespace:'test', apiVersion: 'v1', kind:'Pod', name: 'pod'})`,
+			call: `dashClient.Get({namespace:'test', apiVersion: 'v1', kind:'Pod', name: 'pod'},{"accessToken": "secret"})`,
 		},
 		{
 			name: "delete fails",

--- a/pkg/plugin/javascript/dashboard_get_test.go
+++ b/pkg/plugin/javascript/dashboard_get_test.go
@@ -48,6 +48,28 @@ func TestDashboardGet_Call(t *testing.T) {
 			ctorArgs: ctorArgs{
 				storage: func(ctx context.Context, ctrl *gomock.Controller) octant.Storage {
 					objectStore := fake2.NewMockStore(ctrl)
+
+					objectStore.EXPECT().
+						Get(ContextType, store.Key{
+							Namespace:  "test",
+							APIVersion: "v1",
+							Kind:       "Pod",
+							Name:       "pod"}).
+						Return(testutil.ToUnstructured(t, testutil.CreatePod("pod")), nil)
+
+					storage := fake.NewMockStorage(ctrl)
+					storage.EXPECT().ObjectStore().Return(objectStore).AnyTimes()
+
+					return storage
+				},
+			},
+			call: `dashClient.Get({namespace:'test', apiVersion: 'v1', kind:'Pod', name: 'pod'})`,
+		},
+		{
+			name: "with arbitrary metadata",
+			ctorArgs: ctorArgs{
+				storage: func(ctx context.Context, ctrl *gomock.Controller) octant.Storage {
+					objectStore := fake2.NewMockStore(ctrl)
 					ctx = context.WithValue(ctx, DashboardMetadataKey("foo"), "baz")
 					ctx = context.WithValue(ctx, DashboardMetadataKey("foo"), "bar")
 					ctx = context.WithValue(ctx, DashboardMetadataKey("qux"), "quuux")

--- a/pkg/plugin/javascript/dashboard_list.go
+++ b/pkg/plugin/javascript/dashboard_list.go
@@ -39,6 +39,7 @@ func (d *DashboardList) Name() string {
 // list is unsuccessful, it will throw a javascript exception.
 func (d *DashboardList) Call(ctx context.Context, vm *goja.Runtime) func(c goja.FunctionCall) goja.Value {
 	return func(c goja.FunctionCall) goja.Value {
+		var newCtx context.Context = context.WithValue(ctx, CloneKey, nil)
 		m := map[string]interface{}{}
 
 		var key store.Key
@@ -57,12 +58,12 @@ func (d *DashboardList) Call(ctx context.Context, vm *goja.Runtime) func(c goja.
 			metadataObj := c.Argument(1).ToObject(vm)
 
 			_ = vm.ExportTo(metadataObj, &metadata)
-			for key, val := range metadata {
-				ctx = context.WithValue(ctx, key, val)
+			for k, val := range metadata {
+				newCtx = context.WithValue(newCtx, DashboardMetadataKey(k), val)
 			}
 		}
 
-		u, _, err := d.storage.ObjectStore().List(ctx, key)
+		u, _, err := d.storage.ObjectStore().List(newCtx, key)
 		if err != nil {
 			panic(panicMessage(vm, err, ""))
 		}

--- a/pkg/plugin/javascript/dashboard_list.go
+++ b/pkg/plugin/javascript/dashboard_list.go
@@ -57,15 +57,7 @@ func (d *DashboardList) Call(ctx context.Context, vm *goja.Runtime) func(c goja.
 
 		metadataArg := c.Argument(1)
 		if !goja.IsUndefined(metadataArg) {
-			var metadata map[string]string
-			metadataObj := metadataArg.ToObject(vm)
-
-			// This will not error as js plugins restrict this type
-			// and we handle both cases
-			_ = vm.ExportTo(metadataObj, &metadata)
-			for k, val := range metadata {
-				newCtx = context.WithValue(newCtx, DashboardMetadataKey(k), val)
-			}
+			newCtx = setObjectStoreContext(newCtx, metadataArg, vm)
 		}
 
 		u, _, err := d.storage.ObjectStore().List(newCtx, key)

--- a/pkg/plugin/javascript/dashboard_list.go
+++ b/pkg/plugin/javascript/dashboard_list.go
@@ -52,6 +52,16 @@ func (d *DashboardList) Call(ctx context.Context, vm *goja.Runtime) func(c goja.
 			panicMessage(vm, fmt.Errorf("key is invalid: %w", err), "")
 		}
 
+		if len(c.Arguments) > 1 {
+			var metadata map[string]interface{}
+			metadataObj := c.Argument(1).ToObject(vm)
+
+			_ = vm.ExportTo(metadataObj, &metadata)
+			for key, val := range metadata {
+				ctx = context.WithValue(ctx, key, val)
+			}
+		}
+
 		u, _, err := d.storage.ObjectStore().List(ctx, key)
 		if err != nil {
 			panic(panicMessage(vm, err, ""))

--- a/pkg/plugin/javascript/dashboard_list_test.go
+++ b/pkg/plugin/javascript/dashboard_list_test.go
@@ -48,6 +48,28 @@ func TestDashboardList_Call(t *testing.T) {
 			ctorArgs: ctorArgs{
 				storage: func(ctx context.Context, ctrl *gomock.Controller) octant.Storage {
 					objectStore := fake2.NewMockStore(ctrl)
+
+					objectStore.EXPECT().
+						List(ContextType, store.Key{
+							Namespace:  "test",
+							APIVersion: "v1",
+							Kind:       "Pod",
+						}).
+						Return(testutil.ToUnstructuredList(t, testutil.CreatePod("pod")), false, nil)
+
+					storage := fake.NewMockStorage(ctrl)
+					storage.EXPECT().ObjectStore().Return(objectStore).AnyTimes()
+
+					return storage
+				},
+			},
+			call: `dashClient.List({namespace:'test', apiVersion: 'v1', kind:'Pod'})`,
+		},
+		{
+			name: "with arbitrary metadata",
+			ctorArgs: ctorArgs{
+				storage: func(ctx context.Context, ctrl *gomock.Controller) octant.Storage {
+					objectStore := fake2.NewMockStore(ctrl)
 					ctx = context.WithValue(ctx, DashboardMetadataKey("foo"), "baz")
 					ctx = context.WithValue(ctx, DashboardMetadataKey("foo"), "bar")
 					ctx = context.WithValue(ctx, DashboardMetadataKey("qux"), "quuux")

--- a/pkg/plugin/javascript/dashboard_list_test.go
+++ b/pkg/plugin/javascript/dashboard_list_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/vmware-tanzu/octant/internal/octant"
 	"github.com/vmware-tanzu/octant/internal/octant/fake"
 	"github.com/vmware-tanzu/octant/internal/testutil"
+	"github.com/vmware-tanzu/octant/pkg/plugin/api"
 	"github.com/vmware-tanzu/octant/pkg/store"
 	fake2 "github.com/vmware-tanzu/octant/pkg/store/fake"
 )
@@ -70,10 +71,10 @@ func TestDashboardList_Call(t *testing.T) {
 			ctorArgs: ctorArgs{
 				storage: func(ctx context.Context, ctrl *gomock.Controller) octant.Storage {
 					objectStore := fake2.NewMockStore(ctrl)
-					ctx = context.WithValue(ctx, DashboardMetadataKey("foo"), "baz")
-					ctx = context.WithValue(ctx, DashboardMetadataKey("foo"), "bar")
-					ctx = context.WithValue(ctx, DashboardMetadataKey("qux"), "quuux")
-					ctx = context.WithValue(ctx, DashboardMetadataKey("qux"), "quux")
+					ctx = context.WithValue(ctx, api.DashboardMetadataKey("foo"), "baz")
+					ctx = context.WithValue(ctx, api.DashboardMetadataKey("foo"), "bar")
+					ctx = context.WithValue(ctx, api.DashboardMetadataKey("qux"), "quuux")
+					ctx = context.WithValue(ctx, api.DashboardMetadataKey("qux"), "quux")
 
 					objectStore.EXPECT().
 						List(ContextType, store.Key{
@@ -83,8 +84,8 @@ func TestDashboardList_Call(t *testing.T) {
 						}).
 						Return(testutil.ToUnstructuredList(t, testutil.CreatePod("pod")), false, nil).
 						Do(func(c context.Context, _ store.Key) {
-							require.Equal(t, "bar", c.Value(DashboardMetadataKey("foo")))
-							require.Equal(t, "quux", c.Value(DashboardMetadataKey("qux")))
+							require.Equal(t, "bar", c.Value(api.DashboardMetadataKey("foo")))
+							require.Equal(t, "quux", c.Value(api.DashboardMetadataKey("qux")))
 						})
 
 					storage := fake.NewMockStorage(ctrl)

--- a/pkg/plugin/javascript/dashboard_list_test.go
+++ b/pkg/plugin/javascript/dashboard_list_test.go
@@ -47,6 +47,7 @@ func TestDashboardList_Call(t *testing.T) {
 			name: "in general",
 			ctorArgs: ctorArgs{
 				storage: func(ctx context.Context, ctrl *gomock.Controller) octant.Storage {
+					ctx = context.WithValue(ctx, "accessToken", "secret")
 					objectStore := fake2.NewMockStore(ctrl)
 					objectStore.EXPECT().
 						List(ctx, store.Key{
@@ -61,7 +62,7 @@ func TestDashboardList_Call(t *testing.T) {
 					return storage
 				},
 			},
-			call: `dashClient.List({namespace:'test', apiVersion: 'v1', kind:'Pod'})`,
+			call: `dashClient.List({namespace:'test', apiVersion: 'v1', kind:'Pod'},{"accessToken": "secret"})`,
 		},
 		{
 			name: "list fails",

--- a/pkg/plugin/javascript/dashboard_update.go
+++ b/pkg/plugin/javascript/dashboard_update.go
@@ -46,15 +46,7 @@ func (d *DashboardUpdate) Call(ctx context.Context, vm *goja.Runtime) func(c goj
 
 		metadataArg := c.Argument(2)
 		if !goja.IsUndefined(metadataArg) {
-			var metadata map[string]string
-			metadataObj := metadataArg.ToObject(vm)
-
-			// This will not error as js plugins restrict this type
-			// and we handle both cases
-			_ = vm.ExportTo(metadataObj, &metadata)
-			for k, val := range metadata {
-				newCtx = context.WithValue(newCtx, DashboardMetadataKey(k), val)
-			}
+			newCtx = setObjectStoreContext(newCtx, metadataArg, vm)
 		}
 
 		results, err := d.storage.ObjectStore().CreateOrUpdateFromYAML(newCtx, namespace, update)

--- a/pkg/plugin/javascript/dashboard_update.go
+++ b/pkg/plugin/javascript/dashboard_update.go
@@ -41,6 +41,16 @@ func (d *DashboardUpdate) Call(ctx context.Context, vm *goja.Runtime) func(c goj
 		namespace := c.Argument(0).String()
 		update := c.Argument(1).String()
 
+		if len(c.Arguments) > 2 {
+			var metadata map[string]interface{}
+			metadataObj := c.Argument(2).ToObject(vm)
+
+			_ = vm.ExportTo(metadataObj, &metadata)
+			for key, val := range metadata {
+				ctx = context.WithValue(ctx, key, val)
+			}
+		}
+
 		results, err := d.storage.ObjectStore().CreateOrUpdateFromYAML(ctx, namespace, update)
 		if err != nil {
 			panic(panicMessage(vm, err, ""))

--- a/pkg/plugin/javascript/dashboard_update_test.go
+++ b/pkg/plugin/javascript/dashboard_update_test.go
@@ -45,6 +45,7 @@ func TestDashboardUpdate_Call(t *testing.T) {
 			name: "in general",
 			ctorArgs: ctorArgs{
 				storage: func(ctx context.Context, ctrl *gomock.Controller) octant.Storage {
+					ctx = context.WithValue(ctx, "accessToken", "secret")
 					objectStore := fake2.NewMockStore(ctrl)
 					objectStore.EXPECT().
 						CreateOrUpdateFromYAML(ctx, "test", "create-yaml").
@@ -55,7 +56,7 @@ func TestDashboardUpdate_Call(t *testing.T) {
 					return storage
 				},
 			},
-			call: `dashClient.Update('test', 'create-yaml')`,
+			call: `dashClient.Update('test', 'create-yaml',{"accessToken": "secret"})`,
 		},
 		{
 			name: "create fails",

--- a/pkg/plugin/javascript/dashboard_update_test.go
+++ b/pkg/plugin/javascript/dashboard_update_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/vmware-tanzu/octant/internal/octant"
 	"github.com/vmware-tanzu/octant/internal/octant/fake"
+	"github.com/vmware-tanzu/octant/pkg/plugin/api"
 	fake2 "github.com/vmware-tanzu/octant/pkg/store/fake"
 )
 
@@ -63,17 +64,17 @@ func TestDashboardUpdate_Call(t *testing.T) {
 			ctorArgs: ctorArgs{
 				storage: func(ctx context.Context, ctrl *gomock.Controller) octant.Storage {
 					objectStore := fake2.NewMockStore(ctrl)
-					ctx = context.WithValue(ctx, DashboardMetadataKey("foo"), "baz")
-					ctx = context.WithValue(ctx, DashboardMetadataKey("foo"), "bar")
-					ctx = context.WithValue(ctx, DashboardMetadataKey("qux"), "quuux")
-					ctx = context.WithValue(ctx, DashboardMetadataKey("qux"), "quux")
+					ctx = context.WithValue(ctx, api.DashboardMetadataKey("foo"), "baz")
+					ctx = context.WithValue(ctx, api.DashboardMetadataKey("foo"), "bar")
+					ctx = context.WithValue(ctx, api.DashboardMetadataKey("qux"), "quuux")
+					ctx = context.WithValue(ctx, api.DashboardMetadataKey("qux"), "quux")
 
 					objectStore.EXPECT().
 						CreateOrUpdateFromYAML(ContextType, "test", "create-yaml").
 						Return([]string{"test"}, nil).
 						Do(func(c context.Context, _, _ string) {
-							require.Equal(t, "bar", c.Value(DashboardMetadataKey("foo")))
-							require.Equal(t, "quux", c.Value(DashboardMetadataKey("qux")))
+							require.Equal(t, "bar", c.Value(api.DashboardMetadataKey("foo")))
+							require.Equal(t, "quux", c.Value(api.DashboardMetadataKey("qux")))
 						})
 
 					storage := fake.NewMockStorage(ctrl)

--- a/pkg/plugin/javascript/dashboard_update_test.go
+++ b/pkg/plugin/javascript/dashboard_update_test.go
@@ -46,6 +46,23 @@ func TestDashboardUpdate_Call(t *testing.T) {
 			ctorArgs: ctorArgs{
 				storage: func(ctx context.Context, ctrl *gomock.Controller) octant.Storage {
 					objectStore := fake2.NewMockStore(ctrl)
+
+					objectStore.EXPECT().
+						CreateOrUpdateFromYAML(ContextType, "test", "create-yaml").
+						Return([]string{"test"}, nil)
+
+					storage := fake.NewMockStorage(ctrl)
+					storage.EXPECT().ObjectStore().Return(objectStore).AnyTimes()
+					return storage
+				},
+			},
+			call: `dashClient.Update('test', 'create-yaml')`,
+		},
+		{
+			name: "with arbitrary metadata",
+			ctorArgs: ctorArgs{
+				storage: func(ctx context.Context, ctrl *gomock.Controller) octant.Storage {
+					objectStore := fake2.NewMockStore(ctrl)
 					ctx = context.WithValue(ctx, DashboardMetadataKey("foo"), "baz")
 					ctx = context.WithValue(ctx, DashboardMetadataKey("foo"), "bar")
 					ctx = context.WithValue(ctx, DashboardMetadataKey("qux"), "quuux")

--- a/pkg/plugin/javascript/helpers_test.go
+++ b/pkg/plugin/javascript/helpers_test.go
@@ -7,6 +7,7 @@ package javascript
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
@@ -17,6 +18,8 @@ import (
 	"github.com/vmware-tanzu/octant/internal/octant"
 	"github.com/vmware-tanzu/octant/internal/octant/fake"
 )
+
+var ContextType gomock.Matcher = gomock.AssignableToTypeOf(reflect.TypeOf((*context.Context)(nil)).Elem())
 
 type functionRunner struct {
 	wantErr bool

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -20,6 +20,9 @@ var (
 	}
 )
 
+// DashboardMetadataKey is a type used for metadata keys passed by plugins
+type DashboardMetadataKey string
+
 // ServicePlugin is the GRPC plugin for Service.
 type ServicePlugin struct {
 	plugin.NetRPCUnsupportedPlugin


### PR DESCRIPTION
**What this PR does / why we need it**:
It allows octant to extract out contextual data sent by the Go plugins. This data is intended to be used by object stores.

**Which issue(s) this PR fixes**
- Fixes #2042

https://github.com/vmware-tanzu/octant/pull/2099
