### PR TITLE
Added SelectFile component

### DIFF
--- a/pkg/view/component/base.go
+++ b/pkg/view/component/base.go
@@ -66,6 +66,8 @@ const (
 	TypeQuadrant = "quadrant"
 	// TypeResourceViewer is a resource viewer component.
 	TypeResourceViewer = "resourceViewer"
+	// TypeSelectFile is a SelectFile component.
+	TypeSelectFile = "selectFile"
 	// TypeSelectors is a selectors component.
 	TypeSelectors = "selectors"
 	// TypeSingleStat is a single stat component.

--- a/pkg/view/component/select_file.go
+++ b/pkg/view/component/select_file.go
@@ -1,0 +1,68 @@
+package component
+
+import "encoding/json"
+
+type SelectFile struct {
+	Base
+	Config SelectFileConfig `json:"config"`
+}
+
+type Layout string
+
+const (
+	LayoutHorizontal Layout = "horizontal"
+	LayoutVertical   Layout = "vertical"
+	LayoutCompact    Layout = "compact"
+)
+
+type FileStatus string
+
+const (
+	FileStatusSuccess FileStatus = "success"
+	FileStatusError   FileStatus = "error"
+)
+
+type SelectFileConfig struct {
+	Label         string     `json:"label"`
+	Multiple      bool       `json:"multiple"`
+	Status        FileStatus `json:"status"`
+	StatusMessage string     `json:"statusMessage"`
+	Layout        Layout     `json:"layout"`
+	Action        string     `json:"action,omitempty"`
+}
+
+// NewSelectFile creates a new Select File component.
+func NewSelectFile(label string, multiple bool, layout Layout, action string) *SelectFile {
+	sel := &SelectFile{
+		Base: newBase(TypeSelectFile, nil),
+		Config: SelectFileConfig{
+			Label:    label,
+			Multiple: multiple,
+			Layout:   layout,
+			Action:   action,
+		},
+	}
+
+	return sel
+}
+
+// SetStatus sets the status and status message.
+func (sf *SelectFile) SetStatus(status FileStatus, message string) {
+	sf.Config.Status = status
+	sf.Config.StatusMessage = message
+}
+
+// GetMetadata accesses the components metadata. Implements Component.
+func (sf *SelectFile) GetMetadata() Metadata {
+	return sf.Metadata
+}
+
+type selectFileMarshal SelectFile
+
+// MarshalJSON implements json.Marshaler.
+func (sf *SelectFile) MarshalJSON() ([]byte, error) {
+	m := selectFileMarshal(*sf)
+	m.Metadata.Type = TypeSelectFile
+	m.Metadata.Title = sf.Metadata.Title
+	return json.Marshal(&m)
+}

--- a/pkg/view/component/select_file.go
+++ b/pkg/view/component/select_file.go
@@ -1,6 +1,6 @@
 package component
 
-import "encoding/json"
+import "github.com/vmware-tanzu/octant/internal/util/json"
 
 type SelectFile struct {
 	Base

--- a/pkg/view/component/select_file_test.go
+++ b/pkg/view/component/select_file_test.go
@@ -1,10 +1,11 @@
 package component
 
 import (
-	"encoding/json"
 	"io/ioutil"
 	"path"
 	"testing"
+
+	"github.com/vmware-tanzu/octant/internal/util/json"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/pkg/view/component/select_file_test.go
+++ b/pkg/view/component/select_file_test.go
@@ -1,0 +1,47 @@
+package component
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_SelectFile_Marshal(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        Component
+		expectedPath string
+		isErr        bool
+	}{
+		{
+			name:         "in general",
+			expectedPath: "select_file.json",
+			input: &SelectFile{
+				Base: newBase(TypeSelectFile, nil),
+				Config: SelectFileConfig{
+					Label:         "Open File",
+					Multiple:      false,
+					Status:        FileStatusSuccess,
+					StatusMessage: "Success",
+					Layout:        LayoutCompact,
+					Action:        "action.octant.dev/SelectFileAction",
+				}},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := json.Marshal(tc.input)
+			isErr := err != nil
+			if isErr != tc.isErr {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			expected, err := ioutil.ReadFile(path.Join("testdata", tc.expectedPath))
+			require.NoError(t, err)
+			assert.JSONEq(t, string(expected), string(actual))
+		})
+	}
+}

--- a/pkg/view/component/testdata/config_select_file.json
+++ b/pkg/view/component/testdata/config_select_file.json
@@ -1,0 +1,8 @@
+{
+  "label": "Open File",
+  "multiple": false,
+  "status": "success",
+  "statusMessage": "Success message",
+  "layout": "compact",
+  "action": "action.octant.dev/SelectFileAction"
+}

--- a/pkg/view/component/testdata/select_file.json
+++ b/pkg/view/component/testdata/select_file.json
@@ -1,0 +1,13 @@
+{
+  "metadata": {
+    "type": "selectFile"
+  },
+  "config": {
+    "label": "Open File",
+    "multiple": false,
+    "status": "success",
+    "statusMessage": "Success",
+    "layout": "compact",
+    "action": "action.octant.dev/SelectFileAction"
+  }
+}

--- a/pkg/view/component/unmarshal.go
+++ b/pkg/view/component/unmarshal.go
@@ -151,6 +151,11 @@ func unmarshal(to TypedObject) (Component, error) {
 		err = errors.Wrapf(json.Unmarshal(to.Config, &t.Config),
 			"unmarshal resourceViewer config")
 		o = t
+	case TypeSelectFile:
+		t := &SelectFile{Base: Base{Metadata: to.Metadata}}
+		err = errors.Wrapf(json.Unmarshal(to.Config, &t.Config),
+			"unmarshal select file config")
+		o = t
 	case TypeSelectors:
 		t := &Selectors{Base: Base{Metadata: to.Metadata}}
 		err = errors.Wrapf(json.Unmarshal(to.Config, &t.Config),

--- a/pkg/view/component/unmarshal_test.go
+++ b/pkg/view/component/unmarshal_test.go
@@ -411,6 +411,22 @@ func Test_unmarshal(t *testing.T) {
 			},
 		},
 		{
+			name:       "selectFile",
+			configFile: "config_select_file.json",
+			objectType: "selectFile",
+			expected: &SelectFile{
+				Config: SelectFileConfig{
+					Label:         "Open File",
+					Multiple:      false,
+					Status:        "success",
+					StatusMessage: "Success message",
+					Layout:        "compact",
+					Action:        "action.octant.dev/SelectFileAction",
+				},
+				Base: newBase(TypeSelectFile, nil),
+			},
+		},
+		{
 			name:       "selectors",
 			configFile: "config_selectors.json",
 			objectType: "selectors",

--- a/web/src/app/modules/shared/components/presentation/select-file/select-file.component.html
+++ b/web/src/app/modules/shared/components/presentation/select-file/select-file.component.html
@@ -1,0 +1,7 @@
+<cds-form-group [layout]="layout">
+  <cds-file>
+    <label>{{label}}</label>
+    <input #fileInput type="file" [multiple]= "multiple" (change)="inputFileChanged($event)"/>
+    <cds-control-message *ngIf="status" [status]="status">{{statusMessage}}</cds-control-message>
+  </cds-file>
+</cds-form-group>

--- a/web/src/app/modules/shared/components/presentation/select-file/select-file.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/select-file/select-file.component.spec.ts
@@ -1,0 +1,32 @@
+// Copyright (c) 2021 the Octant contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { SelectFileComponent } from './select-file.component';
+import { SharedModule } from '../../../shared.module';
+import { windowProvider, WindowToken } from '../../../../../window';
+
+describe('SelectFileComponent', () => {
+  let component: SelectFileComponent;
+  let fixture: ComponentFixture<SelectFileComponent>;
+
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [SharedModule],
+        providers: [{ provide: WindowToken, useFactory: windowProvider }],
+      }).compileComponents();
+    })
+  );
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SelectFileComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/web/src/app/modules/shared/components/presentation/select-file/select-file.component.ts
+++ b/web/src/app/modules/shared/components/presentation/select-file/select-file.component.ts
@@ -1,0 +1,73 @@
+// Copyright (c) 2021 the Octant contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import {
+  Component,
+  ElementRef,
+  EventEmitter,
+  isDevMode,
+  OnInit,
+  Output,
+  ViewChild,
+} from '@angular/core';
+import { AbstractViewComponent } from '../../abstract-view/abstract-view.component';
+import { SelectFileView } from '../../../models/content';
+import { WebsocketService } from '../../../../../data/services/websocket/websocket.service';
+import { ActionService } from '../../../services/action/action.service';
+
+@Component({
+  selector: 'app-view-select-file',
+  templateUrl: './select-file.component.html',
+})
+export class SelectFileComponent
+  extends AbstractViewComponent<SelectFileView>
+  implements OnInit {
+  label: string;
+  multiple: boolean;
+  layout: string;
+  status: string;
+  statusMessage: string;
+  action: string;
+
+  @ViewChild('fileInput') fileInput: ElementRef;
+  @Output() fileChanged: EventEmitter<any> = new EventEmitter<any>();
+
+  constructor(private actionService: ActionService) {
+    super();
+  }
+
+  update() {
+    const view = this.v;
+    this.label = view.config.label;
+    this.layout = view.config.layout;
+    this.multiple = view.config.multiple;
+    this.status = view.config.status;
+    this.status = view.config.status;
+    this.statusMessage = view.config.statusMessage;
+    this.action = view.config.action;
+  }
+
+  inputFileChanged(event) {
+    if (event.target.files && event.target.files[0]) {
+      if (this.fileChanged) {
+        this.fileChanged.emit(event.target.files);
+      }
+      if (isDevMode()) {
+        console.log('Selected file(s):', event.target.files);
+      }
+
+      if (this.action) {
+        this.actionService.perform({
+          action: this.action,
+          files: event.target.files,
+        });
+      }
+    }
+  }
+
+  reset() {
+    this.fileInput.nativeElement.value = '';
+    this.fileInput.nativeElement.dispatchEvent(new Event('change'));
+  }
+}

--- a/web/src/app/modules/shared/components/smart/editor/editor.component.html
+++ b/web/src/app/modules/shared/components/smart/editor/editor.component.html
@@ -8,15 +8,13 @@
   </div>
 
   <div class="controls">
-    <button (click)="reset()" [disabled]="!isModified" class="btn">
+    <app-view-select-file [view]= "selectFileView" (fileChanged)="inputFileChanged($event)"></app-view-select-file>
+    <cds-button size="sm" action="outline" (click)="reset()" [disabled]="!isModified" >
       Reset
-    </button>
-    <button
-      (click)="submit()"
-      [disabled]="isUpdateEnabled()"
-      class="btn btn-primary"
+    </cds-button>
+    <cds-button size="sm" action="outline" (click)="submit()" [disabled]="isUpdateEnabled()"
     >
       {{ submitLabel }}
-    </button>
+    </cds-button>
   </div>
 </div>

--- a/web/src/app/modules/shared/components/smart/editor/editor.component.scss
+++ b/web/src/app/modules/shared/components/smart/editor/editor.component.scss
@@ -29,9 +29,13 @@ ngx-monaco-editor {
 }
 
 .controls {
-  height: 50px;
+  display: flex;
 
-  button {
-    float: right;
+  cds-button {
+    margin-left: 16px;
+  }
+
+  app-view-select-file {
+    flex: 1;
   }
 }

--- a/web/src/app/modules/shared/components/smart/editor/editor.component.ts
+++ b/web/src/app/modules/shared/components/smart/editor/editor.component.ts
@@ -3,13 +3,14 @@ Copyright (c) 2020 the Octant contributors. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-import { Component, OnDestroy, OnInit } from '@angular/core';
-import { EditorView } from '../../../models/content';
+import { Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { EditorView, SelectFileView } from '../../../models/content';
 import { NamespaceService } from '../../../services/namespace/namespace.service';
 import { ActionService } from '../../../services/action/action.service';
 import { AbstractViewComponent } from '../../abstract-view/abstract-view.component';
 import { ThemeService } from '../../../services/theme/theme.service';
 import { Subscription } from 'rxjs';
+import { SelectFileComponent } from '../../presentation/select-file/select-file.component';
 
 interface Options {
   readOnly: boolean;
@@ -50,6 +51,20 @@ export class EditorComponent
   submitAction = 'action.octant.dev/update';
   submitLabel = 'Update';
 
+  @ViewChild(SelectFileComponent)
+  private selectFileComponent: SelectFileComponent;
+
+  selectFileView: SelectFileView = {
+    config: {
+      label: 'Open File',
+      multiple: false,
+      layout: 'compact',
+    },
+    metadata: {
+      type: 'selectFile',
+    },
+  };
+
   constructor(
     private namespaceService: NamespaceService,
     private themeService: ThemeService,
@@ -72,6 +87,18 @@ export class EditorComponent
     this.subscriptionTheme = this.themeService.themeType.subscribe(() =>
       this.syncMonacoTheme()
     );
+  }
+
+  inputFileChanged(files: any) {
+    if (files && files[0]) {
+      const reader = new FileReader();
+
+      reader.onload = e => {
+        this.editorValue = e.target.result as string;
+        this.isModified = true;
+      };
+      reader.readAsText(files[0]);
+    }
   }
 
   update() {
@@ -105,6 +132,7 @@ export class EditorComponent
   }
 
   reset() {
+    this.selectFileComponent.reset();
     this.value = this.pristineValue;
   }
 

--- a/web/src/app/modules/shared/dynamic-components.ts
+++ b/web/src/app/modules/shared/dynamic-components.ts
@@ -44,6 +44,7 @@ import { DropdownComponent } from './components/presentation/dropdown/dropdown.c
 import { IconComponent } from './components/presentation/icon/icon.component';
 import { SignpostComponent } from './components/presentation/signpost/signpost.component';
 import { ButtonComponent } from './components/presentation/button/button.component';
+import { SelectFileComponent } from './components/presentation/select-file/select-file.component';
 
 export interface ComponentMapping {
   [key: string]: Type<any>;
@@ -77,6 +78,7 @@ const DynamicComponentMapping: ComponentMapping = {
   ports: PortsComponent,
   quadrant: QuadrantComponent,
   resourceViewer: ResourceViewerComponent,
+  selectFile: SelectFileComponent,
   selectors: SelectorsComponent,
   singleStat: SingleStatComponent,
   stepper: StepperComponent,

--- a/web/src/app/modules/shared/models/content.ts
+++ b/web/src/app/modules/shared/models/content.ts
@@ -624,3 +624,14 @@ export interface ButtonView extends View {
     style?: string;
   };
 }
+
+export interface SelectFileView extends View {
+  config: {
+    label: string;
+    multiple: boolean;
+    layout: 'horizontal' | 'vertical' | 'compact';
+    status?: 'success' | 'error';
+    statusMessage?: string;
+    action?: string;
+  };
+}

--- a/web/src/app/modules/shared/shared.module.ts
+++ b/web/src/app/modules/shared/shared.module.ts
@@ -38,6 +38,7 @@ import { LabelSelectorComponent } from './components/presentation/label-selector
 import { ModalComponent } from './components/presentation/modal/modal.component';
 import { CytoscapeComponent } from './components/presentation/cytoscape/cytoscape.component';
 import { Cytoscape2Component } from './components/presentation/cytoscape2/cytoscape2.component';
+import { SelectFileComponent } from './components/presentation/select-file/select-file.component';
 import { SelectorsComponent } from './components/presentation/selectors/selectors.component';
 import { ResourceViewerComponent } from './components/presentation/resource-viewer/resource-viewer.component';
 import { SummaryComponent } from './components/presentation/summary/summary.component';
@@ -146,6 +147,7 @@ import { ButtonComponent } from './components/presentation/button/button.compone
     RelativePipe,
     TruncatePipe,
     SelectorsComponent,
+    SelectFileComponent,
     SingleStatComponent,
     SliderViewComponent,
     SummaryComponent,
@@ -218,6 +220,7 @@ import { ButtonComponent } from './components/presentation/button/button.compone
     ResourceViewerComponent,
     SignpostComponent,
     SelectorsComponent,
+    SelectFileComponent,
     SingleStatComponent,
     SliderViewComponent,
     SummaryComponent,
@@ -302,6 +305,7 @@ import { ButtonComponent } from './components/presentation/button/button.compone
     ResourceViewerComponent,
     SignpostComponent,
     SelectorsComponent,
+    SelectFileComponent,
     SliderViewComponent,
     SingleStatComponent,
     SummaryComponent,

--- a/web/src/stories/select.file.stories.mdx
+++ b/web/src/stories/select.file.stories.mdx
@@ -1,0 +1,43 @@
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
+import { argTypesView } from "./helpers/helpers";
+
+export const selectFileDocs= { source: { code: `text := component.NewText("sampleText")`}}
+
+export const selectFileView = {
+  metadata: {
+    type: 'selectFile',
+  },
+  config: {
+    label: 'Open File',
+    multiple: false,
+    status: 'success',
+    statusMessage: 'Success message',
+    layout: 'compact',
+    action: 'action.octant.dev/SelectFileAction'
+  },
+};
+
+export const SelectFileStoryTemplate = args => ({
+  template: `<app-view-select-file [view]= "view"></app-view-select-file>`,
+  argTypes: argTypesView,
+  props: { view: args.view },
+});
+
+<h1>Select File component</h1>
+<h2>Description</h2>
+
+<p>The Select File component is used to select a file or multiple files from a file system</p>
+<h2>Example</h2>
+
+<Meta title="Components/Select File" argTypes = { argTypesView } />
+
+<Canvas withToolbar>
+  <Story name="Select File component"
+         parameters={{ docs: selectFileDocs }}
+         args= {{ view: selectFileView }}>
+    { SelectFileStoryTemplate.bind({}) }
+  </Story>
+</Canvas>
+
+<h2>Props</h2>
+<ArgsTable story = "Select File component" />


### PR DESCRIPTION
Added a new SelectFile component intended to be used to select file(s) from the file system. 

Also added this new file selector to apply yaml, so it's now possible to select and open a yaml file before applying it.  While there, I refactored the form buttons to use `cds-button` and be consistent with the FileSelect button.

Signed-off-by: Milan Klanjsek <mklanjsek@pivotal.io>

- Fixes #2243 
