### PR TITLE
Bump goreleaser to 0.161.0

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -44,7 +44,7 @@ jobs:
     name: Run goreleaser
     needs: [nightly-build]
     runs-on: ubuntu-latest
-    container: goreleaser/goreleaser:v0.128.0-cgo
+    container: goreleaser/goreleaser:v0.161.0
     steps:
       - uses: actions/checkout@v2
       - name: Run goreleaser

--- a/.github/workflows/preflight-checks.yaml
+++ b/.github/workflows/preflight-checks.yaml
@@ -128,7 +128,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [bundle_assets, verify_tag]
     runs-on: ubuntu-latest
-    container: goreleaser/goreleaser:v0.128.0-cgo
+    container: goreleaser/goreleaser:v0.161.0
     steps:
       - uses: actions/checkout@v2
       - name: Run GoReleaser


### PR DESCRIPTION
Fixes issue where it tries to use go 1.15 for compiling.

Signed-off-by: Sam Foo <foos@vmware.com>
