### PR TITLE
Remove extraneous div from tab buttons

### DIFF
--- a/web/src/app/modules/shared/components/presentation/tabs/tabs.component.html
+++ b/web/src/app/modules/shared/components/presentation/tabs/tabs.component.html
@@ -10,16 +10,14 @@
 </div>
 <clr-tabs *ngIf="tabs.length > 1; else noTabs">
   <clr-tab *ngFor="let tab of tabs; trackBy: identifyTab">
-    <div clrTabLink class="tab-button">
-      <button clrTabLink class="tab-button" (click)="clickTab(tab.accessor)">
-        {{ tab.name }}
-      </button>
-      <clr-icon
-        shape="times"
-        *ngIf="closable"
-        (click)="closeTab(tab.accessor)"
-      ></clr-icon>
-    </div>
+    <button clrTabLink class="tab-button" (click)="clickTab(tab.accessor)">
+      {{ tab.name }}
+    </button>
+    <clr-icon
+      shape="times"
+      *ngIf="closable"
+      (click)="closeTab(tab.accessor)"
+    ></clr-icon>
     <ng-template [clrIfActive]="activeTab === tab.accessor">
       <clr-tab-content>
         <app-view-container [view]="tab.view"></app-view-container>


### PR DESCRIPTION
Removes this double underline effect that can be observed between switching tabs.

![image](https://user-images.githubusercontent.com/10288252/116290338-35fa1d80-a748-11eb-825e-e46219a22547.png)

Signed-off-by: Sam Foo <foos@vmware.com>

