### PR TITLE
Update component dynamically if view type changes

### DIFF
--- a/web/src/app/modules/shared/components/view/view-container.component.ts
+++ b/web/src/app/modules/shared/components/view/view-container.component.ts
@@ -38,6 +38,8 @@ interface Viewer {
 })
 export class ViewContainerComponent implements OnInit, AfterViewInit {
   @ViewChild(ViewHostDirective, { static: true }) appView: ViewHostDirective;
+  lastViewType: string;
+
   @Input() set view(v: View) {
     if (v && v.metadata) {
       const cur = JSON.stringify(v);
@@ -79,7 +81,7 @@ export class ViewContainerComponent implements OnInit, AfterViewInit {
   }
 
   loadView(view: View) {
-    if (!this.componentRef) {
+    if (!this.componentRef || this.lastViewType !== view.metadata.type) {
       const viewType = view.metadata.type;
       let component: Type<any> = this.componentMappings[viewType];
       if (!component) {


### PR DESCRIPTION
The recent Resource Viewer [change](https://github.com/vmware-tanzu/octant/pull/2177) uncovered problems with updating the object status component. After Resource Viewer selection has been changed, the status view was not updated when component of different type had to be used, so for example we were missing heptagon indicators in some cases. This change is fixing that by checking the view type and forcing the update if new view has different type.  

Signed-off-by: Milan Klanjsek <mklanjsek@pivotal.io>
