### PR TITLE
Fixed problem with jsoniter sorting

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -13,8 +13,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	"github.com/gorilla/mux"
-	jsoniter "github.com/json-iterator/go"
+
 	"github.com/spf13/viper"
 
 	"github.com/vmware-tanzu/octant/internal/config"
@@ -24,8 +26,6 @@ import (
 )
 
 //go:generate mockgen -destination=./fake/mock_service.go -package=fake github.com/vmware-tanzu/octant/internal/api Service
-
-var json = jsoniter.ConfigFastest
 
 const (
 	// ListenerAddrKey is the environment variable for the Octant listener address.

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -16,7 +16,6 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -31,8 +30,6 @@ import (
 	"github.com/vmware-tanzu/octant/pkg/navigation"
 	"github.com/vmware-tanzu/octant/pkg/view/component"
 )
-
-var json = jsoniter.ConfigFastest
 
 func TestAPI_routes(t *testing.T) {
 	cases := []struct {

--- a/internal/api/breadcrumb_test.go
+++ b/internal/api/breadcrumb_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/vmware-tanzu/octant/internal/api"
+	"github.com/vmware-tanzu/octant/internal/util/json"
 	"github.com/vmware-tanzu/octant/pkg/navigation"
 )
 

--- a/internal/api/content_manager.go
+++ b/internal/api/content_manager.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	"github.com/vmware-tanzu/octant/internal/config"
 	ocontext "github.com/vmware-tanzu/octant/internal/context"
 	oevent "github.com/vmware-tanzu/octant/pkg/event"

--- a/internal/api/context_manager.go
+++ b/internal/api/context_manager.go
@@ -9,6 +9,8 @@ import (
 	"bytes"
 	"context"
 
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	oevent "github.com/vmware-tanzu/octant/pkg/event"
 
 	"github.com/pkg/errors"

--- a/internal/api/helper_manager.go
+++ b/internal/api/helper_manager.go
@@ -9,6 +9,8 @@ import (
 	"bytes"
 	"context"
 
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	oevent "github.com/vmware-tanzu/octant/pkg/event"
 
 	"github.com/vmware-tanzu/octant/internal/config"

--- a/internal/api/namespaces_manager.go
+++ b/internal/api/namespaces_manager.go
@@ -9,6 +9,8 @@ import (
 	"bytes"
 	"context"
 
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	"github.com/pkg/errors"
 
 	"github.com/vmware-tanzu/octant/internal/cluster"

--- a/internal/api/navigation_manager.go
+++ b/internal/api/navigation_manager.go
@@ -11,6 +11,8 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	oevent "github.com/vmware-tanzu/octant/pkg/event"
 
 	"github.com/pkg/errors"

--- a/internal/api/websocket_client.go
+++ b/internal/api/websocket_client.go
@@ -11,6 +11,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	"github.com/vmware-tanzu/octant/pkg/event"
 
 	"github.com/google/uuid"

--- a/internal/describer/describer_test.go
+++ b/internal/describer/describer_test.go
@@ -8,12 +8,10 @@ package describer
 import (
 	corev1 "k8s.io/api/core/v1"
 
-	jsoniter "github.com/json-iterator/go"
+	"github.com/vmware-tanzu/octant/internal/util/json"
 
 	"github.com/vmware-tanzu/octant/pkg/view/component"
 )
-
-var json = jsoniter.ConfigFastest
 
 type emptyComponent struct{}
 

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -10,8 +10,9 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/require"
+
+	"github.com/vmware-tanzu/octant/internal/util/json"
 
 	clusterFake "github.com/vmware-tanzu/octant/internal/cluster/fake"
 	configFake "github.com/vmware-tanzu/octant/internal/config/fake"
@@ -19,8 +20,6 @@ import (
 	objectStoreFake "github.com/vmware-tanzu/octant/pkg/store/fake"
 	"github.com/vmware-tanzu/octant/pkg/view/component"
 )
-
-var json = jsoniter.ConfigFastest
 
 func Test_realGenerator_Generate(t *testing.T) {
 	textOther := component.NewText("other")

--- a/internal/modules/localcontent/localcontent.go
+++ b/internal/modules/localcontent/localcontent.go
@@ -14,18 +14,17 @@ import (
 	"path/filepath"
 	"strings"
 
-	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/vmware-tanzu/octant/internal/util/json"
 
 	"github.com/vmware-tanzu/octant/internal/module"
 	"github.com/vmware-tanzu/octant/internal/octant"
 	"github.com/vmware-tanzu/octant/pkg/navigation"
 	"github.com/vmware-tanzu/octant/pkg/view/component"
 )
-
-var json = jsoniter.ConfigFastest
 
 type LocalContent struct {
 	root string

--- a/internal/modules/overview/portforward.go
+++ b/internal/modules/overview/portforward.go
@@ -13,7 +13,7 @@ import (
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	jsoniter "github.com/json-iterator/go"
+	"github.com/vmware-tanzu/octant/internal/util/json"
 
 	"github.com/vmware-tanzu/octant/internal/api"
 	internalLog "github.com/vmware-tanzu/octant/internal/log"
@@ -21,8 +21,6 @@ import (
 	"github.com/vmware-tanzu/octant/internal/portforward"
 	"github.com/vmware-tanzu/octant/pkg/log"
 )
-
-var json = jsoniter.ConfigFastest
 
 type portForwardCreateRequest struct {
 	APIVersion string `json:"apiVersion,omitempty"`

--- a/internal/octant/container_editor.go
+++ b/internal/octant/container_editor.go
@@ -9,6 +9,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 

--- a/internal/octant/cordon.go
+++ b/internal/octant/cordon.go
@@ -9,6 +9,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	"github.com/pkg/errors"
 
 	corev1 "k8s.io/api/core/v1"

--- a/internal/octant/object.go
+++ b/internal/octant/object.go
@@ -1,5 +1,1 @@
 package octant
-
-import jsoniter "github.com/json-iterator/go"
-
-var json = jsoniter.ConfigFastest

--- a/internal/printer/container.go
+++ b/internal/printer/container.go
@@ -9,6 +9,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	"github.com/vmware-tanzu/octant/internal/log"
 	"github.com/vmware-tanzu/octant/internal/util/kubernetes"
 

--- a/internal/printer/horizontalpodautoscaler.go
+++ b/internal/printer/horizontalpodautoscaler.go
@@ -11,6 +11,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	"github.com/pkg/errors"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"

--- a/internal/printer/networkpolicy.go
+++ b/internal/printer/networkpolicy.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -11,8 +11,6 @@ import (
 	"reflect"
 	"strings"
 
-	jsoniter "github.com/json-iterator/go"
-
 	"github.com/vmware-tanzu/octant/internal/config"
 	"github.com/vmware-tanzu/octant/internal/link"
 
@@ -23,8 +21,6 @@ import (
 
 	"github.com/vmware-tanzu/octant/pkg/view/component"
 )
-
-var json = jsoniter.ConfigFastest
 
 //go:generate mockgen -destination=./fake/mock_printer.go -package=fake github.com/vmware-tanzu/octant/internal/printer Printer
 

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -9,6 +9,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	"github.com/golang/mock/gomock"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"

--- a/internal/printer/volume.go
+++ b/internal/printer/volume.go
@@ -6,6 +6,8 @@ SPDX-License-Identifier: Apache-2.0
 package printer
 
 import (
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/vmware-tanzu/octant/pkg/view/component"

--- a/internal/testutil/assert.go
+++ b/internal/testutil/assert.go
@@ -3,12 +3,11 @@ package testutil
 import (
 	"testing"
 
-	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-)
 
-var json = jsoniter.ConfigFastest
+	"github.com/vmware-tanzu/octant/internal/util/json"
+)
 
 // AssertJSONEqual asserts two object's generated JSON is equal.
 func AssertJSONEqual(t *testing.T, expected, actual interface{}) {

--- a/internal/util/json/json.go
+++ b/internal/util/json/json.go
@@ -1,0 +1,22 @@
+/*
+Copyright (c) 2021 the Octant contributors. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package json
+
+import jsoniter "github.com/json-iterator/go"
+
+// Globally configure jsoniter to use fastest configuration together with sorting
+var jsonConfig = jsoniter.Config{
+	EscapeHTML:                    false,
+	MarshalFloatWith6Digits:       true,
+	ObjectFieldMustBeSimpleString: true,
+	SortMapKeys:                   true,
+}.Froze()
+
+var NewEncoder = jsonConfig.NewEncoder
+var NewDecoder = jsonConfig.NewDecoder
+var Unmarshal = jsonConfig.Unmarshal
+var Marshal = jsonConfig.Marshal
+var MarshalIndent = jsonConfig.MarshalIndent

--- a/internal/util/json/json_test.go
+++ b/internal/util/json/json_test.go
@@ -1,0 +1,20 @@
+package json
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_JSON_ConversionSortsProperly(t *testing.T) {
+	input := map[string]interface{}{
+		"a": 5,
+		"c": "test",
+		"d": true,
+		"b": 95.5,
+	}
+	output, err := Marshal(input)
+	require.NoError(t, err)
+
+	require.Equal(t, `{"a":5,"b":95.5,"c":"test","d":true}`, string(output))
+}

--- a/pkg/action/actions.go
+++ b/pkg/action/actions.go
@@ -5,10 +5,6 @@ SPDX-License-Identifier: Apache-2.0
 
 package action
 
-import jsoniter "github.com/json-iterator/go"
-
-var json = jsoniter.ConfigFastest
-
 const (
 	// RequestSetNamespace is the action for when the current namespace in Octant changes.
 	// The ActionRequest.Payload for this action contains a single string entry `namespace` with a value

--- a/pkg/action/payload.go
+++ b/pkg/action/payload.go
@@ -10,6 +10,8 @@ import (
 	"math"
 	"strconv"
 
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/dash/dash_test.go
+++ b/pkg/dash/dash_test.go
@@ -24,11 +24,12 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/gorilla/websocket"
-	jsoniter "github.com/json-iterator/go"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/vmware-tanzu/octant/internal/util/json"
 
 	"github.com/vmware-tanzu/octant/internal/cluster"
 	internalLog "github.com/vmware-tanzu/octant/internal/log"
@@ -37,8 +38,6 @@ import (
 	clusterFake "github.com/vmware-tanzu/octant/internal/cluster/fake"
 	"github.com/vmware-tanzu/octant/pkg/log"
 )
-
-var json = jsoniter.ConfigFastest
 
 func TestRunner_ValidateKubeconfig(t *testing.T) {
 	fs := afero.NewMemMapFs()

--- a/pkg/navigation/navigation.go
+++ b/pkg/navigation/navigation.go
@@ -11,7 +11,7 @@ import (
 	"path"
 	"sort"
 
-	jsoniter "github.com/json-iterator/go"
+	"github.com/vmware-tanzu/octant/internal/util/json"
 
 	"github.com/pkg/errors"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -23,8 +23,6 @@ import (
 	"github.com/vmware-tanzu/octant/pkg/icon"
 	"github.com/vmware-tanzu/octant/pkg/store"
 )
-
-var json = jsoniter.ConfigFastest
 
 // Option is an option for configuring navigation.
 type Option func(*Navigation) error

--- a/pkg/plugin/api/api_test.go
+++ b/pkg/plugin/api/api_test.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	jsoniter "github.com/json-iterator/go"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -25,8 +24,6 @@ import (
 	"github.com/vmware-tanzu/octant/pkg/store"
 	storeFake "github.com/vmware-tanzu/octant/pkg/store/fake"
 )
-
-var json = jsoniter.ConfigFastest
 
 type apiMocks struct {
 	objectStore *storeFake.MockStore

--- a/pkg/plugin/api/client_test.go
+++ b/pkg/plugin/api/client_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/vmware-tanzu/octant/internal/testutil"
+	"github.com/vmware-tanzu/octant/internal/util/json"
 	"github.com/vmware-tanzu/octant/pkg/plugin/api"
 	"github.com/vmware-tanzu/octant/pkg/plugin/api/fake"
 	"github.com/vmware-tanzu/octant/pkg/plugin/api/proto"

--- a/pkg/plugin/api/conversion.go
+++ b/pkg/plugin/api/conversion.go
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 package api
 
 import (
-	jsoniter "github.com/json-iterator/go"
+	"github.com/vmware-tanzu/octant/internal/util/json"
 
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/wrappers"
@@ -19,8 +19,6 @@ import (
 	"github.com/vmware-tanzu/octant/pkg/plugin/api/proto"
 	"github.com/vmware-tanzu/octant/pkg/store"
 )
-
-var json = jsoniter.ConfigFastest
 
 func convertFromKey(in store.Key) (*proto.KeyRequest, error) {
 	keyRequest := proto.KeyRequest{

--- a/pkg/plugin/conversion.go
+++ b/pkg/plugin/conversion.go
@@ -6,6 +6,8 @@ SPDX-License-Identifier: Apache-2.0
 package plugin
 
 import (
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/vmware-tanzu/octant/pkg/navigation"

--- a/pkg/plugin/grpc.go
+++ b/pkg/plugin/grpc.go
@@ -8,6 +8,8 @@ package plugin
 import (
 	"context"
 
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	"github.com/davecgh/go-spew/spew"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"

--- a/pkg/plugin/grpc_test.go
+++ b/pkg/plugin/grpc_test.go
@@ -11,13 +11,14 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/vmware-tanzu/octant/internal/util/json"
 
 	"github.com/vmware-tanzu/octant/internal/testutil"
 	"github.com/vmware-tanzu/octant/pkg/navigation"
@@ -27,8 +28,6 @@ import (
 	"github.com/vmware-tanzu/octant/pkg/view/component"
 	"github.com/vmware-tanzu/octant/pkg/view/flexlayout"
 )
-
-var json = jsoniter.ConfigFastest
 
 type grpcClientMocks struct {
 	broker      *fake.MockBroker

--- a/pkg/plugin/javascript.go
+++ b/pkg/plugin/javascript.go
@@ -12,6 +12,8 @@ import (
 	"path"
 	"sync"
 
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	ocontext "github.com/vmware-tanzu/octant/internal/context"
 
 	"github.com/dop251/goja"

--- a/pkg/plugin/javascript/conversion.go
+++ b/pkg/plugin/javascript/conversion.go
@@ -10,12 +10,10 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	jsoniter "github.com/json-iterator/go"
+	"github.com/vmware-tanzu/octant/internal/util/json"
 
 	"github.com/vmware-tanzu/octant/pkg/view/component"
 )
-
-var json = jsoniter.ConfigFastest
 
 // ConvertToComponent attempts to convert interface i to a Component.
 func ConvertToComponent(name string, i interface{}) (component.Component, error) {

--- a/pkg/plugin/javascript/httpclient.go
+++ b/pkg/plugin/javascript/httpclient.go
@@ -12,6 +12,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	"github.com/dop251/goja"
 )
 

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -9,13 +9,10 @@ import (
 	"context"
 
 	"github.com/hashicorp/go-plugin"
-	jsoniter "github.com/json-iterator/go"
 	"google.golang.org/grpc"
 
 	"github.com/vmware-tanzu/octant/pkg/plugin/dashboard"
 )
-
-var json = jsoniter.ConfigFastest
 
 var (
 	pluginMap = map[string]plugin.Plugin{

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
-	jsoniter "github.com/json-iterator/go"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -21,11 +20,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/cache"
 
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	"github.com/vmware-tanzu/octant/internal/cluster"
 	"github.com/vmware-tanzu/octant/pkg/action"
 )
-
-var json = jsoniter.ConfigFastest
 
 //go:generate mockgen  -destination=./fake/mock_store.go -package=fake github.com/vmware-tanzu/octant/pkg/store Store
 

--- a/pkg/view/component/annotations.go
+++ b/pkg/view/component/annotations.go
@@ -5,6 +5,8 @@ SPDX-License-Identifier: Apache-2.0
 
 package component
 
+import "github.com/vmware-tanzu/octant/internal/util/json"
+
 // Annotations is a component representing key/value based annotations
 //
 // +octant:component

--- a/pkg/view/component/annotations_test.go
+++ b/pkg/view/component/annotations_test.go
@@ -10,14 +10,13 @@ import (
 	"path/filepath"
 	"testing"
 
-	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	"github.com/vmware-tanzu/octant/pkg/view/component"
 )
-
-var json = jsoniter.ConfigFastest
 
 func Test_Annotations_Marshal(t *testing.T) {
 	cases := []struct {

--- a/pkg/view/component/button.go
+++ b/pkg/view/component/button.go
@@ -1,6 +1,8 @@
 package component
 
 import (
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	"github.com/pkg/errors"
 
 	"github.com/vmware-tanzu/octant/pkg/action"

--- a/pkg/view/component/button_test.go
+++ b/pkg/view/component/button_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/view/component/card.go
+++ b/pkg/view/component/card.go
@@ -1,6 +1,8 @@
 package component
 
 import (
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	"github.com/pkg/errors"
 )
 

--- a/pkg/view/component/code.go
+++ b/pkg/view/component/code.go
@@ -5,6 +5,8 @@ SPDX-License-Identifier: Apache-2.0
 
 package component
 
+import "github.com/vmware-tanzu/octant/internal/util/json"
+
 // Value is a component for code
 //
 // +octant:component

--- a/pkg/view/component/code_test.go
+++ b/pkg/view/component/code_test.go
@@ -8,6 +8,8 @@ package component
 import (
 	"testing"
 
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/view/component/component.go
+++ b/pkg/view/component/component.go
@@ -9,10 +9,10 @@ import (
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	"github.com/vmware-tanzu/octant/pkg/action"
 )
-
-var json = jsoniter.ConfigFastest
 
 // EmptyContentResponse is an empty content response.
 var EmptyContentResponse = ContentResponse{}

--- a/pkg/view/component/container.go
+++ b/pkg/view/component/container.go
@@ -5,6 +5,8 @@ SPDX-License-Identifier: Apache-2.0
 
 package component
 
+import "github.com/vmware-tanzu/octant/internal/util/json"
+
 // Containers is a component wrapping multiple docker container definitions
 //
 // +octant:component

--- a/pkg/view/component/container_test.go
+++ b/pkg/view/component/container_test.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/view/component/donut_chart.go
+++ b/pkg/view/component/donut_chart.go
@@ -5,6 +5,8 @@
 
 package component
 
+import "github.com/vmware-tanzu/octant/internal/util/json"
+
 type DonutChartSize int
 
 const (

--- a/pkg/view/component/dropdown.go
+++ b/pkg/view/component/dropdown.go
@@ -5,6 +5,8 @@ SPDX-License-Identifier: Apache-2.0
 
 package component
 
+import "github.com/vmware-tanzu/octant/internal/util/json"
+
 // DropdownType defines what the dropdown source is (UI component that's visible when dropdown is closed)
 //
 type DropdownType string

--- a/pkg/view/component/dropdown_test.go
+++ b/pkg/view/component/dropdown_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/view/component/editor.go
+++ b/pkg/view/component/editor.go
@@ -8,6 +8,8 @@ package component
 import (
 	"fmt"
 
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/vmware-tanzu/octant/internal/util/kubernetes"

--- a/pkg/view/component/error.go
+++ b/pkg/view/component/error.go
@@ -7,6 +7,8 @@ package component
 
 import (
 	"fmt"
+
+	"github.com/vmware-tanzu/octant/internal/util/json"
 )
 
 // Error is a component for freetext

--- a/pkg/view/component/expression_selector.go
+++ b/pkg/view/component/expression_selector.go
@@ -6,6 +6,8 @@ SPDX-License-Identifier: Apache-2.0
 package component
 
 import (
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	"github.com/pkg/errors"
 )
 

--- a/pkg/view/component/extension.go
+++ b/pkg/view/component/extension.go
@@ -1,6 +1,8 @@
 package component
 
 import (
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	"github.com/vmware-tanzu/octant/pkg/action"
 )
 

--- a/pkg/view/component/flexlayout.go
+++ b/pkg/view/component/flexlayout.go
@@ -7,6 +7,8 @@ package component
 
 import (
 	"errors"
+
+	"github.com/vmware-tanzu/octant/internal/util/json"
 )
 
 const (

--- a/pkg/view/component/form.go
+++ b/pkg/view/component/form.go
@@ -6,6 +6,8 @@ SPDX-License-Identifier: Apache-2.0
 package component
 
 import (
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/pkg/view/component/form_test.go
+++ b/pkg/view/component/form_test.go
@@ -3,6 +3,8 @@ package component
 import (
 	"testing"
 
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/pkg/view/component/graphviz.go
+++ b/pkg/view/component/graphviz.go
@@ -5,6 +5,8 @@ SPDX-License-Identifier: Apache-2.0
 
 package component
 
+import "github.com/vmware-tanzu/octant/internal/util/json"
+
 // GraphvizConfig is the contents of Graphviz.
 type GraphvizConfig struct {
 	DOT string `json:"dot,omitempty"`

--- a/pkg/view/component/grid_actions.go
+++ b/pkg/view/component/grid_actions.go
@@ -7,6 +7,8 @@
 package component
 
 import (
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	"github.com/vmware-tanzu/octant/pkg/action"
 )
 

--- a/pkg/view/component/iframe.go
+++ b/pkg/view/component/iframe.go
@@ -5,6 +5,8 @@ SPDX-License-Identifier: Apache-2.0
 
 package component
 
+import "github.com/vmware-tanzu/octant/internal/util/json"
+
 // IFrame is a component for displaying content in an iframe
 //
 // +octant:component

--- a/pkg/view/component/label_selector.go
+++ b/pkg/view/component/label_selector.go
@@ -5,6 +5,8 @@ SPDX-License-Identifier: Apache-2.0
 
 package component
 
+import "github.com/vmware-tanzu/octant/internal/util/json"
+
 // LabelSelectorConfig is the contents of LabelSelector
 type LabelSelectorConfig struct {
 	Key   string `json:"key"`

--- a/pkg/view/component/label_test.go
+++ b/pkg/view/component/label_test.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/pkg/view/component/labels.go
+++ b/pkg/view/component/labels.go
@@ -5,6 +5,8 @@ SPDX-License-Identifier: Apache-2.0
 
 package component
 
+import "github.com/vmware-tanzu/octant/internal/util/json"
+
 var labelsFilteredKeys = []string{
 	"controller-revision-hash",
 	"controller-uid",

--- a/pkg/view/component/link.go
+++ b/pkg/view/component/link.go
@@ -5,6 +5,8 @@ SPDX-License-Identifier: Apache-2.0
 
 package component
 
+import "github.com/vmware-tanzu/octant/internal/util/json"
+
 // Link is a text component that contains a link.
 //
 // +octant:component

--- a/pkg/view/component/link_test.go
+++ b/pkg/view/component/link_test.go
@@ -8,6 +8,8 @@ package component
 import (
 	"testing"
 
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/view/component/list.go
+++ b/pkg/view/component/list.go
@@ -5,6 +5,8 @@ SPDX-License-Identifier: Apache-2.0
 
 package component
 
+import "github.com/vmware-tanzu/octant/internal/util/json"
+
 // List contains other Components
 //
 // +octant:component

--- a/pkg/view/component/list_test.go
+++ b/pkg/view/component/list_test.go
@@ -10,6 +10,8 @@ import (
 	"path"
 	"testing"
 
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/view/component/loading.go
+++ b/pkg/view/component/loading.go
@@ -5,6 +5,8 @@ SPDX-License-Identifier: Apache-2.0
 
 package component
 
+import "github.com/vmware-tanzu/octant/internal/util/json"
+
 // Loading is a component for a spinner
 //
 // +octant:component

--- a/pkg/view/component/logs.go
+++ b/pkg/view/component/logs.go
@@ -5,6 +5,8 @@ SPDX-License-Identifier: Apache-2.0
 
 package component
 
+import "github.com/vmware-tanzu/octant/internal/util/json"
+
 var defaultDurations = []Since{
 	{"5 minutes", 300},
 	{"10 minutes", 600},

--- a/pkg/view/component/logs_test.go
+++ b/pkg/view/component/logs_test.go
@@ -10,6 +10,8 @@ import (
 	"path"
 	"testing"
 
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/view/component/modal.go
+++ b/pkg/view/component/modal.go
@@ -1,5 +1,7 @@
 package component
 
+import "github.com/vmware-tanzu/octant/internal/util/json"
+
 type ModalSize string
 
 const (

--- a/pkg/view/component/pod_status.go
+++ b/pkg/view/component/pod_status.go
@@ -5,6 +5,8 @@ SPDX-License-Identifier: Apache-2.0
 
 package component
 
+import "github.com/vmware-tanzu/octant/internal/util/json"
+
 // PodSummary is a status summary for a pod.
 type PodSummary struct {
 	Details []Component `json:"details,omitempty"`

--- a/pkg/view/component/pod_status_test.go
+++ b/pkg/view/component/pod_status_test.go
@@ -11,6 +11,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/view/component/port.go
+++ b/pkg/view/component/port.go
@@ -6,6 +6,8 @@ SPDX-License-Identifier: Apache-2.0
 package component
 
 import (
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	"github.com/vmware-tanzu/octant/pkg/action"
 )
 

--- a/pkg/view/component/quadrant.go
+++ b/pkg/view/component/quadrant.go
@@ -7,6 +7,8 @@ package component
 
 import (
 	"fmt"
+
+	"github.com/vmware-tanzu/octant/internal/util/json"
 )
 
 // QuadrantPosition denotes a position within a quadrant

--- a/pkg/view/component/resource_viewer.go
+++ b/pkg/view/component/resource_viewer.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	"github.com/pkg/errors"
 )
 

--- a/pkg/view/component/resource_viewer_test.go
+++ b/pkg/view/component/resource_viewer_test.go
@@ -10,6 +10,8 @@ import (
 	"path"
 	"testing"
 
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/view/component/selectors.go
+++ b/pkg/view/component/selectors.go
@@ -7,6 +7,8 @@ package component
 
 import (
 	"sort"
+
+	"github.com/vmware-tanzu/octant/internal/util/json"
 )
 
 // Selector identifies a Component as being a selector flavor.

--- a/pkg/view/component/selectors_test.go
+++ b/pkg/view/component/selectors_test.go
@@ -10,6 +10,8 @@ import (
 	"path"
 	"testing"
 
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/view/component/single_stat.go
+++ b/pkg/view/component/single_stat.go
@@ -5,6 +5,8 @@
 
 package component
 
+import "github.com/vmware-tanzu/octant/internal/util/json"
+
 type SingleStatValue struct {
 	Text  string `json:"text"`
 	Color string `json:"color"`

--- a/pkg/view/component/stepper.go
+++ b/pkg/view/component/stepper.go
@@ -5,6 +5,8 @@ SPDX-License-Identifier: Apache-2.0
 
 package component
 
+import "github.com/vmware-tanzu/octant/internal/util/json"
+
 // Stepper component implements json.Marshaler
 //
 // +octant:component

--- a/pkg/view/component/stepper_test.go
+++ b/pkg/view/component/stepper_test.go
@@ -5,6 +5,8 @@ import (
 	"path"
 	"testing"
 
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/view/component/summary.go
+++ b/pkg/view/component/summary.go
@@ -6,6 +6,8 @@ SPDX-License-Identifier: Apache-2.0
 package component
 
 import (
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	"github.com/vmware-tanzu/octant/internal/util/strings"
 )
 

--- a/pkg/view/component/summary_test.go
+++ b/pkg/view/component/summary_test.go
@@ -10,6 +10,8 @@ import (
 	"path"
 	"testing"
 
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/view/component/table.go
+++ b/pkg/view/component/table.go
@@ -10,6 +10,8 @@ import (
 	"sort"
 	"sync"
 
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	"github.com/davecgh/go-spew/spew"
 
 	"github.com/pkg/errors"

--- a/pkg/view/component/table_test.go
+++ b/pkg/view/component/table_test.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/view/component/terminal.go
+++ b/pkg/view/component/terminal.go
@@ -7,6 +7,8 @@ package component
 
 import (
 	"time"
+
+	"github.com/vmware-tanzu/octant/internal/util/json"
 )
 
 type TerminalDetails struct {

--- a/pkg/view/component/terminal_test.go
+++ b/pkg/view/component/terminal_test.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/view/component/testing.go
+++ b/pkg/view/component/testing.go
@@ -3,6 +3,8 @@ package component
 import (
 	"testing"
 
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/view/component/text.go
+++ b/pkg/view/component/text.go
@@ -7,6 +7,8 @@ package component
 
 import (
 	"fmt"
+
+	"github.com/vmware-tanzu/octant/internal/util/json"
 )
 
 // TextStatus is the status of a text component

--- a/pkg/view/component/text_test.go
+++ b/pkg/view/component/text_test.go
@@ -8,6 +8,8 @@ package component
 import (
 	"testing"
 
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/view/component/timestamp.go
+++ b/pkg/view/component/timestamp.go
@@ -7,6 +7,8 @@ package component
 
 import (
 	"time"
+
+	"github.com/vmware-tanzu/octant/internal/util/json"
 )
 
 // Timestamp is a component representing a point in time

--- a/pkg/view/component/timestamp_test.go
+++ b/pkg/view/component/timestamp_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/view/component/unmarshal.go
+++ b/pkg/view/component/unmarshal.go
@@ -6,6 +6,8 @@ SPDX-License-Identifier: Apache-2.0
 package component
 
 import (
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	"github.com/pkg/errors"
 )
 

--- a/pkg/view/component/yaml.go
+++ b/pkg/view/component/yaml.go
@@ -8,6 +8,8 @@ package component
 import (
 	"strings"
 
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	"github.com/pkg/errors"
 	"k8s.io/client-go/tools/clientcmd/api/latest"
 

--- a/pkg/view/component/yaml_test.go
+++ b/pkg/view/component/yaml_test.go
@@ -10,6 +10,8 @@ import (
 	"path"
 	"testing"
 
+	"github.com/vmware-tanzu/octant/internal/util/json"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"


### PR DESCRIPTION
- Refactored the `jsoniter` initialization code inside a single entry point in global utility package,
- Modified the `jsoniter` configuration to use combination of `ConfigFastest ` and `SortMapKeys ` flags,
- Verified that addressed both label and resource viewer issue from #2133,
- Added unit test to make sure json marshaling is properly sorting fields, 

Signed-off-by: Milan Klanjsek <mklanjsek@pivotal.io>

Fixes #2133 


