### PR TITLE
Extract store metadata sent by Go plugins

### DIFF
--- a/changelogs/unreleased/2140-xtreme-vikram-yadav
+++ b/changelogs/unreleased/2140-xtreme-vikram-yadav
@@ -1,0 +1,1 @@
+Add lookup for object store  metadata from Go plugins

--- a/pkg/plugin/javascript/dashboard_client.go
+++ b/pkg/plugin/javascript/dashboard_client.go
@@ -10,14 +10,12 @@ import (
 	"fmt"
 
 	"github.com/vmware-tanzu/octant/pkg/event"
+	"github.com/vmware-tanzu/octant/pkg/plugin/api"
 
 	"github.com/dop251/goja"
 
 	"github.com/vmware-tanzu/octant/internal/octant"
 )
-
-// DashboardMetadataKey is a type used for metadata keys passed by plugins
-type DashboardMetadataKey string
 
 // ModularDashboardClientFactory is a modular octant.DashboardClientFactory. It configures
 // itself based on functions passed when it is initialized.
@@ -85,7 +83,7 @@ func setObjectStoreContext(ctx context.Context, jsObj goja.Value, vm *goja.Runti
 	// and we handle the case of having undefined value
 	_ = vm.ExportTo(metadataObj, &metadata)
 	for k, val := range metadata {
-		ctx = context.WithValue(ctx, DashboardMetadataKey(k), val)
+		ctx = context.WithValue(ctx, api.DashboardMetadataKey(k), val)
 	}
 
 	return ctx

--- a/pkg/plugin/javascript/dashboard_delete_test.go
+++ b/pkg/plugin/javascript/dashboard_delete_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/vmware-tanzu/octant/pkg/plugin/api"
+
 	"github.com/vmware-tanzu/octant/internal/octant"
 	"github.com/vmware-tanzu/octant/internal/octant/fake"
 	"github.com/vmware-tanzu/octant/pkg/store"
@@ -69,10 +71,10 @@ func TestDashboardDelete_Call(t *testing.T) {
 			ctorArgs: ctorArgs{
 				storage: func(ctx context.Context, ctrl *gomock.Controller) octant.Storage {
 					objectStore := fake2.NewMockStore(ctrl)
-					ctx = context.WithValue(ctx, DashboardMetadataKey("foo"), "baz")
-					ctx = context.WithValue(ctx, DashboardMetadataKey("foo"), "bar")
-					ctx = context.WithValue(ctx, DashboardMetadataKey("qux"), "quuux")
-					ctx = context.WithValue(ctx, DashboardMetadataKey("qux"), "quux")
+					ctx = context.WithValue(ctx, api.DashboardMetadataKey("foo"), "baz")
+					ctx = context.WithValue(ctx, api.DashboardMetadataKey("foo"), "bar")
+					ctx = context.WithValue(ctx, api.DashboardMetadataKey("qux"), "quuux")
+					ctx = context.WithValue(ctx, api.DashboardMetadataKey("qux"), "quux")
 
 					objectStore.EXPECT().
 						Delete(ContextType, store.Key{
@@ -82,8 +84,8 @@ func TestDashboardDelete_Call(t *testing.T) {
 							Name:       "my-replica-set"}).
 						Return(nil).
 						Do(func(c context.Context, _ store.Key) {
-							require.Equal(t, "bar", c.Value(DashboardMetadataKey("foo")))
-							require.Equal(t, "quux", c.Value(DashboardMetadataKey("qux")))
+							require.Equal(t, "bar", c.Value(api.DashboardMetadataKey("foo")))
+							require.Equal(t, "quux", c.Value(api.DashboardMetadataKey("qux")))
 						})
 
 					storage := fake.NewMockStorage(ctrl)

--- a/pkg/plugin/javascript/dashboard_get_test.go
+++ b/pkg/plugin/javascript/dashboard_get_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/vmware-tanzu/octant/internal/octant"
 	"github.com/vmware-tanzu/octant/internal/octant/fake"
 	"github.com/vmware-tanzu/octant/internal/testutil"
+	"github.com/vmware-tanzu/octant/pkg/plugin/api"
 	"github.com/vmware-tanzu/octant/pkg/store"
 	fake2 "github.com/vmware-tanzu/octant/pkg/store/fake"
 )
@@ -70,10 +71,10 @@ func TestDashboardGet_Call(t *testing.T) {
 			ctorArgs: ctorArgs{
 				storage: func(ctx context.Context, ctrl *gomock.Controller) octant.Storage {
 					objectStore := fake2.NewMockStore(ctrl)
-					ctx = context.WithValue(ctx, DashboardMetadataKey("foo"), "baz")
-					ctx = context.WithValue(ctx, DashboardMetadataKey("foo"), "bar")
-					ctx = context.WithValue(ctx, DashboardMetadataKey("qux"), "quuux")
-					ctx = context.WithValue(ctx, DashboardMetadataKey("qux"), "quux")
+					ctx = context.WithValue(ctx, api.DashboardMetadataKey("foo"), "baz")
+					ctx = context.WithValue(ctx, api.DashboardMetadataKey("foo"), "bar")
+					ctx = context.WithValue(ctx, api.DashboardMetadataKey("qux"), "quuux")
+					ctx = context.WithValue(ctx, api.DashboardMetadataKey("qux"), "quux")
 
 					objectStore.EXPECT().
 						Get(ContextType, store.Key{
@@ -83,8 +84,8 @@ func TestDashboardGet_Call(t *testing.T) {
 							Name:       "pod"}).
 						Return(testutil.ToUnstructured(t, testutil.CreatePod("pod")), nil).
 						Do(func(c context.Context, _ store.Key) {
-							require.Equal(t, "bar", c.Value(DashboardMetadataKey("foo")))
-							require.Equal(t, "quux", c.Value(DashboardMetadataKey("qux")))
+							require.Equal(t, "bar", c.Value(api.DashboardMetadataKey("foo")))
+							require.Equal(t, "quux", c.Value(api.DashboardMetadataKey("qux")))
 						})
 
 					storage := fake.NewMockStorage(ctrl)

--- a/pkg/plugin/javascript/dashboard_list_test.go
+++ b/pkg/plugin/javascript/dashboard_list_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/vmware-tanzu/octant/internal/octant"
 	"github.com/vmware-tanzu/octant/internal/octant/fake"
 	"github.com/vmware-tanzu/octant/internal/testutil"
+	"github.com/vmware-tanzu/octant/pkg/plugin/api"
 	"github.com/vmware-tanzu/octant/pkg/store"
 	fake2 "github.com/vmware-tanzu/octant/pkg/store/fake"
 )
@@ -70,10 +71,10 @@ func TestDashboardList_Call(t *testing.T) {
 			ctorArgs: ctorArgs{
 				storage: func(ctx context.Context, ctrl *gomock.Controller) octant.Storage {
 					objectStore := fake2.NewMockStore(ctrl)
-					ctx = context.WithValue(ctx, DashboardMetadataKey("foo"), "baz")
-					ctx = context.WithValue(ctx, DashboardMetadataKey("foo"), "bar")
-					ctx = context.WithValue(ctx, DashboardMetadataKey("qux"), "quuux")
-					ctx = context.WithValue(ctx, DashboardMetadataKey("qux"), "quux")
+					ctx = context.WithValue(ctx, api.DashboardMetadataKey("foo"), "baz")
+					ctx = context.WithValue(ctx, api.DashboardMetadataKey("foo"), "bar")
+					ctx = context.WithValue(ctx, api.DashboardMetadataKey("qux"), "quuux")
+					ctx = context.WithValue(ctx, api.DashboardMetadataKey("qux"), "quux")
 
 					objectStore.EXPECT().
 						List(ContextType, store.Key{
@@ -83,8 +84,8 @@ func TestDashboardList_Call(t *testing.T) {
 						}).
 						Return(testutil.ToUnstructuredList(t, testutil.CreatePod("pod")), false, nil).
 						Do(func(c context.Context, _ store.Key) {
-							require.Equal(t, "bar", c.Value(DashboardMetadataKey("foo")))
-							require.Equal(t, "quux", c.Value(DashboardMetadataKey("qux")))
+							require.Equal(t, "bar", c.Value(api.DashboardMetadataKey("foo")))
+							require.Equal(t, "quux", c.Value(api.DashboardMetadataKey("qux")))
 						})
 
 					storage := fake.NewMockStorage(ctrl)

--- a/pkg/plugin/javascript/dashboard_update_test.go
+++ b/pkg/plugin/javascript/dashboard_update_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/vmware-tanzu/octant/internal/octant"
 	"github.com/vmware-tanzu/octant/internal/octant/fake"
+	"github.com/vmware-tanzu/octant/pkg/plugin/api"
 	fake2 "github.com/vmware-tanzu/octant/pkg/store/fake"
 )
 
@@ -63,17 +64,17 @@ func TestDashboardUpdate_Call(t *testing.T) {
 			ctorArgs: ctorArgs{
 				storage: func(ctx context.Context, ctrl *gomock.Controller) octant.Storage {
 					objectStore := fake2.NewMockStore(ctrl)
-					ctx = context.WithValue(ctx, DashboardMetadataKey("foo"), "baz")
-					ctx = context.WithValue(ctx, DashboardMetadataKey("foo"), "bar")
-					ctx = context.WithValue(ctx, DashboardMetadataKey("qux"), "quuux")
-					ctx = context.WithValue(ctx, DashboardMetadataKey("qux"), "quux")
+					ctx = context.WithValue(ctx, api.DashboardMetadataKey("foo"), "baz")
+					ctx = context.WithValue(ctx, api.DashboardMetadataKey("foo"), "bar")
+					ctx = context.WithValue(ctx, api.DashboardMetadataKey("qux"), "quuux")
+					ctx = context.WithValue(ctx, api.DashboardMetadataKey("qux"), "quux")
 
 					objectStore.EXPECT().
 						CreateOrUpdateFromYAML(ContextType, "test", "create-yaml").
 						Return([]string{"test"}, nil).
 						Do(func(c context.Context, _, _ string) {
-							require.Equal(t, "bar", c.Value(DashboardMetadataKey("foo")))
-							require.Equal(t, "quux", c.Value(DashboardMetadataKey("qux")))
+							require.Equal(t, "bar", c.Value(api.DashboardMetadataKey("foo")))
+							require.Equal(t, "quux", c.Value(api.DashboardMetadataKey("qux")))
 						})
 
 					storage := fake.NewMockStorage(ctrl)

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -20,6 +20,9 @@ var (
 	}
 )
 
+// DashboardMetadataKey is a type used for metadata keys passed by plugins
+type DashboardMetadataKey string
+
 // ServicePlugin is the GRPC plugin for Service.
 type ServicePlugin struct {
 	plugin.NetRPCUnsupportedPlugin

--- a/web/src/stories/docs/plugins/GoPluginsIntro.story.mdx
+++ b/web/src/stories/docs/plugins/GoPluginsIntro.story.mdx
@@ -283,3 +283,22 @@ This pod has both a Configuration and Status.
 ### Items
 
 A plugin with support for `PrinterItems` allow adding a `FlexLayoutItem` consisting of a width and a view component.
+
+## Custom Runtime
+
+### Custom object store
+
+For runtimes with custom object store implementations, Go plugins can pass arbitrary key/values when issuing calls to the object store.
+A plugin can set a grpc header with prefix `x-octant-` which will be consumed by the grpc server to set up random properties for the object store context.
+For example: To set a property named `foo` on the object store context, a plugin can set a grpc header named `x-octant-foo`.
+
+```go
+func handlePrint(request *service.PrintRequest) (plugin.PrintResponse, error) {
+  ...
+  key, err := store.KeyFromObject(request.Object)
+	if err != nil {
+		return plugin.PrintResponse{}, err
+	}
+  ctx = metadata.AppendToOutgoingContext(request.Context(), "x-octant-foo", "bar")
+  u, err := request.DashboardClient.Get(ctx, key)
+```


### PR DESCRIPTION
Signed-off-by: Vikram Yadav <yvikram@vmware.com>


**What this PR does / why we need it**: It allows octant to extract out contextual data sent by the Go plugins. This data is intended to be used by object stores.

- Fixes #2042

Related PR: #2099
