### PR TITLE
Fix url on docs page

### DIFF
--- a/site/_config.yml
+++ b/site/_config.yml
@@ -18,6 +18,7 @@ footer:
   content: To help you get started, see the documentation.
   cta_title:
   cta_url: /docs
+  cta_reference_url: https://reference.octant.dev/
   cta_text: Documentation
   vm-link: http://vmware.github.io/
 

--- a/site/_includes/footer.html
+++ b/site/_includes/footer.html
@@ -7,7 +7,11 @@
             </div>
             <div class="col-xs-12 col-sm-6 col-lg-3 offset-lg-1">
                 <p><strong>{{ site.footer.cta_title }}</strong></p>
+                {% if page.url == "/docs/" %}
+                <a href="{{ site.footer.cta_reference_url }}" class="btn btn-sm btn-primary btn-no-border">{{ site.footer.cta_text }}</a>
+                {% else %}
                 <a href="{{ site.footer.cta_url }}" class="btn btn-sm btn-primary btn-no-border">{{ site.footer.cta_text }}</a>
+                {% endif %}
             </div>
         </div>
     </div>


### PR DESCRIPTION
Signed-off-by: ftovaro <f.tovar12@gmail.com>

**What this PR does / why we need it**:

We have a link in our docs page that is pointing to the same page:
![image](https://user-images.githubusercontent.com/4805305/111230791-29fe3600-85b6-11eb-84a0-e480685966f7.png)

What I did was to identify which page is loading the footer and select the link depending of the page, if we are already in docs, redirect to `https://reference.octant.dev/`

![image](https://user-images.githubusercontent.com/4805305/111230970-6fbafe80-85b6-11eb-9d5f-5ce10dc3175c.png)

If not, go to the doc page:

![image](https://user-images.githubusercontent.com/4805305/111231025-86f9ec00-85b6-11eb-990a-e88c980123c5.png)



**Which issue(s) this PR fixes**
- Fixes #1924 

**Special notes for your reviewer**:

**Release note**:
```
release-note
```
