### PR TITLE
Make Resource Viewer layout repeatable

### DIFF
--- a/internal/objectvisitor/apiservice_test.go
+++ b/internal/objectvisitor/apiservice_test.go
@@ -38,15 +38,16 @@ func TestAPIService_Visit(t *testing.T) {
 	u := testutil.ToUnstructured(t, object)
 
 	handler := fake.NewMockObjectHandler(controller)
+	handler.EXPECT().SetLevel(gomock.Any(), 1).Return(2)
 	handler.EXPECT().
-		AddEdge(gomock.Any(), u, testutil.ToUnstructured(t, service)).
+		AddEdge(gomock.Any(), u, testutil.ToUnstructured(t, service), gomock.Any()).
 		Return(nil)
 
 	var visited []unstructured.Unstructured
 	visitor := fake.NewMockVisitor(controller)
 	visitor.EXPECT().
-		Visit(gomock.Any(), gomock.Any(), handler, true).
-		DoAndReturn(func(ctx context.Context, object *unstructured.Unstructured, handler objectvisitor.ObjectHandler, _ bool) error {
+		Visit(gomock.Any(), gomock.Any(), handler, true, gomock.Any()).
+		DoAndReturn(func(ctx context.Context, object *unstructured.Unstructured, handler objectvisitor.ObjectHandler, _ bool, _ int) error {
 			visited = append(visited, *object)
 			return nil
 		})
@@ -66,7 +67,7 @@ func TestAPIService_Visit(t *testing.T) {
 	apiService := objectvisitor.NewAPIService(objectStore)
 
 	ctx := context.Background()
-	err := apiService.Visit(ctx, u, handler, visitor, true)
+	err := apiService.Visit(ctx, u, handler, visitor, true, 1)
 
 	sortObjectsByName(t, visited)
 
@@ -92,9 +93,10 @@ func TestAPIService_Visit_notfound(t *testing.T) {
 
 	var visited []unstructured.Unstructured
 	visitor := fake.NewMockVisitor(controller)
+	handler.EXPECT().SetLevel(gomock.Any(), 1).Return(2)
 	visitor.EXPECT().
-		Visit(gomock.Any(), gomock.Any(), handler, true).
-		DoAndReturn(func(ctx context.Context, object *unstructured.Unstructured, handler objectvisitor.ObjectHandler, _ bool) error {
+		Visit(gomock.Any(), gomock.Any(), handler, true, gomock.Any()).
+		DoAndReturn(func(ctx context.Context, object *unstructured.Unstructured, handler objectvisitor.ObjectHandler, _ bool, _ int) error {
 			visited = append(visited, *object)
 			return nil
 		}).AnyTimes()
@@ -114,7 +116,7 @@ func TestAPIService_Visit_notfound(t *testing.T) {
 	apiService := objectvisitor.NewAPIService(objectStore)
 
 	ctx := context.Background()
-	err := apiService.Visit(ctx, u, handler, visitor, true)
+	err := apiService.Visit(ctx, u, handler, visitor, true, 1)
 
 	sortObjectsByName(t, visited)
 
@@ -134,9 +136,10 @@ func TestAPIService_Visit_local(t *testing.T) {
 
 	var visited []unstructured.Unstructured
 	visitor := fake.NewMockVisitor(controller)
+	handler.EXPECT().SetLevel(gomock.Any(), 1).Return(2)
 	visitor.EXPECT().
-		Visit(gomock.Any(), gomock.Any(), handler, true).
-		DoAndReturn(func(ctx context.Context, object *unstructured.Unstructured, handler objectvisitor.ObjectHandler, _ bool) error {
+		Visit(gomock.Any(), gomock.Any(), handler, true, gomock.Any()).
+		DoAndReturn(func(ctx context.Context, object *unstructured.Unstructured, handler objectvisitor.ObjectHandler, _ bool, _ int) error {
 			visited = append(visited, *object)
 			return nil
 		}).AnyTimes()
@@ -146,7 +149,7 @@ func TestAPIService_Visit_local(t *testing.T) {
 	apiService := objectvisitor.NewAPIService(objectStore)
 
 	ctx := context.Background()
-	err := apiService.Visit(ctx, u, handler, visitor, true)
+	err := apiService.Visit(ctx, u, handler, visitor, true, 1)
 
 	sortObjectsByName(t, visited)
 

--- a/internal/objectvisitor/fake/mock_default_typed_visitor.go
+++ b/internal/objectvisitor/fake/mock_default_typed_visitor.go
@@ -38,15 +38,15 @@ func (m *MockDefaultTypedVisitor) EXPECT() *MockDefaultTypedVisitorMockRecorder 
 }
 
 // Visit mocks base method
-func (m *MockDefaultTypedVisitor) Visit(arg0 context.Context, arg1 *unstructured.Unstructured, arg2 objectvisitor.ObjectHandler, arg3 objectvisitor.Visitor, arg4 bool) error {
+func (m *MockDefaultTypedVisitor) Visit(arg0 context.Context, arg1 *unstructured.Unstructured, arg2 objectvisitor.ObjectHandler, arg3 objectvisitor.Visitor, arg4 bool, arg5 int) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Visit", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "Visit", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Visit indicates an expected call of Visit
-func (mr *MockDefaultTypedVisitorMockRecorder) Visit(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockDefaultTypedVisitorMockRecorder) Visit(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Visit", reflect.TypeOf((*MockDefaultTypedVisitor)(nil).Visit), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Visit", reflect.TypeOf((*MockDefaultTypedVisitor)(nil).Visit), arg0, arg1, arg2, arg3, arg4, arg5)
 }

--- a/internal/objectvisitor/fake/mock_object_handler.go
+++ b/internal/objectvisitor/fake/mock_object_handler.go
@@ -36,17 +36,17 @@ func (m *MockObjectHandler) EXPECT() *MockObjectHandlerMockRecorder {
 }
 
 // AddEdge mocks base method
-func (m *MockObjectHandler) AddEdge(arg0 context.Context, arg1, arg2 *unstructured.Unstructured) error {
+func (m *MockObjectHandler) AddEdge(arg0 context.Context, arg1, arg2 *unstructured.Unstructured, arg3 int) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddEdge", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "AddEdge", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // AddEdge indicates an expected call of AddEdge
-func (mr *MockObjectHandlerMockRecorder) AddEdge(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockObjectHandlerMockRecorder) AddEdge(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddEdge", reflect.TypeOf((*MockObjectHandler)(nil).AddEdge), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddEdge", reflect.TypeOf((*MockObjectHandler)(nil).AddEdge), arg0, arg1, arg2, arg3)
 }
 
 // Process mocks base method
@@ -61,4 +61,18 @@ func (m *MockObjectHandler) Process(arg0 context.Context, arg1 *unstructured.Uns
 func (mr *MockObjectHandlerMockRecorder) Process(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Process", reflect.TypeOf((*MockObjectHandler)(nil).Process), arg0, arg1)
+}
+
+// SetLevel mocks base method
+func (m *MockObjectHandler) SetLevel(arg0 string, arg1 int) int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetLevel", arg0, arg1)
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// SetLevel indicates an expected call of SetLevel
+func (mr *MockObjectHandlerMockRecorder) SetLevel(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLevel", reflect.TypeOf((*MockObjectHandler)(nil).SetLevel), arg0, arg1)
 }

--- a/internal/objectvisitor/fake/mock_typed_visitor.go
+++ b/internal/objectvisitor/fake/mock_typed_visitor.go
@@ -53,15 +53,15 @@ func (mr *MockTypedVisitorMockRecorder) Supports() *gomock.Call {
 }
 
 // Visit mocks base method
-func (m *MockTypedVisitor) Visit(arg0 context.Context, arg1 *unstructured.Unstructured, arg2 objectvisitor.ObjectHandler, arg3 objectvisitor.Visitor, arg4 bool) error {
+func (m *MockTypedVisitor) Visit(arg0 context.Context, arg1 *unstructured.Unstructured, arg2 objectvisitor.ObjectHandler, arg3 objectvisitor.Visitor, arg4 bool, arg5 int) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Visit", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "Visit", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Visit indicates an expected call of Visit
-func (mr *MockTypedVisitorMockRecorder) Visit(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockTypedVisitorMockRecorder) Visit(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Visit", reflect.TypeOf((*MockTypedVisitor)(nil).Visit), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Visit", reflect.TypeOf((*MockTypedVisitor)(nil).Visit), arg0, arg1, arg2, arg3, arg4, arg5)
 }

--- a/internal/objectvisitor/fake/mock_visitor.go
+++ b/internal/objectvisitor/fake/mock_visitor.go
@@ -38,15 +38,15 @@ func (m *MockVisitor) EXPECT() *MockVisitorMockRecorder {
 }
 
 // Visit mocks base method
-func (m *MockVisitor) Visit(arg0 context.Context, arg1 *unstructured.Unstructured, arg2 objectvisitor.ObjectHandler, arg3 bool) error {
+func (m *MockVisitor) Visit(arg0 context.Context, arg1 *unstructured.Unstructured, arg2 objectvisitor.ObjectHandler, arg3 bool, arg4 int) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Visit", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "Visit", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Visit indicates an expected call of Visit
-func (mr *MockVisitorMockRecorder) Visit(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockVisitorMockRecorder) Visit(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Visit", reflect.TypeOf((*MockVisitor)(nil).Visit), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Visit", reflect.TypeOf((*MockVisitor)(nil).Visit), arg0, arg1, arg2, arg3, arg4)
 }

--- a/internal/objectvisitor/ingress_test.go
+++ b/internal/objectvisitor/ingress_test.go
@@ -29,14 +29,15 @@ func TestIngress_Visit(t *testing.T) {
 
 	handler := fake.NewMockObjectHandler(controller)
 	handler.EXPECT().
-		AddEdge(gomock.Any(), u, testutil.ToUnstructured(t, service)).
+		AddEdge(gomock.Any(), u, testutil.ToUnstructured(t, service), gomock.Any()).
 		Return(nil)
 
 	var visited []unstructured.Unstructured
 	visitor := fake.NewMockVisitor(controller)
+	handler.EXPECT().SetLevel(gomock.Any(), 1).Return(2)
 	visitor.EXPECT().
-		Visit(gomock.Any(), gomock.Any(), handler, true).
-		DoAndReturn(func(ctx context.Context, object *unstructured.Unstructured, handler objectvisitor.ObjectHandler, _ bool) error {
+		Visit(gomock.Any(), gomock.Any(), handler, true, gomock.Any()).
+		DoAndReturn(func(ctx context.Context, object *unstructured.Unstructured, handler objectvisitor.ObjectHandler, _ bool, _ int) error {
 			visited = append(visited, *object)
 			return nil
 		})
@@ -44,7 +45,7 @@ func TestIngress_Visit(t *testing.T) {
 	ingress := objectvisitor.NewIngress(q)
 
 	ctx := context.Background()
-	err := ingress.Visit(ctx, u, handler, visitor, true)
+	err := ingress.Visit(ctx, u, handler, visitor, true, 1)
 
 	sortObjectsByName(t, visited)
 
@@ -66,13 +67,14 @@ func TestIngress_Visit_invalid_service_name(t *testing.T) {
 		Return(testutil.ToUnstructuredList(t), nil)
 
 	handler := fake.NewMockObjectHandler(controller)
+	handler.EXPECT().SetLevel(gomock.Any(), 1).Return(2)
 
 	visitor := fake.NewMockVisitor(controller)
 
 	ingress := objectvisitor.NewIngress(q)
 
 	ctx := context.Background()
-	err := ingress.Visit(ctx, u, handler, visitor, true)
+	err := ingress.Visit(ctx, u, handler, visitor, true, 1)
 
 	assert.NoError(t, err)
 

--- a/internal/objectvisitor/mutatingwebhookconfiguration_test.go
+++ b/internal/objectvisitor/mutatingwebhookconfiguration_test.go
@@ -45,15 +45,16 @@ func TestMutatingWebhookConfiguration_Visit(t *testing.T) {
 	u := testutil.ToUnstructured(t, object)
 
 	handler := fake.NewMockObjectHandler(controller)
+	handler.EXPECT().SetLevel(gomock.Any(), 1).Return(2)
 	handler.EXPECT().
-		AddEdge(gomock.Any(), u, testutil.ToUnstructured(t, service)).
+		AddEdge(gomock.Any(), u, testutil.ToUnstructured(t, service), gomock.Any()).
 		Return(nil)
 
 	var visited []unstructured.Unstructured
 	visitor := fake.NewMockVisitor(controller)
 	visitor.EXPECT().
-		Visit(gomock.Any(), gomock.Any(), handler, gomock.Any()).
-		DoAndReturn(func(ctx context.Context, object *unstructured.Unstructured, handler objectvisitor.ObjectHandler, _ bool) error {
+		Visit(gomock.Any(), gomock.Any(), handler, gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, object *unstructured.Unstructured, handler objectvisitor.ObjectHandler, _ bool, _ int) error {
 			visited = append(visited, *object)
 			return nil
 		})
@@ -73,7 +74,7 @@ func TestMutatingWebhookConfiguration_Visit(t *testing.T) {
 	mutatingWebhookConfiguration := objectvisitor.NewMutatingWebhookConfiguration(objectStore)
 
 	ctx := context.Background()
-	err := mutatingWebhookConfiguration.Visit(ctx, u, handler, visitor, true)
+	err := mutatingWebhookConfiguration.Visit(ctx, u, handler, visitor, true, 1)
 
 	sortObjectsByName(t, visited)
 
@@ -103,12 +104,13 @@ func TestMutatingWebhookConfiguration_Visit_notfound(t *testing.T) {
 	u := testutil.ToUnstructured(t, object)
 
 	handler := fake.NewMockObjectHandler(controller)
+	handler.EXPECT().SetLevel(gomock.Any(), 1).Return(2)
 
 	var visited []unstructured.Unstructured
 	visitor := fake.NewMockVisitor(controller)
 	visitor.EXPECT().
-		Visit(gomock.Any(), gomock.Any(), handler, gomock.Any()).
-		DoAndReturn(func(ctx context.Context, object *unstructured.Unstructured, handler objectvisitor.ObjectHandler, _ bool) error {
+		Visit(gomock.Any(), gomock.Any(), handler, gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, object *unstructured.Unstructured, handler objectvisitor.ObjectHandler, _ bool, _ int) error {
 			visited = append(visited, *object)
 			return nil
 		}).AnyTimes()
@@ -128,7 +130,7 @@ func TestMutatingWebhookConfiguration_Visit_notfound(t *testing.T) {
 	mutatingWebhookConfiguration := objectvisitor.NewMutatingWebhookConfiguration(objectStore)
 
 	ctx := context.Background()
-	err := mutatingWebhookConfiguration.Visit(ctx, u, handler, visitor, true)
+	err := mutatingWebhookConfiguration.Visit(ctx, u, handler, visitor, true, 1)
 
 	sortObjectsByName(t, visited)
 
@@ -154,12 +156,13 @@ func TestMutatingWebhookConfiguration_Visit_url(t *testing.T) {
 	u := testutil.ToUnstructured(t, object)
 
 	handler := fake.NewMockObjectHandler(controller)
+	handler.EXPECT().SetLevel(gomock.Any(), 1).Return(2)
 
 	var visited []unstructured.Unstructured
 	visitor := fake.NewMockVisitor(controller)
 	visitor.EXPECT().
-		Visit(gomock.Any(), gomock.Any(), handler, gomock.Any()).
-		DoAndReturn(func(ctx context.Context, object *unstructured.Unstructured, handler objectvisitor.ObjectHandler, _ bool) error {
+		Visit(gomock.Any(), gomock.Any(), handler, gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, object *unstructured.Unstructured, handler objectvisitor.ObjectHandler, _ bool, _ int) error {
 			visited = append(visited, *object)
 			return nil
 		}).AnyTimes()
@@ -169,7 +172,7 @@ func TestMutatingWebhookConfiguration_Visit_url(t *testing.T) {
 	mutatingWebhookConfiguration := objectvisitor.NewMutatingWebhookConfiguration(objectStore)
 
 	ctx := context.Background()
-	err := mutatingWebhookConfiguration.Visit(ctx, u, handler, visitor, true)
+	err := mutatingWebhookConfiguration.Visit(ctx, u, handler, visitor, true, 1)
 
 	sortObjectsByName(t, visited)
 

--- a/internal/objectvisitor/object_test.go
+++ b/internal/objectvisitor/object_test.go
@@ -53,8 +53,9 @@ func TestObject_Visit(t *testing.T) {
 			},
 			handler: func(ctrl *gomock.Controller) *fake.MockObjectHandler {
 				handler := fake.NewMockObjectHandler(ctrl)
-				handler.EXPECT().AddEdge(gomock.Any(), replicaSet, pod).Return(nil)
-				handler.EXPECT().AddEdge(gomock.Any(), replicaSet, deployment).Return(nil)
+				handler.EXPECT().SetLevel(gomock.Any(), 1).Return(2)
+				handler.EXPECT().AddEdge(gomock.Any(), replicaSet, pod, gomock.Any()).Return(nil)
+				handler.EXPECT().AddEdge(gomock.Any(), replicaSet, deployment, gomock.Any()).Return(nil)
 				handler.EXPECT().Process(gomock.Any(), replicaSet).Return(nil)
 				return handler
 			},
@@ -81,8 +82,9 @@ func TestObject_Visit(t *testing.T) {
 			visitObject: pod,
 			handler: func(ctrl *gomock.Controller) *fake.MockObjectHandler {
 				handler := fake.NewMockObjectHandler(ctrl)
-				handler.EXPECT().AddEdge(gomock.Any(), pod, replicaSet).Return(nil)
-				handler.EXPECT().AddEdge(gomock.Any(), pod, deployment).Return(nil)
+				handler.EXPECT().SetLevel(gomock.Any(), 1).Return(2)
+				handler.EXPECT().AddEdge(gomock.Any(), pod, replicaSet, gomock.Any()).Return(nil)
+				handler.EXPECT().AddEdge(gomock.Any(), pod, deployment, gomock.Any()).Return(nil)
 				handler.EXPECT().Process(gomock.Any(), pod).Return(nil)
 				return handler
 			},
@@ -109,8 +111,8 @@ func TestObject_Visit(t *testing.T) {
 			var mu sync.Mutex
 			visitor := fake.NewMockVisitor(controller)
 			visitor.EXPECT().
-				Visit(gomock.Any(), gomock.Any(), handler, gomock.Any()).
-				DoAndReturn(func(ctx context.Context, object *unstructured.Unstructured, handler objectvisitor.ObjectHandler, _ bool) error {
+				Visit(gomock.Any(), gomock.Any(), handler, gomock.Any(), gomock.Any()).
+				DoAndReturn(func(ctx context.Context, object *unstructured.Unstructured, handler objectvisitor.ObjectHandler, _ bool, _ int) error {
 					mu.Lock()
 					defer mu.Unlock()
 					visited = append(visited, *object)
@@ -121,7 +123,7 @@ func TestObject_Visit(t *testing.T) {
 			object := objectvisitor.NewObject(tt.ctorArgs.dashConfig(controller), tt.ctorArgs.queryer(controller))
 
 			ctx := context.Background()
-			err := object.Visit(ctx, tt.visitObject, handler, visitor, true)
+			err := object.Visit(ctx, tt.visitObject, handler, visitor, true, 1)
 			require.NoError(t, err)
 
 			sortObjectsByName(t, visited)

--- a/internal/objectvisitor/objectvisitor_test.go
+++ b/internal/objectvisitor/objectvisitor_test.go
@@ -39,12 +39,12 @@ func TestDefaultVisitor_Visit_use_typed_visitor(t *testing.T) {
 
 	defaultHandler := ovFake.NewMockDefaultTypedVisitor(controller)
 	defaultHandler.EXPECT().
-		Visit(gomock.Any(), unstructuredPod, handler, gomock.Any(), true).Return(nil)
+		Visit(gomock.Any(), unstructuredPod, handler, gomock.Any(), true, gomock.Any()).Return(nil)
 
 	tv := ovFake.NewMockTypedVisitor(controller)
 	tv.EXPECT().Supports().Return(gvk.Pod).AnyTimes()
 	tv.EXPECT().
-		Visit(gomock.Any(), unstructuredPod, handler, gomock.Any(), true)
+		Visit(gomock.Any(), unstructuredPod, handler, gomock.Any(), true, gomock.Any())
 	tvList := []objectvisitor.TypedVisitor{tv}
 
 	dv, err := objectvisitor.NewDefaultVisitor(dashConfig, q,
@@ -53,6 +53,6 @@ func TestDefaultVisitor_Visit_use_typed_visitor(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	err = dv.Visit(ctx, testutil.ToUnstructured(t, pod), handler, true)
+	err = dv.Visit(ctx, testutil.ToUnstructured(t, pod), handler, true, 1)
 	require.NoError(t, err)
 }

--- a/internal/objectvisitor/pod_test.go
+++ b/internal/objectvisitor/pod_test.go
@@ -47,25 +47,26 @@ func TestPod_Visit(t *testing.T) {
 		Return([]*corev1.PersistentVolumeClaim{pvc}, nil)
 
 	handler := fake.NewMockObjectHandler(controller)
+	handler.EXPECT().SetLevel(gomock.Any(), 1).Return(2)
 	handler.EXPECT().
-		AddEdge(gomock.Any(), u, testutil.ToUnstructured(t, service)).
-		Return(nil)
-	handler.EXPECT().
-		AddEdge(gomock.Any(), u, testutil.ToUnstructured(t, serviceAccount)).
+		AddEdge(gomock.Any(), u, testutil.ToUnstructured(t, service), gomock.Any()).
 		Return(nil)
 	handler.EXPECT().
-		AddEdge(gomock.Any(), u, testutil.ToUnstructured(t, configMap)).
+		AddEdge(gomock.Any(), u, testutil.ToUnstructured(t, serviceAccount), gomock.Any()).
 		Return(nil)
-	handler.EXPECT().AddEdge(gomock.Any(), u, testutil.ToUnstructured(t, secret)).
+	handler.EXPECT().
+		AddEdge(gomock.Any(), u, testutil.ToUnstructured(t, configMap), gomock.Any()).
 		Return(nil)
-	handler.EXPECT().AddEdge(gomock.Any(), u, testutil.ToUnstructured(t, pvc)).
+	handler.EXPECT().AddEdge(gomock.Any(), u, testutil.ToUnstructured(t, secret), gomock.Any()).
+		Return(nil)
+	handler.EXPECT().AddEdge(gomock.Any(), u, testutil.ToUnstructured(t, pvc), gomock.Any()).
 		Return(nil)
 
 	var visited []unstructured.Unstructured
 	visitor := fake.NewMockVisitor(controller)
 	visitor.EXPECT().
-		Visit(gomock.Any(), gomock.Any(), handler, true).
-		DoAndReturn(func(ctx context.Context, object *unstructured.Unstructured, handler objectvisitor.ObjectHandler, _ bool) error {
+		Visit(gomock.Any(), gomock.Any(), handler, true, gomock.Any()).
+		DoAndReturn(func(ctx context.Context, object *unstructured.Unstructured, handler objectvisitor.ObjectHandler, _ bool, _ int) error {
 			visited = append(visited, *object)
 			return nil
 		}).AnyTimes()
@@ -73,7 +74,7 @@ func TestPod_Visit(t *testing.T) {
 	pod := objectvisitor.NewPod(q)
 
 	ctx := context.Background()
-	err := pod.Visit(ctx, u, handler, visitor, true)
+	err := pod.Visit(ctx, u, handler, visitor, true, 1)
 
 	sortObjectsByName(t, visited)
 

--- a/internal/objectvisitor/service.go
+++ b/internal/objectvisitor/service.go
@@ -34,7 +34,7 @@ func (Service) Supports() schema.GroupVersionKind {
 }
 
 // Visit visits a service. It looks for associated pods and ingresses.
-func (s *Service) Visit(ctx context.Context, object *unstructured.Unstructured, handler ObjectHandler, visitor Visitor, visitDescendants bool) error {
+func (s *Service) Visit(ctx context.Context, object *unstructured.Unstructured, handler ObjectHandler, visitor Visitor, visitDescendants bool, level int) error {
 	ctx, span := trace.StartSpan(ctx, "visitService")
 	defer span.End()
 
@@ -42,6 +42,7 @@ func (s *Service) Visit(ctx context.Context, object *unstructured.Unstructured, 
 	if err := kubernetes.FromUnstructured(object, service); err != nil {
 		return err
 	}
+	level = handler.SetLevel(service.Kind, level)
 
 	var g errgroup.Group
 
@@ -59,11 +60,10 @@ func (s *Service) Visit(ctx context.Context, object *unstructured.Unstructured, 
 					return err
 				}
 				u := &unstructured.Unstructured{Object: m}
-				if err := visitor.Visit(ctx, u, handler, visitDescendants); err != nil {
+				if err := visitor.Visit(ctx, u, handler, visitDescendants, level); err != nil {
 					return err
 				}
-
-				return handler.AddEdge(ctx, object, u)
+				return handler.AddEdge(ctx, object, u, level)
 			})
 
 		}
@@ -86,13 +86,13 @@ func (s *Service) Visit(ctx context.Context, object *unstructured.Unstructured, 
 				}
 				u := &unstructured.Unstructured{Object: m}
 				if visitDescendants {
-					if err := visitor.Visit(ctx, u, handler, false); err != nil {
+					if err := visitor.Visit(ctx, u, handler, false, level); err != nil {
 						return errors.Wrapf(err, "service %s visit ingress %s",
 							kubernetes.PrintObject(service), kubernetes.PrintObject(ingress))
 					}
 				}
 
-				return handler.AddEdge(ctx, object, u)
+				return handler.AddEdge(ctx, object, u, level)
 			})
 		}
 
@@ -114,12 +114,12 @@ func (s *Service) Visit(ctx context.Context, object *unstructured.Unstructured, 
 				}
 				u := &unstructured.Unstructured{Object: m}
 				if visitDescendants {
-					if err := visitor.Visit(ctx, u, handler, false); err != nil {
+					if err := visitor.Visit(ctx, u, handler, false, level); err != nil {
 						return err
 					}
 				}
 
-				return handler.AddEdge(ctx, object, u)
+				return handler.AddEdge(ctx, object, u, level)
 			})
 
 		}
@@ -142,12 +142,12 @@ func (s *Service) Visit(ctx context.Context, object *unstructured.Unstructured, 
 				}
 				u := &unstructured.Unstructured{Object: m}
 				if visitDescendants {
-					if err := visitor.Visit(ctx, u, handler, false); err != nil {
+					if err := visitor.Visit(ctx, u, handler, false, level); err != nil {
 						return err
 					}
 				}
 
-				return handler.AddEdge(ctx, object, u)
+				return handler.AddEdge(ctx, object, u, level)
 			})
 
 		}
@@ -170,12 +170,12 @@ func (s *Service) Visit(ctx context.Context, object *unstructured.Unstructured, 
 				}
 				u := &unstructured.Unstructured{Object: m}
 				if visitDescendants {
-					if err := visitor.Visit(ctx, u, handler, false); err != nil {
+					if err := visitor.Visit(ctx, u, handler, false, level); err != nil {
 						return err
 					}
 				}
 
-				return handler.AddEdge(ctx, object, u)
+				return handler.AddEdge(ctx, object, u, level)
 			})
 
 		}

--- a/internal/objectvisitor/service_test.go
+++ b/internal/objectvisitor/service_test.go
@@ -49,28 +49,29 @@ func TestService_Visit(t *testing.T) {
 		Return([]*admissionregistrationv1.ValidatingWebhookConfiguration{validatingWebhookConfiguration}, nil)
 
 	handler := fake.NewMockObjectHandler(controller)
+	handler.EXPECT().SetLevel(gomock.Any(), 1).Return(2)
 	handler.EXPECT().
-		AddEdge(gomock.Any(), u, testutil.ToUnstructured(t, ingress)).
+		AddEdge(gomock.Any(), u, testutil.ToUnstructured(t, ingress), gomock.Any()).
 		Return(nil)
 	handler.EXPECT().
-		AddEdge(gomock.Any(), u, testutil.ToUnstructured(t, pod)).
+		AddEdge(gomock.Any(), u, testutil.ToUnstructured(t, pod), gomock.Any()).
 		Return(nil)
 	handler.EXPECT().
-		AddEdge(gomock.Any(), u, testutil.ToUnstructured(t, apiService)).
+		AddEdge(gomock.Any(), u, testutil.ToUnstructured(t, apiService), gomock.Any()).
 		Return(nil)
 	handler.EXPECT().
-		AddEdge(gomock.Any(), u, testutil.ToUnstructured(t, mutatingWebhookConfiguration)).
+		AddEdge(gomock.Any(), u, testutil.ToUnstructured(t, mutatingWebhookConfiguration), gomock.Any()).
 		Return(nil)
 	handler.EXPECT().
-		AddEdge(gomock.Any(), u, testutil.ToUnstructured(t, validatingWebhookConfiguration)).
+		AddEdge(gomock.Any(), u, testutil.ToUnstructured(t, validatingWebhookConfiguration), gomock.Any()).
 		Return(nil)
 
 	var visited []unstructured.Unstructured
 	var m sync.Mutex
 	visitor := fake.NewMockVisitor(controller)
 	visitor.EXPECT().
-		Visit(gomock.Any(), gomock.Any(), handler, gomock.Any()).
-		DoAndReturn(func(ctx context.Context, object *unstructured.Unstructured, handler objectvisitor.ObjectHandler, _ bool) error {
+		Visit(gomock.Any(), gomock.Any(), handler, gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, object *unstructured.Unstructured, handler objectvisitor.ObjectHandler, _ bool, _ int) error {
 			m.Lock()
 			defer m.Unlock()
 			visited = append(visited, *object)
@@ -82,7 +83,7 @@ func TestService_Visit(t *testing.T) {
 
 	ctx := context.Background()
 
-	err := service.Visit(ctx, u, handler, visitor, true)
+	err := service.Visit(ctx, u, handler, visitor, true, 1)
 
 	sortObjectsByName(t, visited)
 	expected := testutil.ToUnstructuredList(t, ingress, mutatingWebhookConfiguration, pod, apiService, validatingWebhookConfiguration)

--- a/internal/objectvisitor/validatingwebhookconfiguration_test.go
+++ b/internal/objectvisitor/validatingwebhookconfiguration_test.go
@@ -45,15 +45,16 @@ func TestValidatingWebhookConfiguration_Visit(t *testing.T) {
 	u := testutil.ToUnstructured(t, object)
 
 	handler := fake.NewMockObjectHandler(controller)
+	handler.EXPECT().SetLevel(gomock.Any(), 1).Return(2)
 	handler.EXPECT().
-		AddEdge(gomock.Any(), u, testutil.ToUnstructured(t, service)).
+		AddEdge(gomock.Any(), u, testutil.ToUnstructured(t, service), gomock.Any()).
 		Return(nil)
 
 	var visited []unstructured.Unstructured
 	visitor := fake.NewMockVisitor(controller)
 	visitor.EXPECT().
-		Visit(gomock.Any(), gomock.Any(), handler, gomock.Any()).
-		DoAndReturn(func(ctx context.Context, object *unstructured.Unstructured, handler objectvisitor.ObjectHandler, _ bool) error {
+		Visit(gomock.Any(), gomock.Any(), handler, gomock.Any(), 2).
+		DoAndReturn(func(ctx context.Context, object *unstructured.Unstructured, handler objectvisitor.ObjectHandler, _ bool, _ int) error {
 			visited = append(visited, *object)
 			return nil
 		})
@@ -73,7 +74,7 @@ func TestValidatingWebhookConfiguration_Visit(t *testing.T) {
 	validatingWebhookConfiguration := objectvisitor.NewValidatingWebhookConfiguration(objectStore)
 
 	ctx := context.Background()
-	err := validatingWebhookConfiguration.Visit(ctx, u, handler, visitor, true)
+	err := validatingWebhookConfiguration.Visit(ctx, u, handler, visitor, true, 1)
 
 	sortObjectsByName(t, visited)
 
@@ -103,12 +104,13 @@ func TestValidatingWebhookConfiguration_Visit_notfound(t *testing.T) {
 	u := testutil.ToUnstructured(t, object)
 
 	handler := fake.NewMockObjectHandler(controller)
+	handler.EXPECT().SetLevel(gomock.Any(), 1).Return(2)
 
 	var visited []unstructured.Unstructured
 	visitor := fake.NewMockVisitor(controller)
 	visitor.EXPECT().
-		Visit(gomock.Any(), gomock.Any(), handler, gomock.Any()).
-		DoAndReturn(func(ctx context.Context, object *unstructured.Unstructured, handler objectvisitor.ObjectHandler, _ bool) error {
+		Visit(gomock.Any(), gomock.Any(), handler, gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, object *unstructured.Unstructured, handler objectvisitor.ObjectHandler, _ bool, _ int) error {
 			visited = append(visited, *object)
 			return nil
 		}).AnyTimes()
@@ -128,7 +130,7 @@ func TestValidatingWebhookConfiguration_Visit_notfound(t *testing.T) {
 	validatingWebhookConfiguration := objectvisitor.NewValidatingWebhookConfiguration(objectStore)
 
 	ctx := context.Background()
-	err := validatingWebhookConfiguration.Visit(ctx, u, handler, visitor, true)
+	err := validatingWebhookConfiguration.Visit(ctx, u, handler, visitor, true, 1)
 
 	sortObjectsByName(t, visited)
 
@@ -154,12 +156,13 @@ func TestValidatingWebhookConfiguration_Visit_url(t *testing.T) {
 	u := testutil.ToUnstructured(t, object)
 
 	handler := fake.NewMockObjectHandler(controller)
+	handler.EXPECT().SetLevel(gomock.Any(), 1).Return(2)
 
 	var visited []unstructured.Unstructured
 	visitor := fake.NewMockVisitor(controller)
 	visitor.EXPECT().
-		Visit(gomock.Any(), gomock.Any(), handler, gomock.Any()).
-		DoAndReturn(func(ctx context.Context, object *unstructured.Unstructured, handler objectvisitor.ObjectHandler, _ bool) error {
+		Visit(gomock.Any(), gomock.Any(), handler, gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, object *unstructured.Unstructured, handler objectvisitor.ObjectHandler, _ bool, _ int) error {
 			visited = append(visited, *object)
 			return nil
 		}).AnyTimes()
@@ -169,7 +172,7 @@ func TestValidatingWebhookConfiguration_Visit_url(t *testing.T) {
 	validatingWebhookConfiguration := objectvisitor.NewValidatingWebhookConfiguration(objectStore)
 
 	ctx := context.Background()
-	err := validatingWebhookConfiguration.Visit(ctx, u, handler, visitor, true)
+	err := validatingWebhookConfiguration.Visit(ctx, u, handler, visitor, true, 1)
 
 	sortObjectsByName(t, visited)
 

--- a/internal/resourceviewer/resourceviewer_test.go
+++ b/internal/resourceviewer/resourceviewer_test.go
@@ -28,7 +28,7 @@ type stubbedVisitor struct{ visitErr error }
 
 var _ objectvisitor.Visitor = (*stubbedVisitor)(nil)
 
-func (v *stubbedVisitor) Visit(ctx context.Context, object *unstructured.Unstructured, handler objectvisitor.ObjectHandler, _ bool) error {
+func (v *stubbedVisitor) Visit(ctx context.Context, object *unstructured.Unstructured, handler objectvisitor.ObjectHandler, _ bool, _ int) error {
 	return v.visitErr
 }
 


### PR DESCRIPTION
This change divides the Resource Viewer node discovery in two parts: first during the tree traversal nodes are added to a cache, and at the end of traversal cached nodes are sorted and applied to the Resource Viewer layout. That ensures repeatable node order and consequently graph layout, while keeping the performance similar as before. This approach turned out to be more reliable than my first attempt of synchronizing the node creation by using go channels. 

Nodes are sorted first by tree depth level and then by node kind/name. This not only improves the visual layout, but it also groups nodes of same kind closer together, opening a door for node grouping and collapsing/expanding.

Signed-off-by: Milan Klanjsek <mklanjsek@pivotal.io>

- Fixes #1944, #1798

