### PR TITLE
Added ability to change type of dynamic component on the fly

### DIFF
--- a/changelogs/unreleased/2215-mklanjsek
+++ b/changelogs/unreleased/2215-mklanjsek
@@ -1,0 +1,1 @@
+Added ability to change dynamic component on the fly

--- a/web/src/app/modules/shared/components/view/view-container.component.spec.ts
+++ b/web/src/app/modules/shared/components/view/view-container.component.spec.ts
@@ -8,6 +8,9 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { ViewContainerComponent } from './view-container.component';
 import { DYNAMIC_COMPONENTS_MAPPING } from '../../dynamic-components';
 import { TextComponent } from '../presentation/text/text.component';
+import { PodStatusView, TextView } from '../../models/content';
+import { SharedModule } from '../../shared.module';
+import { PodStatusComponent } from '../presentation/pod-status/pod-status.component';
 
 describe('ViewContainerComponent', () => {
   let component: ViewContainerComponent;
@@ -17,11 +20,13 @@ describe('ViewContainerComponent', () => {
     waitForAsync(() => {
       TestBed.configureTestingModule({
         declarations: [ViewContainerComponent],
+        imports: [SharedModule],
         providers: [
           {
             provide: DYNAMIC_COMPONENTS_MAPPING,
             useValue: {
               text: TextComponent,
+              podStatus: PodStatusComponent,
             },
           },
         ],
@@ -37,5 +42,38 @@ describe('ViewContainerComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should recreate component when different type', () => {
+    const textView: TextView = {
+      config: { value: 'some text' },
+      metadata: { type: 'text', title: [], accessor: 'accessor' },
+    };
+
+    const podStatusView: PodStatusView = {
+      metadata: { type: 'podStatus' },
+      config: {
+        pods: {
+          pod1: {
+            details: [textView],
+            status: 'ok',
+          },
+        },
+      },
+    };
+
+    component.view = textView;
+    fixture.detectChanges();
+    expect(component.componentRef.instance.view.metadata.type).toEqual('text');
+    expect(component.componentRef.componentType.name).toEqual('TextComponent');
+
+    component.view = podStatusView;
+    fixture.detectChanges();
+    expect(component.componentRef.instance.view.metadata.type).toEqual(
+      'podStatus'
+    );
+    expect(component.componentRef.componentType.name).toEqual(
+      'PodStatusComponent'
+    );
   });
 });

--- a/web/src/app/modules/shared/components/view/view-container.component.ts
+++ b/web/src/app/modules/shared/components/view/view-container.component.ts
@@ -51,7 +51,7 @@ export class ViewContainerComponent implements OnInit, AfterViewInit {
   @Output() viewInit: EventEmitter<void> = new EventEmitter<void>();
 
   private start: number;
-  private componentRef: ComponentRef<Viewer>;
+  public componentRef: ComponentRef<Viewer>;
   private previous: string;
 
   constructor(
@@ -79,7 +79,11 @@ export class ViewContainerComponent implements OnInit, AfterViewInit {
   }
 
   loadView(view: View) {
-    if (!this.componentRef) {
+    const componentChanged =
+      this.componentRef &&
+      view.metadata.type !== this.componentRef.instance.view.metadata.type;
+
+    if (!this.componentRef || componentChanged) {
       const viewType = view.metadata.type;
       let component: Type<any> = this.componentMappings[viewType];
       if (!component) {


### PR DESCRIPTION
Previously, when `ViewContainerComponent` has been created, it would dynamically create underlying component and that component was immutable. That behavior caused issues when content of component view was changing during component lifetime, for example when status view in Resource Viewer was changing type from `text` to `podStatus`, as described in #2215. During testing, I discovered that the Event lists were affected as well, as items in them can have either `text` or `link` type.  
  
We now check the new view type when view is updated and recreate the component if types differ.
 
Signed-off-by: Milan Klanjsek <mklanjsek@pivotal.io>

- Fixes #2215

