### PR TITLE
Fixed Resource Viewer bug with missing pods

### DIFF
--- a/internal/modules/workloads/detail_describer.go
+++ b/internal/modules/workloads/detail_describer.go
@@ -118,8 +118,10 @@ _%s_
 	}
 
 	var objects []*unstructured.Unstructured
-	for _, pod := range cur.Pods().Items {
-		objects = append(objects, &pod)
+	pods := cur.Pods().Items
+
+	for i := 0; i < len(pods); i++ {
+		objects = append(objects, &pods[i])
 	}
 
 	rv, err := resourceviewer.Create(ctx, options.Dash, options.Queryer, objects...)
@@ -147,7 +149,7 @@ _%s_
 
 func (d *DetailDescriber) createResponse(components ...component.Component) component.ContentResponse {
 	cr := component.ContentResponse{
-		Title:      component.TitleFromString("Workload X"),
+		Title:      component.TitleFromString(""),
 		Components: components,
 	}
 


### PR DESCRIPTION
Fixed problem with pods that were missing in Resource Viewer status area - when multiple pods were present, only one was showing up. That was also causing constant updates because different pod was used each time. Problem was traced down to the way we were iterating kist of pods before passing them to the Resource Viewer.

Also removed the obnoxious applications view `Workload X` header
