### PR TITLE
Fix Daemonset incorrectly showing status when pod is unavailable

### DIFF
--- a/changelogs/unreleased/1565-GuessWhoSamFoo
+++ b/changelogs/unreleased/1565-GuessWhoSamFoo
@@ -1,0 +1,1 @@
+Fixed Daemonset incorrectly showing status when pod is unavailable

--- a/internal/objectstatus/daemonset.go
+++ b/internal/objectstatus/daemonset.go
@@ -36,7 +36,7 @@ func daemonSet(_ context.Context, object runtime.Object, _ store.Store) (ObjectS
 			nodeStatus: component.NodeStatusWarning,
 			Details:    []component.Component{component.NewText("Daemon Set pods are running on nodes that aren't supposed to run Daemon Set pods")},
 		}, nil
-	case status.NumberAvailable != status.NumberReady:
+	case status.DesiredNumberScheduled != status.NumberReady:
 		return ObjectStatus{
 			nodeStatus: component.NodeStatusWarning,
 			Details:    []component.Component{component.NewText("Daemon Set pods are not ready")},

--- a/pkg/view/component/button.go
+++ b/pkg/view/component/button.go
@@ -29,7 +29,7 @@ type ButtonStatus string
 const (
 	// ButtonSizeBlock is a full width button
 	ButtonSizeBlock ButtonSize = "block"
-	// ButtonSizeLarge is a small button
+	// ButtonSizeMedium is a clarity small button
 	ButtonSizeMedium ButtonSize = "md"
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The object status for daemonsets were checking against current number scheduled rather than desired number.

**Which issue(s) this PR fixes**
- Fixes #1565 
 Not fixing the second point raised in that issue where warning and error status are sorted to the top because many objects can change status at once and cause a poor UX if elements on a datagrid were constantly moving.
