### PR TITLE
Fixed issue with theme initial value

### DIFF
--- a/web/src/app/modules/shared/services/preferences/preferences.service.spec.ts
+++ b/web/src/app/modules/shared/services/preferences/preferences.service.spec.ts
@@ -95,4 +95,18 @@ describe('PreferencesService', () => {
       100
     );
   });
+
+  it('theme initial value set properly', () => {
+    service.preferences.get('theme').subject.next('light');
+    const defaultPrefs = service.getPreferences();
+    const defaultElement = defaultPrefs.panels[0].sections[0].elements[0];
+    expect(defaultElement.name).toEqual('theme');
+    expect(defaultElement.value.toString()).toEqual('light');
+
+    service.preferences.get('theme').subject.next('dark');
+    const newPrefs = service.getPreferences();
+    const newElement = newPrefs.panels[0].sections[0].elements[0];
+    expect(newElement.name).toEqual('theme');
+    expect(newElement.value.toString()).toEqual('dark');
+  });
 });

--- a/web/src/app/modules/shared/services/preferences/preferences.service.ts
+++ b/web/src/app/modules/shared/services/preferences/preferences.service.ts
@@ -86,6 +86,7 @@ export class PreferencesService implements OnDestroy {
         ''
       )
     );
+    this.updateTheme();
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
Make sure that theme is always properly loaded, even if service initialization was not performed as expected.

Signed-off-by: Milan Klanjsek <mklanjsek@pivotal.io>
