### PR TITLE
Fixed changelog generation script to support usernames containing '-'

### DIFF
--- a/changelogs/CHANGELOG-0.18.md
+++ b/changelogs/CHANGELOG-0.18.md
@@ -15,13 +15,13 @@
 ### Bug Fixes
   * Removed resource age column from Custom Resources (#1462, @lenriquez)
   * Fixed issue with clusterless configuration specified at startup (#2058) (#2058, @mklanjsek)
-  * Fixed broken link in Go Plugins Intro doc (#2098, @xtreme)
+  * Fixed broken link in Go Plugins Intro doc (#2098, @xtreme-jon-ji)
 
 ### All Changes
   * Added the table page size preference (#1850, @lenriquez)
   * Reduced tooltip size on label to avoid hidden tags on K8s object (#2044, @lenriquez)
-  * Added lookup for additional metadata from JS plugins (#2099, @xtreme)
-  * Added lookup for object store  metadata from Go plugins (#2140, @xtreme)
+  * Added lookup for additional metadata from JS plugins (#2099, @xtreme-vikram-yadav)
+  * Added lookup for object store  metadata from Go plugins (#2140, @xtreme-vikram-yadav)
   * Added memstats flag (#2127, @GuessWhoSamFoo)
   * Added timeline component (#2130, @GuessWhoSamFoo)
   * Added expandable row to datagrids (#2179, @GuessWhoSamFoo)

--- a/changelogs/unreleased/2270-xtreme-jon-ji
+++ b/changelogs/unreleased/2270-xtreme-jon-ji
@@ -1,0 +1,1 @@
+Fixed changelog generation script to support usernames containing '-'

--- a/hacks/changelogs.sh
+++ b/hacks/changelogs.sh
@@ -9,9 +9,9 @@ UNRELEASED=$(ls -t ${CHANGELOG_PATH})
 echo -e "Generating CHANGELOG markdown from ${CHANGELOG_PATH}\n"
 for entry in $UNRELEASED
 do
-    IFS=$'-' read -ra pruser <<<"$entry"
+    IFS=$'-' read -r prnum pruser <<< "$entry"
     contents=$(cat ${CHANGELOG_PATH}/${entry})
-    echo "  * ${contents} (#${pruser[0]}, @${pruser[1]})"
+    echo "  * ${contents} (#${prnum}, @${pruser})"
 done
 echo -e "\nCopy and paste the list above in to the appropriate CHANGELOG file."
 echo "Be sure to run: git rm ${CHANGELOG_PATH}/*"


### PR DESCRIPTION
**What this PR does / why we need it**:
GitHub usernames of PR authors that contain `-` are not displayed correctly in changelog
 
**Which issue(s) this PR fixes**
- Fixes #2270

**Special notes for your reviewer**:
<s>This change updates the script, but does not address the already-generated v0.18.0 changelog found at https://github.com/vmware-tanzu/octant/releases/tag/v0.18.0</s> Updated changelog as per feedback