### PR TITLE
Update nfpms.name_template for nightly goreleaser

### DIFF
--- a/.goreleaser-nightly.yml
+++ b/.goreleaser-nightly.yml
@@ -39,7 +39,7 @@ archives:
     format_overrides:
       - goos: windows
         format: zip
-    name_template: "{{.ProjectName}}_{{.Date}}_{{.Os}}-{{.Arch}}"
+    file_name_template: "{{.ProjectName}}_{{.Date}}_{{.Os}}-{{.Arch}}"
     replacements:
       darwin: macOS
       linux: Linux


### PR DESCRIPTION
xref: https://github.com/vmware-tanzu/octant/actions/runs/691732117

https://goreleaser.com/deprecations/#nfpmsname_template

Signed-off-by: Sam Foo <foos@vmware.com>

