### PR TITLE
Add expandable rows to datagrids

### DIFF
--- a/changelogs/unreleased/2179-GuessWhoSamFoo
+++ b/changelogs/unreleased/2179-GuessWhoSamFoo
@@ -1,0 +1,1 @@
+Added expandable row to datagrids

--- a/pkg/view/component/base.go
+++ b/pkg/view/component/base.go
@@ -26,6 +26,8 @@ const (
 	TypeEditor = "editor"
 	// TypeError is an error component.
 	TypeError = "error"
+	// TypeExpandableRowDetail is an expandable detail component for table rows.
+	TypeExpandableRowDetail = "expandableRowDetail"
 	// TypeExtension is an extension component.
 	TypeExtension = "extension"
 	// TypeExpressionSelector is an expression selector component.

--- a/pkg/view/component/row_detail.go
+++ b/pkg/view/component/row_detail.go
@@ -1,0 +1,81 @@
+package component
+
+import (
+	"github.com/vmware-tanzu/octant/internal/util/json"
+)
+
+const (
+	// ExpandableRowKey is the key for an expandable row
+	ExpandableRowKey = "_expand"
+)
+
+// AddExpandableDetail allows a row to be expandable
+func (t TableRow) AddExpandableDetail(body Component, replaceContent bool) {
+	er, ok := t[ExpandableRowKey].(*ExpandableRowDetail)
+	if !ok {
+		er = NewExpandableRowDetail(body, replaceContent)
+	}
+	t[ExpandableRowKey] = er
+}
+
+// ExpandableRowDetail is a component hidden by a toggle under each table row.
+//
+// +octant:component
+type ExpandableRowDetail struct {
+	Base
+
+	Config ExpandableDetailConfig `json:"config"`
+}
+
+// ExpandableDetailConfig is a configuration for an expandable row detail.
+type ExpandableDetailConfig struct {
+	Replace bool      `json:"replace"`
+	Body    Component `json:"body"`
+}
+
+// Unmarshal unmarshals an expandable row detail config from JSON.
+func (e *ExpandableDetailConfig) UnmarshalJSON(data []byte) error {
+	x := struct {
+		Body    *TypedObject `json:"body"`
+		Replace bool         `json:"replace"`
+	}{}
+
+	if err := json.Unmarshal(data, &x); err != nil {
+		return err
+	}
+
+	if x.Body != nil {
+		var err error
+		e.Body, err = x.Body.ToComponent()
+		if err != nil {
+			return err
+		}
+	}
+	e.Replace = x.Replace
+	return nil
+}
+
+var _ Component = &ExpandableRowDetail{}
+
+// NewExpandableRowDetail creates an expandable detail for a table row.
+func NewExpandableRowDetail(body Component, replaceContent bool) *ExpandableRowDetail {
+	e := ExpandableRowDetail{
+		Base: newBase(TypeExpandableRowDetail, nil),
+		Config: ExpandableDetailConfig{
+			Body:    body,
+			Replace: replaceContent,
+		},
+	}
+	return &e
+}
+
+type expandableDetailMarshal ExpandableRowDetail
+
+func (e ExpandableRowDetail) MarshalJSON() ([]byte, error) {
+	k := expandableDetailMarshal{
+		Base:   e.Base,
+		Config: e.Config,
+	}
+	k.Metadata.Type = TypeExpandableRowDetail
+	return json.Marshal(&k)
+}

--- a/pkg/view/component/row_detail_test.go
+++ b/pkg/view/component/row_detail_test.go
@@ -1,0 +1,54 @@
+package component
+
+import (
+	"io/ioutil"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vmware-tanzu/octant/internal/util/json"
+)
+
+func TestTableRow_AddExpandableDetail(t *testing.T) {
+	text := NewText("detail")
+	expected := NewExpandableRowDetail(text, true)
+	row := TableRow{
+		"abc": NewText("123"),
+	}
+	row.AddExpandableDetail(text, true)
+
+	require.Equal(t, expected, row[ExpandableRowKey])
+}
+
+func TestTableTow_ExpandableDetail_Marshal(t *testing.T) {
+	cases := []struct {
+		name         string
+		input        *ExpandableRowDetail
+		expectedPath string
+		isErr        bool
+	}{
+		{
+			name: "in general",
+			input: &ExpandableRowDetail{
+				Base:   newBase(TypeExpandableRowDetail, nil),
+				Config: ExpandableDetailConfig{Body: NewText("test")},
+			},
+			expectedPath: "expandable_row.json",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := json.Marshal(tc.input)
+			isErr := err != nil
+			if isErr != tc.isErr {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			expected, err := ioutil.ReadFile(path.Join("testdata", tc.expectedPath))
+			require.NoError(t, err)
+			assert.JSONEq(t, string(expected), string(actual))
+		})
+	}
+}

--- a/pkg/view/component/testdata/config_detail_pane.json
+++ b/pkg/view/component/testdata/config_detail_pane.json
@@ -1,0 +1,22 @@
+{
+  "body": {
+    "metadata": {
+      "type": "text"
+    },
+    "config": {
+      "value": "test"
+    },
+    "title": [
+      {
+        "metadata": {
+          "type": "text"
+        },
+        "config": {
+          "value": "title"
+        }
+      }
+    ]
+  }
+}
+
+

--- a/pkg/view/component/testdata/config_expandable_row_detail.json
+++ b/pkg/view/component/testdata/config_expandable_row_detail.json
@@ -1,0 +1,11 @@
+{
+  "replace": true,
+  "body": {
+    "metadata": {
+      "type": "text"
+    },
+    "config": {
+      "value": "test"
+    }
+  }
+}

--- a/pkg/view/component/testdata/expandable_row.json
+++ b/pkg/view/component/testdata/expandable_row.json
@@ -1,0 +1,16 @@
+{
+  "metadata": {
+    "type": "expandableRowDetail"
+  },
+  "config": {
+    "replace": false,
+    "body": {
+      "metadata": {
+        "type": "text"
+      },
+      "config": {
+        "value": "test"
+      }
+    }
+  }
+}

--- a/pkg/view/component/unmarshal.go
+++ b/pkg/view/component/unmarshal.go
@@ -71,6 +71,11 @@ func unmarshal(to TypedObject) (Component, error) {
 		err = errors.Wrapf(json.Unmarshal(to.Config, &t.Config),
 			"unmarshal expressionSelector config")
 		o = t
+	case TypeExpandableRowDetail:
+		t := &ExpandableRowDetail{Base: Base{Metadata: to.Metadata}}
+		err = errors.Wrapf(json.Unmarshal(to.Config, &t.Config),
+			"unmarshal expandable row detail config")
+		o = t
 	case TypeFlexLayout:
 		t := &FlexLayout{Base: Base{Metadata: to.Metadata}}
 		err = errors.Wrapf(json.Unmarshal(to.Config, &t.Config),

--- a/pkg/view/component/unmarshal_test.go
+++ b/pkg/view/component/unmarshal_test.go
@@ -164,6 +164,18 @@ func Test_unmarshal(t *testing.T) {
 			},
 		},
 		{
+			name:       "expandable row detail",
+			configFile: "config_expandable_row_detail.json",
+			objectType: "expandableRowDetail",
+			expected: &ExpandableRowDetail{
+				Config: ExpandableDetailConfig{
+					Body:    NewText("test"),
+					Replace: true,
+				},
+				Base: newBase(TypeExpandableRowDetail, nil),
+			},
+		},
+		{
 			name:       "flexlayout",
 			configFile: "config_flexlayout.json",
 			objectType: "flexlayout",
@@ -630,7 +642,6 @@ func Test_unmarshal(t *testing.T) {
 
 			got, err := unmarshal(to)
 			require.NoError(t, err)
-
 			AssertEqual(t, tc.expected, got)
 		})
 	}

--- a/web/src/app/modules/shared/components/presentation/datagrid/datagrid.component.html
+++ b/web/src/app/modules/shared/components/presentation/datagrid/datagrid.component.html
@@ -46,6 +46,11 @@
     <clr-dg-cell *ngFor="let column of columns; trackBy: identifyColumn">
       <app-view-container [view]="row.data[column]"></app-view-container>
     </clr-dg-cell>
+    <ng-container ngProjectAs="clr-dg-row-detail" *ngIf="row?.detailView">
+      <clr-dg-row-detail *clrIfExpanded [clrDgReplace]="row?.replace">
+        <app-view-container [view]="row.detailView"></app-view-container>
+      </clr-dg-row-detail>
+    </ng-container>
   </clr-dg-row>
   <clr-dg-footer>
     <clr-dg-pagination #pagination [clrDgPageSize]="defaultPageSize">

--- a/web/src/app/modules/shared/components/presentation/datagrid/datagrid.component.html
+++ b/web/src/app/modules/shared/components/presentation/datagrid/datagrid.component.html
@@ -46,9 +46,9 @@
     <clr-dg-cell *ngFor="let column of columns; trackBy: identifyColumn">
       <app-view-container [view]="row.data[column]"></app-view-container>
     </clr-dg-cell>
-    <ng-container ngProjectAs="clr-dg-row-detail" *ngIf="row?.detailView">
+    <ng-container ngProjectAs="clr-dg-row-detail" *ngIf="row?.expandedDetail">
       <clr-dg-row-detail *clrIfExpanded [clrDgReplace]="row?.replace">
-        <app-view-container [view]="row.detailView"></app-view-container>
+        <app-view-container [view]="row.expandedDetail"></app-view-container>
       </clr-dg-row-detail>
     </ng-container>
   </clr-dg-row>

--- a/web/src/app/modules/shared/components/presentation/datagrid/datagrid.component.ts
+++ b/web/src/app/modules/shared/components/presentation/datagrid/datagrid.component.ts
@@ -12,12 +12,14 @@ import {
 } from '@angular/core';
 import {
   Confirmation,
+  ExpandableRowDetailView,
   GridAction,
   GridActionsView,
   TableFilters,
   TableRow,
   TableRowWithMetadata,
   TableView,
+  View,
 } from 'src/app/modules/shared/models/content';
 import trackByIndex from 'src/app/util/trackBy/trackByIndex';
 import trackByIdentity from 'src/app/util/trackBy/trackByIdentity';
@@ -54,6 +56,7 @@ export class DatagridComponent
   buttonGroup?: ButtonGroupView;
   isModalOpen = false;
   defaultPageSize: number;
+  detail = { name: 'test' };
 
   actionDialogOptions: ActionDialogOptions = undefined;
 
@@ -111,9 +114,17 @@ export class DatagridComponent
 
     return rows.map(row => {
       let actions: GridAction[] = [];
+      let detailView: View;
+      let replace: boolean;
 
       if (row.hasOwnProperty('_action')) {
         actions = (row._action as GridActionsView).config.actions;
+      }
+
+      if (row.hasOwnProperty('_expand')) {
+        const erv = (row._expand as ExpandableRowDetailView).config;
+        detailView = erv.body;
+        replace = erv.replace;
       }
 
       const isDeleted = !!row._isDeleted;
@@ -122,6 +133,8 @@ export class DatagridComponent
         data: row,
         actions,
         isDeleted,
+        detailView,
+        replace,
       };
     });
   }

--- a/web/src/app/modules/shared/components/presentation/datagrid/datagrid.component.ts
+++ b/web/src/app/modules/shared/components/presentation/datagrid/datagrid.component.ts
@@ -56,7 +56,6 @@ export class DatagridComponent
   buttonGroup?: ButtonGroupView;
   isModalOpen = false;
   defaultPageSize: number;
-  detail = { name: 'test' };
 
   actionDialogOptions: ActionDialogOptions = undefined;
 
@@ -114,7 +113,7 @@ export class DatagridComponent
 
     return rows.map(row => {
       let actions: GridAction[] = [];
-      let detailView: View;
+      let expandedDetail: View;
       let replace: boolean;
 
       if (row.hasOwnProperty('_action')) {
@@ -123,7 +122,7 @@ export class DatagridComponent
 
       if (row.hasOwnProperty('_expand')) {
         const erv = (row._expand as ExpandableRowDetailView).config;
-        detailView = erv.body;
+        expandedDetail = erv.body;
         replace = erv.replace;
       }
 
@@ -133,7 +132,7 @@ export class DatagridComponent
         data: row,
         actions,
         isDeleted,
-        detailView,
+        expandedDetail,
         replace,
       };
     });

--- a/web/src/app/modules/shared/models/content.ts
+++ b/web/src/app/modules/shared/models/content.ts
@@ -176,6 +176,13 @@ export interface ListView extends View {
   };
 }
 
+export interface ExpandableRowDetailView extends View {
+  config: {
+    body: View;
+    replace: boolean;
+  };
+}
+
 export interface ExpressionSelectorView extends View {
   config: {
     key: string;

--- a/web/src/app/modules/shared/models/content.ts
+++ b/web/src/app/modules/shared/models/content.ts
@@ -356,6 +356,8 @@ export interface TableRow {
 export interface TableRowWithMetadata {
   data: TableRow;
   actions?: GridAction[];
+  replace?: boolean;
+  expandedDetail?: View;
   isDeleted: boolean;
 }
 

--- a/web/src/stories/table.stories.mdx
+++ b/web/src/stories/table.stories.mdx
@@ -11,6 +11,18 @@ table.Add(component.TableRow{
 table.Sort("A")
 table.Reverse()`}}
 
+export const tableExpandableRowDocs= {source: {code: `cols := component.NewTableCols("A", "B")
+table := component.NewTable("Table Title", "Empty text", cols)
+card := component.NewCard(component.TitleFromString("Table Title"))
+card.SetBody(component.NewText("Card text"))
+row := component.TableRow{
+  "A": component.NewText("1"),
+}
+row.AddExpandableDetail(card, false)
+table.Add(row)
+table.Sort("A")
+table.Reverse()`}}
+
 export const textView = {
   config: {
     value: 'Table Title',
@@ -20,18 +32,42 @@ export const textView = {
   },
 };
 
+export const bodyView= {
+  config: {
+    value: 'Card text',
+  },
+  metadata: {
+    type: 'text',
+  },
+};
+
+export const cardView = {
+  config: {
+    body: bodyView,
+    actions: null,
+    alert: null,
+  },
+  metadata: {
+    title: [textView],
+    type: 'card',
+  },
+};
+
 <h1>Table Component</h1>
 <h2>Description</h2>
 
 <p>A table component is used to show tabular data with support for filtering, pagination, and sorting.</p>
 
 <p>When used in a Summary component, the table is intended to show simpler data as pagination, title, and filtering are removed.</p>
-<h2>Example</h2>
 
 <Meta title="Components/Table" component={DatagridComponent} />
 
+<h2>Table component</h2>
+
+<p>A table component with filtering, pagination, and title. The number of items per page can also be configured.</p>
+
 <Canvas withToolbar>
-  <Story name="Table component" parameters={{ docs: tableDocs }} height="800px" >
+  <Story name="Table component" parameters={{ docs: tableDocs }} height="250px" >
   {{
     props: {
       view: object('View', {
@@ -81,8 +117,104 @@ export const textView = {
   </Story>
 </Canvas>
 
+<h2>Table with expandable row</h2>
+
+<p>An expandable row consists of a toggle on the left that expands a row to show a hidden component.
+The component can be configured to replace the contents of the row.</p>
+
+<Canvas withToolbar>
+  <Story name="Table component expandable row" parameters={{ docs: tableExpandableRowDocs }} height="390px" >
+    {{
+      props: {
+        view: object('View', {
+          metadata: {
+            type: 'table',
+            title: [textView],
+          },
+          config: {
+            columns: [
+              {
+                name: 'A',
+                accessor: 'A',
+              },
+              {
+                name: 'B',
+                accessor: 'B',
+              },
+            ],
+            rows: [
+              {
+                _expand: {
+                  metadata: {
+                    type: 'expandableRow',
+                  },
+                  config: {
+                    replace: false,
+                    body: cardView,
+                  },
+                },
+                A: {
+                  config: {
+                    value: '1',
+                  },
+                  metadata: {
+                    type: 'text'
+                  },
+                },
+                B: {
+                  config: {
+                    value: '2',
+                  },
+                  metadata: {
+                    type: 'text',
+                  },
+                },
+              },
+              {
+                _expand: {
+                  metadata: {
+                    type: 'expandableRow',
+                  },
+                  config: {
+                    replace: true,
+                    body: cardView,
+                  },
+                },
+                A: {
+                  config: {
+                    value: '3',
+                  },
+                  metadata: {
+                    type: 'text'
+                  },
+                },
+                B: {
+                  config: {
+                    value: '4',
+                  },
+                  metadata: {
+                    type: 'text',
+                  },
+                },
+              },
+            ],
+            emptyContent: 'Empty text',
+            loading: false,
+            filters: {},
+          },
+        }),
+      },
+      component: DatagridComponent,
+    }}
+  </Story>
+</Canvas>
+
 <h2>Props</h2>
 <ArgsTable of={DatagridComponent} />
+
+<h2>Table with summary</h2>
+
+<p>When used in a Summary component, the table is intended to show simpler data as pagination, title, and filtering are removed.</p>
 
 <Canvas withToolbar>
   <Story name="Table used with summary" parameters={{ docs: tableDocs }} height="" >


### PR DESCRIPTION
**What this PR does / why we need it**:

![Peek 2021-03-18 16-19](https://user-images.githubusercontent.com/10288252/111709897-bfdbd000-8805-11eb-9bcf-cc2b9baf9023.gif)

Allows rows in datagrids to have expandable rows which contains another view component.

**Which issue(s) this PR fixes**
- Fixes #2019 

Signed-off-by: Sam Foo <foos@vmware.com>

