### PR TITLE
Add clipboard option to text component for secrets

### DIFF
--- a/changelogs/unreleased/512-GuessWhoSamFoo
+++ b/changelogs/unreleased/512-GuessWhoSamFoo
@@ -1,0 +1,1 @@
+Added clipboard option to text component

--- a/internal/printer/secret.go
+++ b/internal/printer/secret.go
@@ -103,10 +103,11 @@ func (s *SecretConfiguration) Create(options Options) (*component.Summary, error
 func describeSecretData(secret corev1.Secret) (*component.Table, error) {
 	table := component.NewTable("Data", "This secret has no data!", secretDataCols)
 
-	for key := range secret.Data {
+	for key, value := range secret.Data {
 		row := component.TableRow{}
-		row["Key"] = component.NewText(key)
-
+		keyText := component.NewText(key)
+		keyText.AddClipboard(string(value))
+		row["Key"] = keyText
 		table.Add(row)
 	}
 

--- a/internal/printer/secret_test.go
+++ b/internal/printer/secret_test.go
@@ -136,9 +136,13 @@ func Test_describeSecretData(t *testing.T) {
 
 	cols := component.NewTableCols("Key")
 	expected := component.NewTable("Data", "This secret has no data!", cols)
+	barText := component.NewText("bar")
+	barText.AddClipboard(string([]byte{0, 1, 2, 3}))
+	fooText := component.NewText("foo")
+	fooText.AddClipboard(string([]byte{0, 1, 2, 3}))
 	expected.Add([]component.TableRow{
-		{"Key": component.NewText("bar")},
-		{"Key": component.NewText("foo")},
+		{"Key": barText},
+		{"Key": fooText},
 	}...)
 
 	component.AssertEqual(t, expected, got)

--- a/pkg/view/component/text.go
+++ b/pkg/view/component/text.go
@@ -43,6 +43,8 @@ type TextConfig struct {
 	TrustedContent bool `json:"trustedContent,omitempty"`
 	// Status sets the status of the component.
 	Status TextStatus `json:"status,omitempty"`
+	// ClipboardValue adds a copy button with text to be added to clipboard
+	ClipboardValue string `json:"clipboardValue,omitempty"`
 }
 
 // NewText creates a text component
@@ -102,6 +104,11 @@ func (t *Text) DisableTrustedContent() {
 // DisableMarkdown disables markdown for this text component.
 func (t *Text) DisableMarkdown() {
 	t.Config.IsMarkdown = false
+}
+
+// AddClipboard adds a clipboard button next to text
+func (t *Text) AddClipboard(value string) {
+	t.Config.ClipboardValue = value
 }
 
 // SetStatus sets the status of the text component.

--- a/pkg/view/component/text_test.go
+++ b/pkg/view/component/text_test.go
@@ -83,6 +83,25 @@ func Test_Text_Marshal(t *testing.T) {
             }
 `,
 		},
+		{
+			name: "with clipboard",
+			input: &Text{
+				Config: TextConfig{
+					Text:           "secret",
+					ClipboardValue: "my-secret",
+				},
+			},
+			expected: `
+            {
+                "metadata": {
+                  "type": "text"
+                },
+                "config": {
+                  "value": "secret",
+				  "clipboardValue": "my-secret"
+                }
+            }
+`},
 	}
 
 	for _, tc := range tests {

--- a/web/src/app/modules/shared/components/presentation/text/text.component.html
+++ b/web/src/app/modules/shared/components/presentation/text/text.component.html
@@ -3,6 +3,14 @@
     <app-indicator [status]="view.config.status"></app-indicator>
   </ng-container>
   {{ value }}
+  <div *ngIf="clipboardValue" class="button-container">
+    <div cds-layout="horizonal gap:sm">
+      <cds-icon-button action="flat" ariaLabel="copy-button" (click)="copyToClipboard()">
+        <cds-icon shape="clipboard"></cds-icon>
+        <ng-container *ngIf="copied">Copied</ng-container>
+      </cds-icon-button>
+    </div>
+  </div>
 </ng-container>
 
 <ng-template #markdown>

--- a/web/src/app/modules/shared/components/presentation/text/text.component.scss
+++ b/web/src/app/modules/shared/components/presentation/text/text.component.scss
@@ -1,3 +1,7 @@
 /* Copyright (c) 2019 the Octant contributors. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+
+.button-container {
+  float: right;
+}

--- a/web/src/app/modules/shared/components/presentation/text/text.component.ts
+++ b/web/src/app/modules/shared/components/presentation/text/text.component.ts
@@ -1,7 +1,14 @@
 // Copyright (c) 2019 the Octant contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
-import { Component, OnInit, SecurityContext } from '@angular/core';
+import {
+  ChangeDetectorRef,
+  Component,
+  OnInit,
+  SecurityContext,
+} from '@angular/core';
+import '@cds/core/button/register';
+import { ClarityIcons, clipboardIcon } from '@cds/core/icon';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { TextView } from 'src/app/modules/shared/models/content';
 import { AbstractViewComponent } from '../../abstract-view/abstract-view.component';
@@ -16,13 +23,19 @@ export class TextComponent
   extends AbstractViewComponent<TextView>
   implements OnInit {
   value: string | SafeHtml;
+  clipboardValue: string;
+  copied: boolean;
 
   isMarkdown: boolean;
 
   hasStatus = false;
 
-  constructor(private readonly sanitizer: DomSanitizer) {
+  constructor(
+    private readonly sanitizer: DomSanitizer,
+    private cdr: ChangeDetectorRef
+  ) {
     super();
+    ClarityIcons.addIcons(clipboardIcon);
   }
 
   update() {
@@ -42,5 +55,23 @@ export class TextComponent
     if (view.config.status) {
       this.hasStatus = true;
     }
+
+    if (view.config.clipboardValue) {
+      this.clipboardValue = view.config.clipboardValue;
+    }
+  }
+
+  copyToClipboard(): void {
+    document.addEventListener('copy', (e: ClipboardEvent) => {
+      e.clipboardData.setData('text/plain', this.clipboardValue);
+      e.preventDefault();
+      document.removeEventListener('copy', null);
+    });
+    document.execCommand('copy');
+    this.copied = !this.copied;
+    setTimeout(() => {
+      this.copied = false;
+      this.cdr.detectChanges();
+    }, 1500);
   }
 }

--- a/web/src/app/modules/shared/models/content.ts
+++ b/web/src/app/modules/shared/models/content.ts
@@ -379,6 +379,7 @@ export interface TextView extends View {
     isMarkdown?: boolean;
     trustedContent?: boolean;
     status?: number;
+    clipboardValue?: string;
   };
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow users to copy secrets to clipboard without showing base64 decoded secrets on screen.

**Which issue(s) this PR fixes**
- Fixes #512 

![512](https://user-images.githubusercontent.com/10288252/116338212-433afa80-a790-11eb-8f2a-aee7037957c2.gif)
