### PR TITLE
Render expression selector in selectors list

### DIFF
--- a/changelogs/unreleased/2252-xtreme-jon-ji
+++ b/changelogs/unreleased/2252-xtreme-jon-ji
@@ -1,0 +1,1 @@
+Fixed expression selector rendering

--- a/web/src/app/modules/shared/components/presentation/expression-selector/expression-selector.component.html
+++ b/web/src/app/modules/shared/components/presentation/expression-selector/expression-selector.component.html
@@ -1,1 +1,2 @@
-<div class="selector--expression">{{ key }} {{ operator }} {{ values }}</div>
+<div *ngIf="values" class="label label-purple">{{ key }} {{ operator }} {{ values }}</div>
+<div *ngIf="!values" class="label label-purple">{{ key }} {{ operator }}</div>

--- a/web/src/app/modules/shared/components/presentation/expression-selector/expression-selector.component.scss
+++ b/web/src/app/modules/shared/components/presentation/expression-selector/expression-selector.component.scss
@@ -1,10 +1,3 @@
 /* Copyright (c) 2019 the Octant contributors. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-
-@import '_mixins';
-@import '_variables';
-
-.selector--expression {
-  @include pill(var(--selector-color));
-}

--- a/web/src/app/modules/shared/components/presentation/expression-selector/expression-selector.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/expression-selector/expression-selector.component.spec.ts
@@ -73,7 +73,7 @@ describe('ExpressionSelectorComponent', () => {
 
     it('should render correctly', () => {
       const element: HTMLElement = fixture.nativeElement.querySelector('div');
-      expect(element.textContent).toEqual('keyOne In valueOne|valueTwo');
+      expect(element.textContent).toEqual('keyOne In valueOne,valueTwo');
     });
   });
 

--- a/web/src/app/modules/shared/components/presentation/expression-selector/expression-selector.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/expression-selector/expression-selector.component.spec.ts
@@ -5,10 +5,12 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { ExpressionSelectorComponent } from './expression-selector.component';
+import { ExpressionSelectorView } from 'src/app/modules/shared/models/content';
 
 describe('ExpressionSelectorComponent', () => {
   let component: ExpressionSelectorComponent;
   let fixture: ComponentFixture<ExpressionSelectorComponent>;
+  let view: ExpressionSelectorView;
 
   beforeEach(
     waitForAsync(() => {
@@ -21,10 +23,80 @@ describe('ExpressionSelectorComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(ExpressionSelectorComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
   it('should create', () => {
+    fixture.detectChanges();
+
     expect(component).toBeTruthy();
+  });
+
+  describe('expression with single value', () => {
+    beforeEach(() => {
+      view = {
+        metadata: {
+          type: 'expressionSelector',
+        },
+        config: {
+          key: 'keyOne',
+          operator: 'NotIn',
+          values: ['valueOne'],
+        },
+      };
+
+      component.view = view;
+      fixture.detectChanges();
+    });
+
+    it('should render correctly', () => {
+      const element: HTMLElement = fixture.nativeElement.querySelector('div');
+      expect(element.textContent).toEqual('keyOne NotIn valueOne');
+    });
+  });
+
+  describe('expression with multiple values', () => {
+    beforeEach(() => {
+      view = {
+        metadata: {
+          type: 'expressionSelector',
+        },
+        config: {
+          key: 'keyOne',
+          operator: 'In',
+          values: ['valueOne', 'valueTwo'],
+        },
+      };
+
+      component.view = view;
+      fixture.detectChanges();
+    });
+
+    it('should render correctly', () => {
+      const element: HTMLElement = fixture.nativeElement.querySelector('div');
+      expect(element.textContent).toEqual('keyOne In valueOne|valueTwo');
+    });
+  });
+
+  describe('expression with no values', () => {
+    beforeEach(() => {
+      view = {
+        metadata: {
+          type: 'expressionSelector',
+        },
+        config: {
+          key: 'keyOne',
+          operator: 'Exists',
+          values: [],
+        },
+      };
+
+      component.view = view;
+      fixture.detectChanges();
+    });
+
+    it('should render correctly', () => {
+      const element: HTMLElement = fixture.nativeElement.querySelector('div');
+      expect(element.textContent).toEqual('keyOne Exists');
+    });
   });
 });

--- a/web/src/app/modules/shared/components/presentation/expression-selector/expression-selector.component.ts
+++ b/web/src/app/modules/shared/components/presentation/expression-selector/expression-selector.component.ts
@@ -24,6 +24,6 @@ export class ExpressionSelectorComponent extends AbstractViewComponent<Expressio
     const view = this.v;
     this.key = view.config.key;
     this.operator = view.config.operator;
-    this.values = view.config.values?.join('|');
+    this.values = view.config.values?.join(',');
   }
 }

--- a/web/src/app/modules/shared/components/presentation/expression-selector/expression-selector.component.ts
+++ b/web/src/app/modules/shared/components/presentation/expression-selector/expression-selector.component.ts
@@ -24,6 +24,6 @@ export class ExpressionSelectorComponent extends AbstractViewComponent<Expressio
     const view = this.v;
     this.key = view.config.key;
     this.operator = view.config.operator;
-    this.values = view.config.values?.join(',');
+    this.values = view.config.values?.join('|');
   }
 }

--- a/web/src/app/modules/shared/components/presentation/overflow-selectors/overflow-selectors.component.html
+++ b/web/src/app/modules/shared/components/presentation/overflow-selectors/overflow-selectors.component.html
@@ -6,7 +6,7 @@
       <app-octant-tooltip *ngSwitchCase="'labelSelector'" tooltipText="{{ selector.config.key }}:{{ selector.config.value }}">
         <app-view-label-selector [view]="selector"></app-view-label-selector>
       </app-octant-tooltip>
-      <app-octant-tooltip *ngSwitchCase="'expressionSelector'" tooltipText="{{ selector.config.key }} {{ selector.config.operator }} {{ selector.config.values?.join('|') }}">
+      <app-octant-tooltip *ngSwitchCase="'expressionSelector'" tooltipText="{{ selector.config.key }} {{ selector.config.operator }} {{ selector.config.values | join: ',' }}">
         <app-view-expression-selector [view]="selector"></app-view-expression-selector>
       </app-octant-tooltip>
     </ng-container>

--- a/web/src/app/modules/shared/components/presentation/overflow-selectors/overflow-selectors.component.html
+++ b/web/src/app/modules/shared/components/presentation/overflow-selectors/overflow-selectors.component.html
@@ -1,12 +1,13 @@
 <div class="selectors-wrapper" *ngIf="selectors">
   <div class="selectors-container">
     <ng-container
-      *ngFor="let selector of showSelectors; trackBy: trackByIdentity"
+      *ngFor="let selector of showSelectors; trackBy: trackByIdentity" [ngSwitch]="selector.metadata.type"
     >
-      <app-octant-tooltip tooltipText="{{ selector.config.key }}:{{ selector.config.value }}">
-        <span class="label label-orange">
-          {{ selector.config.key }}:{{ selector.config.value }}
-        </span>
+      <app-octant-tooltip *ngSwitchCase="'labelSelector'" tooltipText="{{ selector.config.key }}:{{ selector.config.value }}">
+        <app-view-label-selector [view]="selector"></app-view-label-selector>
+      </app-octant-tooltip>
+      <app-octant-tooltip *ngSwitchCase="'expressionSelector'" tooltipText="{{ selector.config.key }} {{ selector.config.operator }} {{ selector.config.values?.join(',') }}">
+        <app-view-expression-selector [view]="selector"></app-view-expression-selector>
       </app-octant-tooltip>
     </ng-container>
   </div>
@@ -17,11 +18,10 @@
     </span>
     <clr-signpost-content [clrPosition]="'left-middle'" *clrIfOpen>
       <ng-container
-        *ngFor="let selector of overflowSelectors; trackBy: trackByIdentity"
+        *ngFor="let selector of overflowSelectors; trackBy: trackByIdentity" [ngSwitch]="selector.metadata.type"
       >
-        <span class="label label-orange">
-          {{ selector.config.key }}:{{ selector.config.value }}
-        </span>
+        <app-view-label-selector *ngSwitchCase="'labelSelector'" [view]="selector"></app-view-label-selector>
+        <app-view-expression-selector *ngSwitchCase="'expressionSelector'" [view]="selector"></app-view-expression-selector>
       </ng-container>
     </clr-signpost-content>
   </clr-signpost>

--- a/web/src/app/modules/shared/components/presentation/overflow-selectors/overflow-selectors.component.html
+++ b/web/src/app/modules/shared/components/presentation/overflow-selectors/overflow-selectors.component.html
@@ -6,7 +6,7 @@
       <app-octant-tooltip *ngSwitchCase="'labelSelector'" tooltipText="{{ selector.config.key }}:{{ selector.config.value }}">
         <app-view-label-selector [view]="selector"></app-view-label-selector>
       </app-octant-tooltip>
-      <app-octant-tooltip *ngSwitchCase="'expressionSelector'" tooltipText="{{ selector.config.key }} {{ selector.config.operator }} {{ selector.config.values?.join(',') }}">
+      <app-octant-tooltip *ngSwitchCase="'expressionSelector'" tooltipText="{{ selector.config.key }} {{ selector.config.operator }} {{ selector.config.values?.join('|') }}">
         <app-view-expression-selector [view]="selector"></app-view-expression-selector>
       </app-octant-tooltip>
     </ng-container>

--- a/web/src/app/modules/shared/components/presentation/overflow-selectors/overflow-selectors.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/overflow-selectors/overflow-selectors.component.spec.ts
@@ -35,7 +35,7 @@ describe('OverflowSelectorsComponent', () => {
     component.selectors = [
       {
         metadata: {
-          type: 'LabelSelector',
+          type: 'labelSelector',
         },
         config: {
           key: 'keyOne',
@@ -44,7 +44,7 @@ describe('OverflowSelectorsComponent', () => {
       },
       {
         metadata: {
-          type: 'LabelSelector',
+          type: 'labelSelector',
         },
         config: {
           key: 'keyTwo',
@@ -53,7 +53,7 @@ describe('OverflowSelectorsComponent', () => {
       },
       {
         metadata: {
-          type: 'LabelSelector',
+          type: 'labelSelector',
         },
         config: {
           key: 'keyThree',
@@ -74,7 +74,7 @@ describe('OverflowSelectorsComponent', () => {
     component.selectors = [
       {
         metadata: {
-          type: 'LabelSelector',
+          type: 'labelSelector',
         },
         config: {
           key: 'keyOne',
@@ -84,6 +84,29 @@ describe('OverflowSelectorsComponent', () => {
     ];
     fixture.detectChanges();
     const renderedSelectors = document.getElementsByClassName('label');
+
+    expect(component.overflowSelectors).toBeUndefined();
+    expect(component.showSelectors.length).toEqual(1);
+    expect(renderedSelectors.length).toEqual(1);
+  });
+
+  it('should display expression selector', () => {
+    component.selectors = [
+      {
+        metadata: {
+          type: 'expressionSelector',
+        },
+        config: {
+          key: 'keyOne',
+          operator: 'In',
+          values: [
+            'valueOne'
+          ]
+        },
+      },
+    ];
+    fixture.detectChanges();
+    const renderedSelectors = document.getElementsByClassName('selector--expression');
 
     expect(component.overflowSelectors).toBeUndefined();
     expect(component.showSelectors.length).toEqual(1);

--- a/web/src/app/modules/shared/components/presentation/overflow-selectors/overflow-selectors.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/overflow-selectors/overflow-selectors.component.spec.ts
@@ -83,7 +83,7 @@ describe('OverflowSelectorsComponent', () => {
       },
     ];
     fixture.detectChanges();
-    const renderedSelectors = document.getElementsByClassName('label');
+    const renderedSelectors = document.getElementsByClassName('label-orange');
 
     expect(component.overflowSelectors).toBeUndefined();
     expect(component.showSelectors.length).toEqual(1);
@@ -104,9 +104,7 @@ describe('OverflowSelectorsComponent', () => {
       },
     ];
     fixture.detectChanges();
-    const renderedSelectors = document.getElementsByClassName(
-      'selector--expression'
-    );
+    const renderedSelectors = document.getElementsByClassName('label-purple');
 
     expect(component.overflowSelectors).toBeUndefined();
     expect(component.showSelectors.length).toEqual(1);

--- a/web/src/app/modules/shared/components/presentation/overflow-selectors/overflow-selectors.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/overflow-selectors/overflow-selectors.component.spec.ts
@@ -99,14 +99,14 @@ describe('OverflowSelectorsComponent', () => {
         config: {
           key: 'keyOne',
           operator: 'In',
-          values: [
-            'valueOne'
-          ]
+          values: ['valueOne'],
         },
       },
     ];
     fixture.detectChanges();
-    const renderedSelectors = document.getElementsByClassName('selector--expression');
+    const renderedSelectors = document.getElementsByClassName(
+      'selector--expression'
+    );
 
     expect(component.overflowSelectors).toBeUndefined();
     expect(component.showSelectors.length).toEqual(1);

--- a/web/src/app/modules/shared/components/presentation/overflow-selectors/overflow-selectors.component.ts
+++ b/web/src/app/modules/shared/components/presentation/overflow-selectors/overflow-selectors.component.ts
@@ -4,16 +4,7 @@
 
 import { AfterViewChecked, Component, ElementRef, Input } from '@angular/core';
 import trackByIdentity from 'src/app/util/trackBy/trackByIdentity';
-
-interface Selector {
-  metadata: {
-    type: string;
-  };
-  config: {
-    key: string;
-    value: string;
-  };
-}
+import {ExpressionSelectorView, LabelSelectorView} from "../../../models/content";
 
 @Component({
   selector: 'app-overflow-selectors',
@@ -21,21 +12,23 @@ interface Selector {
   styleUrls: ['./overflow-selectors.component.scss'],
 })
 export class OverflowSelectorsComponent implements AfterViewChecked {
-  @Input() set selectors(selectors: Selector[]) {
+  @Input() set selectors(
+    selectors: Array<LabelSelectorView | ExpressionSelectorView>
+  ) {
     this.selectorsList = selectors;
     this.updateSelectors();
   }
 
-  get selectors(): Selector[] {
+  get selectors(): Array<LabelSelectorView | ExpressionSelectorView> {
     return this.selectorsList;
   }
 
   constructor(private rootElement: ElementRef) {}
   @Input() numberShownSelectors = 2;
 
-  private selectorsList: Selector[];
-  showSelectors: Selector[];
-  overflowSelectors: Selector[];
+  private selectorsList: Array<LabelSelectorView | ExpressionSelectorView>;
+  showSelectors: Array<LabelSelectorView | ExpressionSelectorView>;
+  overflowSelectors: Array<LabelSelectorView | ExpressionSelectorView>;
   trackByIdentity = trackByIdentity;
   componentWidth = 0;
 

--- a/web/src/app/modules/shared/components/presentation/overflow-selectors/overflow-selectors.component.ts
+++ b/web/src/app/modules/shared/components/presentation/overflow-selectors/overflow-selectors.component.ts
@@ -4,7 +4,10 @@
 
 import { AfterViewChecked, Component, ElementRef, Input } from '@angular/core';
 import trackByIdentity from 'src/app/util/trackBy/trackByIdentity';
-import { ExpressionSelectorView, LabelSelectorView } from 'src/app/modules/shared/models/content';
+import {
+  ExpressionSelectorView,
+  LabelSelectorView,
+} from 'src/app/modules/shared/models/content';
 
 @Component({
   selector: 'app-overflow-selectors',

--- a/web/src/app/modules/shared/components/presentation/overflow-selectors/overflow-selectors.component.ts
+++ b/web/src/app/modules/shared/components/presentation/overflow-selectors/overflow-selectors.component.ts
@@ -4,7 +4,7 @@
 
 import { AfterViewChecked, Component, ElementRef, Input } from '@angular/core';
 import trackByIdentity from 'src/app/util/trackBy/trackByIdentity';
-import {ExpressionSelectorView, LabelSelectorView} from "../../../models/content";
+import { ExpressionSelectorView, LabelSelectorView } from 'src/app/modules/shared/models/content';
 
 @Component({
   selector: 'app-overflow-selectors',

--- a/web/src/app/modules/shared/components/presentation/selectors/selectors.component.ts
+++ b/web/src/app/modules/shared/components/presentation/selectors/selectors.component.ts
@@ -21,20 +21,4 @@ export class SelectorsComponent extends AbstractViewComponent<SelectorsView> {
   }
 
   update() {}
-
-  identifyItem(
-    index: number,
-    item: ExpressionSelectorView | LabelSelectorView
-  ): string {
-    const { key } = item.config;
-    const labelSelector = item as LabelSelectorView;
-    const expressionSelector = item as ExpressionSelectorView;
-    if (labelSelector.config.value) {
-      return `${key}-${labelSelector.config.value}`;
-    } else if (expressionSelector.config.values) {
-      return `${key}-${
-        expressionSelector.config.operator
-      }-${expressionSelector.config.values.join(',')}`;
-    }
-  }
 }

--- a/web/src/app/modules/shared/pipes/join/join.pipe.spec.ts
+++ b/web/src/app/modules/shared/pipes/join/join.pipe.spec.ts
@@ -1,0 +1,35 @@
+import { JoinPipe } from './join.pipe';
+
+describe('JoinPipe', () => {
+  const pipe = new JoinPipe();
+
+  it('create an instance', () => {
+    expect(pipe).toBeTruthy();
+  });
+
+  describe('empty values', () => {
+    it('returns empty string if null', () => {
+      expect(pipe.transform(null, 'some-delimiter')).toEqual('');
+    });
+
+    it('returns empty string if empty array', () => {
+      expect(pipe.transform([], 'some-delimiter')).toEqual('');
+    });
+  });
+
+  describe('single value', () => {
+    it('returns only the single value', () => {
+      expect(pipe.transform(['a-cool-value'], 'some-delimiter')).toEqual(
+        'a-cool-value'
+      );
+    });
+  });
+
+  describe('multiple values', () => {
+    it('returns joined values', () => {
+      expect(pipe.transform(['valueA', 'valueB', 'valueC'], ',')).toEqual(
+        'valueA,valueB,valueC'
+      );
+    });
+  });
+});

--- a/web/src/app/modules/shared/pipes/join/join.pipe.ts
+++ b/web/src/app/modules/shared/pipes/join/join.pipe.ts
@@ -1,0 +1,10 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'join',
+})
+export class JoinPipe implements PipeTransform {
+  transform(values: string[], delimiter: string): string {
+    return values?.join(delimiter) || '';
+  }
+}

--- a/web/src/app/modules/shared/shared.module.ts
+++ b/web/src/app/modules/shared/shared.module.ts
@@ -84,6 +84,7 @@ import { DataModule } from '../../data/data.module';
 import { OverlayscrollbarsModule } from 'overlayscrollbars-ngx';
 import { StringEscapePipe } from './pipes/stringEscape/string.escape.pipe';
 import { IconComponent } from './components/presentation/icon/icon.component';
+import { JoinPipe } from './pipes/join/join.pipe';
 
 @NgModule({
   declarations: [
@@ -161,6 +162,7 @@ import { IconComponent } from './components/presentation/icon/icon.component';
     MissingComponentComponent,
     OctantTooltipComponent,
     BottomPanelComponent,
+    JoinPipe,
   ],
   entryComponents: [
     AccordionComponent,
@@ -303,6 +305,7 @@ import { IconComponent } from './components/presentation/icon/icon.component';
     OctantTooltipComponent,
     BottomPanelComponent,
     StringEscapePipe,
+    JoinPipe,
   ],
 })
 export class SharedModule {}


### PR DESCRIPTION
**What this PR does / why we need it**: Fix expression selector rendering

**Which issue(s) this PR fixes**
- Fixes #2252

**Special notes for your reviewer**:
Couple of questions:
- Should `overflow-selectors` reuse the existing `label-selector` and `expression-selector` components? Wondering if `label-selector` portion of the `overflow-selector` was previously duplicated on purpose
- Is the design for `expression-selector` up-to-date? It doesn't use the same label styling as labels/label selector (see screenshot below)

<img width="1120" alt="Screenshot 2021-03-31 at 3 49 22 PM" src="https://user-images.githubusercontent.com/4840235/113110496-b9a01780-9239-11eb-91dd-beda11452f44.png">

Related issue:
- Selector filtering in `content-text-filter` treats selectors as label selectors, with only `key` and `value` fields. Thus, the filter does not search within expression operator/values. Should this be fixed alongside this PR, or should I raise a separate issue? 

