### PR TITLE
Add button styling and href link options

### DIFF
--- a/changelogs/unreleased/2208-GuessWhoSamFoo
+++ b/changelogs/unreleased/2208-GuessWhoSamFoo
@@ -1,0 +1,1 @@
+Added buttton styling and href link options

--- a/pkg/view/component/button.go
+++ b/pkg/view/component/button.go
@@ -8,6 +8,39 @@ import (
 	"github.com/vmware-tanzu/octant/pkg/action"
 )
 
+const (
+	// ButtonStatusSuccess is a green button
+	ButtonStatusSuccess ButtonStatus = "success"
+	// ButtonStatusInfo is the default blue color
+	ButtonStatusInfo ButtonStatus = "info"
+	// ButtonStatusDanger is a red button
+	ButtonStatusDanger ButtonStatus = "danger"
+	// ButtonStatusDisabled is a disabled button
+	ButtonStatusDisabled ButtonStatus = "disabled"
+)
+
+type ButtonStatus string
+
+const (
+	// ButtonSizeBlock is a full width button
+	ButtonSizeBlock ButtonSize = "block"
+	// ButtonSizeSmall is a small button
+	ButtonSizeLarge ButtonSize = "lg"
+)
+
+type ButtonSize string
+
+const (
+	// ButtonStyleOutline is a transparent button with a colored border
+	ButtonStyleOutline ButtonStyle = "outline"
+	// ButtonStyleSolid is a button with solid color
+	ButtonStyleSolid ButtonStyle = "solid"
+	// ButtonStyleFlat is a button with no background color or outline
+	ButtonStyleFlat ButtonStyle = "link"
+)
+
+type ButtonStyle string
+
 // Confirmation is configuration for a confirmation dialog.
 type Confirmation struct {
 	Title string `json:"title"`
@@ -34,12 +67,44 @@ func WithModal(modal *Modal) ButtonOption {
 	}
 }
 
+// WithLink configures a button with an href
+func WithButtonLink(ref string) ButtonOption {
+	return func(button *Button) {
+		button.Ref = ref
+	}
+}
+
+// WithButtonStatus configures the button color
+func WithButtonStatus(status ButtonStatus) ButtonOption {
+	return func(button *Button) {
+		button.Status = status
+	}
+}
+
+// WithButtonSize configures the button size
+func WithButtonSize(size ButtonSize) ButtonOption {
+	return func(button *Button) {
+		button.Size = size
+	}
+}
+
+// WithButtonStyle configures the button appearance
+func WithButtonStyle(style ButtonStyle) ButtonOption {
+	return func(button *Button) {
+		button.Style = style
+	}
+}
+
 func (b *Button) UnmarshalJSON(data []byte) error {
 	x := struct {
 		Name         string         `json:"name"`
 		Payload      action.Payload `json:"payload"`
 		Confirmation *Confirmation  `json:"confirmation,omitempty"`
 		Modal        *TypedObject   `json:"modal,omitempty"`
+		Ref          string         `json:"ref,omitempty"`
+		Status       ButtonStatus   `json:"status,omitempty"`
+		Size         ButtonSize     `json:"size,omitempty"`
+		Style        ButtonStyle    `json:"style,omitempty"`
 	}{}
 
 	if err := json.Unmarshal(data, &x); err != nil {
@@ -62,6 +127,10 @@ func (b *Button) UnmarshalJSON(data []byte) error {
 	b.Name = x.Name
 	b.Payload = x.Payload
 	b.Confirmation = x.Confirmation
+	b.Ref = x.Ref
+	b.Status = x.Status
+	b.Size = x.Size
+	b.Style = x.Style
 
 	return nil
 }
@@ -72,6 +141,10 @@ type Button struct {
 	Payload      action.Payload `json:"payload"`
 	Confirmation *Confirmation  `json:"confirmation,omitempty"`
 	Modal        Component      `json:"modal,omitempty"`
+	Ref          string         `json:"ref,omitempty"`
+	Status       ButtonStatus   `json:"status,omitempty"`
+	Size         ButtonSize     `json:"size,omitempty"`
+	Style        ButtonStyle    `json:"style,omitempty"`
 }
 
 // NewButton creates an instance of Button.
@@ -79,6 +152,20 @@ func NewButton(name string, payload action.Payload, options ...ButtonOption) But
 	button := Button{
 		Name:    name,
 		Payload: payload,
+	}
+
+	for _, option := range options {
+		option(&button)
+	}
+
+	return button
+}
+
+// NewButtonLink creates a button component that navigates to a link
+func NewButtonLink(name, ref string, options ...ButtonOption) Button {
+	button := Button{
+		Name: name,
+		Ref:  ref,
 	}
 
 	for _, option := range options {

--- a/pkg/view/component/button_test.go
+++ b/pkg/view/component/button_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/vmware-tanzu/octant/pkg/action"
+
 	"github.com/vmware-tanzu/octant/internal/util/json"
 
 	"github.com/stretchr/testify/assert"
@@ -43,4 +45,105 @@ func Test_ButtonGroup_Marshal(t *testing.T) {
 
 		})
 	}
+}
+
+func TestButtonGroup_AddButton(t *testing.T) {
+	bg := NewButtonGroup()
+	button := NewButton("button", action.Payload{})
+	bg.AddButton(button)
+	expected := ButtonGroup{
+		Base: newBase(TypeButtonGroup, nil),
+		Config: ButtonGroupConfig{
+			Buttons: []Button{
+				button,
+			},
+		},
+	}
+	require.Equal(t, expected, *bg)
+}
+
+func Test_Button_Options(t *testing.T) {
+	cases := []struct {
+		name     string
+		optsFunc []ButtonOption
+		expected Button
+	}{
+		{
+			name: "modal",
+			optsFunc: []ButtonOption{
+				WithModal(&Modal{
+					Base:   newBase(TypeModal, TitleFromString("modal title")),
+					Config: ModalConfig{},
+				}),
+			},
+			expected: Button{
+				Modal: NewModal(TitleFromString("modal title")),
+			},
+		},
+		{
+			name: "link",
+			optsFunc: []ButtonOption{
+				WithButtonLink("example.com"),
+			},
+			expected: Button{
+				Ref: "example.com",
+			},
+		},
+		{
+			name: "status",
+			optsFunc: []ButtonOption{
+				WithButtonStatus(ButtonStatusDanger),
+			},
+			expected: Button{
+				Status: ButtonStatusDanger,
+			},
+		},
+		{
+			name: "size",
+			optsFunc: []ButtonOption{
+				WithButtonSize(ButtonSizeLarge),
+			},
+			expected: Button{
+				Size: ButtonSizeLarge,
+			},
+		},
+		{
+			name: "style",
+			optsFunc: []ButtonOption{
+				WithButtonStyle(ButtonStyleOutline),
+			},
+			expected: Button{
+				Style: ButtonStyleOutline,
+			},
+		},
+		{
+			name: "multiple opts",
+			optsFunc: []ButtonOption{
+				WithButtonStatus(ButtonStatusSuccess),
+				WithButtonSize(ButtonSizeBlock),
+				WithButtonStyle(ButtonStyleFlat),
+			},
+			expected: Button{
+				Status: ButtonStatusSuccess,
+				Size:   ButtonSizeBlock,
+				Style:  ButtonStyleFlat,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := NewButton("", nil, tc.optsFunc...)
+			require.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestNewButtonLink(t *testing.T) {
+	buttonLink := NewButtonLink("link button", "example.com")
+	expected := Button{
+		Name: "link button",
+		Ref:  "example.com",
+	}
+	require.Equal(t, expected, buttonLink)
 }

--- a/pkg/view/component/link.go
+++ b/pkg/view/component/link.go
@@ -19,8 +19,9 @@ var _ Component = &Link{}
 
 // LinkConfig is the contents of Link
 type LinkConfig struct {
-	Text string `json:"value"`
-	Ref  string `json:"ref"`
+	Text    string    `json:"value"`
+	Ref     string    `json:"ref"`
+	Content Component `json:"content,omitempty"`
 	// Status sets the status of the component.
 	Status       TextStatus `json:"status,omitempty" tsType:"number"`
 	StatusDetail Component  `json:"statusDetail,omitempty"`
@@ -30,6 +31,7 @@ func (lc *LinkConfig) UnmarshalJSON(data []byte) error {
 	x := struct {
 		Text         string       `json:"value,omitempty"`
 		Ref          string       `json:"ref,omitempty"`
+		Content      *TypedObject `json:"content,omitempty"`
 		Status       TextStatus   `json:"status,omitempty"`
 		StatusDetail *TypedObject `json:"statusDetail,omitempty"`
 	}{}
@@ -47,6 +49,13 @@ func (lc *LinkConfig) UnmarshalJSON(data []byte) error {
 			return err
 		}
 		lc.StatusDetail = sd
+	}
+	if x.Content != nil {
+		t, err := x.Content.ToComponent()
+		if err != nil {
+			return err
+		}
+		lc.Content = t
 	}
 
 	return nil
@@ -68,6 +77,18 @@ func NewLink(title, s, ref string, options ...LinkOption) *Link {
 		option(l)
 	}
 
+	return l
+}
+
+// NewLinkFromComponent wraps a component around href anchors
+func NewLinkFromComponent(c Component, ref string) *Link {
+	l := &Link{
+		Base: newBase(TypeLink, nil),
+		Config: LinkConfig{
+			Ref:     ref,
+			Content: c,
+		},
+	}
 	return l
 }
 

--- a/web/src/app/modules/shared/components/presentation/button-group/button-group.component.html
+++ b/web/src/app/modules/shared/components/presentation/button-group/button-group.component.html
@@ -1,11 +1,12 @@
-<clr-button-group *ngIf="v.config.buttons" class="btn-primary">
-  <clr-button
-    *ngFor="let button of v.config.buttons; trackBy: trackByFn"
-    class="{{ class }}"
-    (click)="onClick(button.payload, button.confirmation, button.modal)"
-  >
-    {{ button.name }}
-  </clr-button>
+<clr-button-group *ngIf="v.config.buttons" class="btn-primary">p
+  <ng-container *ngFor="let button of buttons; trackBy: trackByFn">
+    <clr-button
+      class="{{ button.style }}"
+      (click)="onClick(button.payload, button.confirmation, button.modal, button.ref)"
+    >
+      {{ button.name }}
+    </clr-button>
+  </ng-container>
 </clr-button-group>
 
 <app-view-modal *ngIf="modalView" [view]="modalView"></app-view-modal>

--- a/web/src/app/modules/shared/components/presentation/button-group/button-group.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/button-group/button-group.component.spec.ts
@@ -33,4 +33,32 @@ describe('ButtonGroupComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('creates button class', () => {
+    const cases = [
+      {
+        style: 'outline',
+        size: 'block',
+        status: 'info',
+        expected: 'btn btn-block btn-info-outline',
+      },
+      {
+        style: 'flat',
+        status: 'disabled',
+        expected: 'btn btn-sm disabled btn-flat',
+      },
+      {
+        style: 'solid',
+        size: 'lg',
+        expected: 'btn btn-solid',
+      },
+      {
+        expected: 'btn btn-sm btn-outline',
+      },
+    ];
+    cases.forEach(test => {
+      const result = component.buttonClass(test.style, test.size, test.status);
+      expect(result).toEqual(test.expected);
+    });
+  });
 });

--- a/web/src/app/modules/shared/components/presentation/button-group/button-group.component.ts
+++ b/web/src/app/modules/shared/components/presentation/button-group/button-group.component.ts
@@ -9,12 +9,17 @@ import {
   Confirmation,
   View,
   ModalView,
+  Button,
 } from '../../../models/content';
 import { ActionService } from '../../../services/action/action.service';
 import { AbstractViewComponent } from '../../abstract-view/abstract-view.component';
 import { ModalService } from '../../../services/modal/modal.service';
 import { DomSanitizer } from '@angular/platform-browser';
 import { parse } from 'marked';
+
+// Todo: move to common import with link.component.ts
+const isUrlExternal = url =>
+  url?.indexOf('://') > 0 || url?.indexOf('//') === 0;
 
 @Component({
   selector: 'app-button-group',
@@ -28,7 +33,7 @@ export class ButtonGroupComponent extends AbstractViewComponent<ButtonGroupView>
   modalTitle = '';
   modalBody = '';
   payload = {};
-  class = '';
+  buttons: Button[];
 
   modalView: View;
 
@@ -41,23 +46,34 @@ export class ButtonGroupComponent extends AbstractViewComponent<ButtonGroupView>
   }
 
   update() {
-    if (this.v.config.buttons) {
-      this.v.config.buttons.forEach(button => {
-        if (button.confirmation) {
-          this.class = 'btn-danger-outline btn-sm';
-        } else {
-          this.class = 'btn-outline btn-sm';
-        }
+    const current = this.v;
+    this.buttons = current.config.buttons;
+    if (this.buttons) {
+      this.buttons.forEach(button => {
         if (button.modal) {
           this.modalView = button.modal;
           const modal = this.modalView as ModalView;
           this.modalService.setState(modal.config.opened);
         }
+        if (button.confirmation) {
+          button.style = 'btn-danger-outline btn-sm';
+        } else {
+          button.style = this.buttonClass(
+            button.style,
+            button.size,
+            button.status
+          );
+        }
       });
     }
   }
 
-  onClick(payload: {}, confirmation?: Confirmation, modal?: View) {
+  onClick(
+    payload: {},
+    confirmation?: Confirmation,
+    modal?: View,
+    ref?: string
+  ) {
     if (modal) {
       this.modalService.openModal();
     }
@@ -67,6 +83,52 @@ export class ButtonGroupComponent extends AbstractViewComponent<ButtonGroupView>
       this.buttonLoad.emit(true);
       this.doAction(payload);
     }
+    if (ref) {
+      if (isUrlExternal(ref)) {
+        window.open(ref);
+      } else {
+        location.href = ref;
+      }
+    }
+  }
+
+  buttonClass(style: string, size: string, status: string): string {
+    const buttonBase = 'btn';
+    const result = [buttonBase];
+    // Default size and style is btn-outline btn-sm
+    let buttonSize = 'btn';
+    let buttonStyles = 'btn';
+
+    if (size) {
+      buttonSize += '-' + size;
+    }
+    if (size === 'lg') {
+      buttonSize = '';
+      result.push(buttonSize);
+    } else if (buttonSize.length > 3) {
+      // no-op
+      result.push(buttonSize);
+    } else {
+      result.push(buttonSize + '-' + 'sm');
+    }
+
+    if (status) {
+      if (status !== 'disabled') {
+        buttonStyles += '-' + status;
+      }
+      if (status === 'disabled') {
+        result.push('disabled');
+      }
+    }
+    if (style) {
+      buttonStyles += '-' + style;
+    }
+    if (buttonStyles.length > 3) {
+      result.push(buttonStyles);
+    } else {
+      result.push(buttonStyles + '-' + 'outline');
+    }
+    return result.filter(String).join(' ');
   }
 
   cancelModal() {

--- a/web/src/app/modules/shared/components/presentation/link/link.component.html
+++ b/web/src/app/modules/shared/components/presentation/link/link.component.html
@@ -1,5 +1,11 @@
+<ng-template [ngIf]="content">
+  <ng-container *ngIf="isExternal; else componentInternal">
+    <a target="_blank" href="{{ ref }}"><app-view-container [view]="content"></app-view-container></a>
+  </ng-container>
+</ng-template>
+
 <ng-template [ngIf]="isExternal" [ngIfElse]="internal">
-  <a target ="_blank" href="{{ ref }}">{{ value }}</a>
+  <a target="_blank" href="{{ ref }}">{{ value }}</a>
 </ng-template>
 
 <ng-template #internal>
@@ -10,4 +16,8 @@
     ></app-indicator>
   </ng-container>
   <a [routerLink]="[ref]">{{ value }}</a>
+</ng-template>
+
+<ng-template #componentInternal>
+  <a [routerLink]="[ref]"><app-view-container [view]="content"></app-view-container></a>
 </ng-template>

--- a/web/src/app/modules/shared/components/presentation/link/link.component.ts
+++ b/web/src/app/modules/shared/components/presentation/link/link.component.ts
@@ -3,7 +3,7 @@
 //
 
 import { Component } from '@angular/core';
-import { LinkView } from 'src/app/modules/shared/models/content';
+import { LinkView, View } from 'src/app/modules/shared/models/content';
 import { AbstractViewComponent } from '../../abstract-view/abstract-view.component';
 
 const isUrlExternal = url =>
@@ -19,6 +19,7 @@ export class LinkComponent extends AbstractViewComponent<LinkView> {
   value: string;
   isExternal: boolean;
   hasStatus: boolean;
+  content: View;
 
   constructor() {
     super();
@@ -29,6 +30,7 @@ export class LinkComponent extends AbstractViewComponent<LinkView> {
     this.ref = view.config.ref;
     this.value = view.config.value;
     this.isExternal = isUrlExternal(this.ref);
+    this.content = view.config.content;
 
     if (view.config.status) {
       this.hasStatus = true;

--- a/web/src/app/modules/shared/models/content.ts
+++ b/web/src/app/modules/shared/models/content.ts
@@ -137,6 +137,10 @@ export interface Button {
   name: string;
   confirmation?: Confirmation;
   modal?: ModalView;
+  ref?: string;
+  status?: string;
+  size?: string;
+  style?: string;
 }
 
 export interface ButtonGroupView extends View {
@@ -178,6 +182,7 @@ export interface LinkView extends View {
     value: string;
     status?: number;
     statusDetail?: View;
+    content?: View;
   };
 }
 

--- a/web/src/stories/button.group.stories.mdx
+++ b/web/src/stories/button.group.stories.mdx
@@ -12,6 +12,13 @@ buttonGroup.AddButton(
       )))
 `}}
 
+export const buttonStyleDocs= { source: { code: `buttonGroup := component.NewButtonGroup()
+button := component.NewButtonLink("Example", "https://google.com",
+		component.WithButtonStyle(component.ButtonStyle(component.ButtonStyleSolid)),
+		component.WithButtonStatus(component.ButtonStatusSuccess))
+buttonGroup.AddButton(button)
+`}}
+
 <h1>Button Group component</h1>
 <h2>Description</h2>
 
@@ -19,12 +26,14 @@ buttonGroup.AddButton(
 <p>The Button component supports a confirmation method with a Markdown compatible message that appears in a modal.
 Buttons requiring confirmation are red.</p>
 
-<h2>Example</h2>
-
 <Meta title="Components/Button Group" component={ButtonGroupComponent} />
 
+<h2>Button Group with Confirmation</h2>
+
+<p>One or more buttons can be added to a button group. A button can send payloads or open a modal.</p>
+
 <Canvas withToolbar>
-  <Story name="ButtonGroup component" parameters={{ docs: buttonDocs }} height="150px" >
+  <Story name="ButtonGroup with Modal" parameters={{ docs: buttonDocs }} height="150px" >
   {{
       props: {
         view:  object('View', {
@@ -47,6 +56,37 @@ Buttons requiring confirmation are red.</p>
       },
       component: ButtonGroupComponent,
       }}
+  </Story>
+</Canvas>
+
+<h2>Button with styling</h2>
+
+<p>Buttons can also be styled to have solid colors instead of a transparent background along with colors.</p>
+<p>A button can also link to a URL.</p>
+
+<Canvas withToolbar>
+  <Story name="ButtonGroup with Link" parameters={{ docs: buttonStyleDocs }} height="150px" >
+    {{
+      props: {
+        view:  object('View', {
+          config: {
+            buttons: [
+              {
+                name: "Example",
+                payload: null,
+                ref: 'https://octant.dev',
+                status: 'success',
+                style: 'solid',
+              }
+            ]
+          },
+          metadata: {
+            type: 'buttonGroup',
+          },
+        }),
+      },
+      component: ButtonGroupComponent,
+    }}
   </Story>
 </Canvas>
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR create two methods for generating a link:

1. It allows plugin authors to wrap a component with `<a href=""><component></component></a>`.
2. It allows creating a link via `component.NewButtonLink`

It also creates a set of configurable styles based on clarity configurations. Due to previous usage of buttons, a default Octant button (not used in a form) is Clarity's `btn-small btn-outline`. The size is converted such that an Octant large button is a normal clarity button.

**Which issue(s) this PR fixes**
- Fixes #2183 and #2184 

Signed-off-by: Sam Foo <foos@vmware.com>

