### PR TITLE
Fix editor height when used in modals

### DIFF
--- a/changelogs/unreleased/2354-GuessWhoSamFoo
+++ b/changelogs/unreleased/2354-GuessWhoSamFoo
@@ -1,0 +1,1 @@
+Fix editor height when used in modals

--- a/web/src/app/modules/shared/components/presentation/modal/modal.component.html
+++ b/web/src/app/modules/shared/components/presentation/modal/modal.component.html
@@ -1,4 +1,4 @@
-<cds-modal size="lg" id="app-modal" [hidden]="!opened" [closable]="true" (closeChange)="toggleModal()">
+<cds-modal [size]="size" id="app-modal" [hidden]="!opened" [closable]="true" (closeChange)="toggleModal()">
   <cds-modal-header>
     <h3 cds-text="title" cds-first-focus tabindex="-1">
       <app-view-title [views]="title"></app-view-title>

--- a/web/src/app/modules/shared/components/presentation/modal/modal.component.scss
+++ b/web/src/app/modules/shared/components/presentation/modal/modal.component.scss
@@ -5,3 +5,9 @@
 app-view-container {
   width: 100%;
 }
+
+cds-modal-content {
+  ::ng-deep ngx-monaco-editor {
+    height: calc(60vh - 100px);
+  }
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Provides a reasonable default height for editor components inside modals.

**Which issue(s) this PR fixes**
- Fixes #2354 

Fixes hard coded large modal to use size parameter from #2328 

Signed-off-by: Sam Foo <foos@vmware.com>
