### PR TITLE
Fixed breadcrumbs breaking to 2nd row

### DIFF
--- a/web/src/app/modules/shared/components/presentation/tabs/tabs.component.html
+++ b/web/src/app/modules/shared/components/presentation/tabs/tabs.component.html
@@ -1,12 +1,8 @@
-<div class="clr-row clr-align-items-center clr-justify-content-between">
-  <div class="clr-col-6">
-    <app-breadcrumb [path]="title"> </app-breadcrumb>
-  </div>
-  <div class="clr-col-6">
-    <div *ngIf="titleComponents?.length > 0" class="title-container">
-      <div *ngFor="let component of titleComponents; trackBy: trackByIndex" class="item">
-        <app-view-container [view]="component"></app-view-container>
-      </div>
+<div class="breadcrumb-row">
+  <app-breadcrumb [path]="title"> </app-breadcrumb>
+  <div *ngIf="titleComponents?.length > 0" class="title-container">
+    <div *ngFor="let component of titleComponents; trackBy: trackByIndex" class="item">
+      <app-view-container [view]="component"></app-view-container>
     </div>
   </div>
 </div>

--- a/web/src/app/modules/shared/components/presentation/tabs/tabs.component.scss
+++ b/web/src/app/modules/shared/components/presentation/tabs/tabs.component.scss
@@ -6,10 +6,17 @@
   outline: none;
 }
 
+.breadcrumb-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+}
+
 .title-container {
-  float: right;
   display: flex;
   justify-content: space-between;
+  flex-wrap: wrap;
+  max-width: 10rem;
+  margin-left: 0.8rem;
 
   .item {
     margin: 0 5px;


### PR DESCRIPTION
Attempt to fix a problem with unnecessary breadcrumb breaking by moving away from fixed layout (as attempted in  #2423) and using the flexible column sizes. This approach ensures that breadcrumbs will break into the 2nd row only when absolutely necessary and at the same time prevents the right buttons taking too much space by imposing the `max-width`.  See how it works in this screen recording:

https://user-images.githubusercontent.com/34245594/117729725-7e81f400-b1a8-11eb-99d3-26f2f99e7c13.mov

Signed-off-by: Milan Klanjsek <mklanjsek@pivotal.io>

