### PR TITLE
increase timeout for remote cmd stream setup

### DIFF
--- a/internal/terminal/instance.go
+++ b/internal/terminal/instance.go
@@ -256,7 +256,7 @@ func (t *instance) terminalStream() error {
 	}()
 
 	select {
-	case <-time.After(200 * time.Millisecond):
+	case <-time.After(1000 * time.Millisecond):
 		return nil
 	case err := <-ch:
 		return err


### PR DESCRIPTION
**What this PR does / why we need it**: This PR fixes the flaky terminal connection error.

**Which issue(s) this PR fixes**
- Fixes #2164

**Special notes for your reviewer**:
We already try multiple shell commands(sh, bash) for terminal (https://github.com/vmware-tanzu/octant/blob/96dd7438f3d1e4a2c4e514238c6b0dcf2d86e4d2/internal/api/terminal_manager.go#L156). 
We just need to wait for a bit longer to setup remote connection stream.
