### PR TITLE
Revert dynamic component update change 

### DIFF
--- a/web/src/app/modules/shared/components/view/view-container.component.ts
+++ b/web/src/app/modules/shared/components/view/view-container.component.ts
@@ -38,8 +38,6 @@ interface Viewer {
 })
 export class ViewContainerComponent implements OnInit, AfterViewInit {
   @ViewChild(ViewHostDirective, { static: true }) appView: ViewHostDirective;
-  lastViewType: string;
-
   @Input() set view(v: View) {
     if (v && v.metadata) {
       const cur = JSON.stringify(v);
@@ -81,7 +79,7 @@ export class ViewContainerComponent implements OnInit, AfterViewInit {
   }
 
   loadView(view: View) {
-    if (!this.componentRef || this.lastViewType !== view.metadata.type) {
+    if (!this.componentRef) {
       const viewType = view.metadata.type;
       let component: Type<any> = this.componentMappings[viewType];
       if (!component) {


### PR DESCRIPTION
Reverting the dynamic component update change introduced in #2212 because further testing showed it was causing unwanted screen updates. 

The original problem that change was trying to fix ([missing heptagon indicators](https://github.com/vmware-tanzu/octant/issues/2215)) will be addressed in 0.19.  

Signed-off-by: Milan Klanjsek mklanjsek@pivotal.io
