### PR TITLE
Improved Resource Viewer initial selection

### DIFF
--- a/changelogs/unreleased/2408-mklanjsek
+++ b/changelogs/unreleased/2408-mklanjsek
@@ -1,0 +1,1 @@
+Improved Resource Viewer initial selection

--- a/internal/describer/tab.go
+++ b/internal/describer/tab.go
@@ -88,7 +88,11 @@ func ResourceViewerTab(ctx context.Context, object runtime.Object, options Optio
 
 	u := &unstructured.Unstructured{Object: m}
 
-	resourceViewerComponent, err := resourceviewer.Create(ctx, options.Dash, options.Queryer, u)
+	var selection = string(u.GetUID())
+	if u.GetKind() == "Pod" {
+		selection = fmt.Sprintf("%s pods", u.GetOwnerReferences()[0].Name)
+	}
+	resourceViewerComponent, err := resourceviewer.Create(ctx, options.Dash, options.Queryer, selection, u)
 	if err != nil {
 		return nil, fmt.Errorf("create resource viewer: %w", err)
 	}

--- a/internal/modules/workloads/detail_describer.go
+++ b/internal/modules/workloads/detail_describer.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"sort"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
@@ -124,7 +125,12 @@ _%s_
 		objects = append(objects, &pods[i])
 	}
 
-	rv, err := resourceviewer.Create(ctx, options.Dash, options.Queryer, objects...)
+	sort.Slice(objects, func(i, j int) bool {
+		return objects[i].GetName() < objects[j].GetName()
+	})
+
+	selection := objects[0].GetOwnerReferences()[0]
+	rv, err := resourceviewer.Create(ctx, options.Dash, options.Queryer, fmt.Sprintf("%s pods", selection.Name), objects...)
 	if err != nil {
 		cr := d.createResponse(
 			component.NewError(component.TitleFromString("Unable to create resource viewer"), err),

--- a/internal/resourceviewer/generator.go
+++ b/internal/resourceviewer/generator.go
@@ -3,8 +3,6 @@ package resourceviewer
 import (
 	"context"
 
-	"k8s.io/apimachinery/pkg/types"
-
 	"github.com/vmware-tanzu/octant/pkg/view/component"
 )
 
@@ -17,7 +15,7 @@ type Details interface {
 }
 
 // GenerateComponent generates a resource viewer component given details.
-func GenerateComponent(ctx context.Context, details Details, selected types.UID) (*component.ResourceViewer, error) {
+func GenerateComponent(ctx context.Context, details Details, selected string) (*component.ResourceViewer, error) {
 	rv := component.NewResourceViewer("Resource Viewer")
 	rv.SetAccessor("resourceViewer")
 
@@ -44,7 +42,7 @@ func GenerateComponent(ctx context.Context, details Details, selected types.UID)
 		}
 	}
 
-	rv.Select(string(selected))
+	rv.Select(selected)
 
 	return rv, nil
 }

--- a/internal/resourceviewer/generator_test.go
+++ b/internal/resourceviewer/generator_test.go
@@ -47,7 +47,7 @@ func TestGenerateComponent(t *testing.T) {
 
 	ctx := context.Background()
 
-	got, err := GenerateComponent(ctx, details, deployment.UID)
+	got, err := GenerateComponent(ctx, details, string(deployment.UID))
 	require.NoError(t, err)
 
 	expected := component.NewResourceViewer("Resource Viewer")

--- a/internal/resourceviewer/resourceviewer.go
+++ b/internal/resourceviewer/resourceviewer.go
@@ -51,7 +51,7 @@ type ResourceViewer struct {
 }
 
 // Create creates a resource viewer given a list objects.
-func Create(ctx context.Context, dashConfig config.Dash, q queryer.Queryer, objects ...*unstructured.Unstructured) (*component.ResourceViewer, error) {
+func Create(ctx context.Context, dashConfig config.Dash, q queryer.Queryer, selection string, objects ...*unstructured.Unstructured) (*component.ResourceViewer, error) {
 	rv, err := New(dashConfig, WithDefaultQueryer(dashConfig, q))
 	if err != nil {
 		return nil, fmt.Errorf("create resource viewer: %w", err)
@@ -74,7 +74,7 @@ func Create(ctx context.Context, dashConfig config.Dash, q queryer.Queryer, obje
 		}
 	}
 
-	c, err := GenerateComponent(ctx, handler, "")
+	c, err := GenerateComponent(ctx, handler, selection)
 	if err != nil {
 		return nil, fmt.Errorf("generate resource viewer component: %w", err)
 	}

--- a/internal/resourceviewer/resourceviewer_test.go
+++ b/internal/resourceviewer/resourceviewer_test.go
@@ -74,9 +74,10 @@ func Test_ResourceViewer(t *testing.T) {
 
 	require.NoError(t, rv.Visit(ctx, deployment, handler))
 
-	vc, err := GenerateComponent(ctx, handler, "")
+	vc, err := GenerateComponent(ctx, handler, "deployment")
 	require.NoError(t, err)
 	assert.NotNil(t, vc)
+	require.Equal(t, vc.Config.Selected, "deployment")
 }
 
 func Test_ResourceViewer_visitor_fails(t *testing.T) {

--- a/web/src/app/modules/shared/components/presentation/cytoscape/cytoscape.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/cytoscape/cytoscape.component.spec.ts
@@ -46,6 +46,7 @@ describe('CytoscapeComponent', () => {
       edges: [],
     };
 
+    component.selectedNodeId = '16428c94-a848-47d5-b1e3-c8245b57959b';
     component.render();
     fixture.detectChanges();
 

--- a/web/src/app/modules/shared/components/presentation/cytoscape/cytoscape.component.ts
+++ b/web/src/app/modules/shared/components/presentation/cytoscape/cytoscape.component.ts
@@ -33,6 +33,7 @@ export class CytoscapeComponent implements OnChanges, OnDestroy {
   @Input() public style: Stylesheet[];
   @Input() public layout: any;
   @Input() public zoom: any;
+  @Input() public selectedNodeId: string;
 
   @Output() select: EventEmitter<any> = new EventEmitter<any>();
   @Output() doubleClick: EventEmitter<any> = new EventEmitter<any>();
@@ -68,6 +69,7 @@ export class CytoscapeComponent implements OnChanges, OnDestroy {
     const localSelect = this.select;
     const localDoubleClick = this.doubleClick;
 
+    this.layout.padding = this.elements?.nodes?.length > 2 ? 20 : 200;
     this.instance = cytoscape({
       container: cyContainer,
       layout: this.layout,
@@ -91,9 +93,9 @@ export class CytoscapeComponent implements OnChanges, OnDestroy {
     });
 
     this.instance.one('render', _ => {
-      const firstNode = this.instance.nodes().first();
+      const selection = this.instance.getElementById(this.selectedNodeId);
       this.instance.nodes().unselect();
-      firstNode.select();
+      selection.select();
     });
 
     // @ts-ignore

--- a/web/src/app/modules/shared/components/presentation/resource-viewer/resource-viewer.component.html
+++ b/web/src/app/modules/shared/components/presentation/resource-viewer/resource-viewer.component.html
@@ -7,6 +7,7 @@
           [layout]="layout"
           [zoom]="zoom"
           [style]="style"
+          [selectedNodeId]="selectedNodeId"
           (select)="nodeChange($event)"
           (doubleClick)="openNode($event)"
         >
@@ -15,7 +16,7 @@
     </div>
     <div class="clr-col-3">
       <div class="status-container">
-        <app-view-object-status [node]="selectedNode"></app-view-object-status>
+        <app-view-object-status [node]="selectedNode()"></app-view-object-status>
       </div>
     </div>
   </div>

--- a/web/src/app/modules/shared/components/presentation/resource-viewer/resource-viewer.component.ts
+++ b/web/src/app/modules/shared/components/presentation/resource-viewer/resource-viewer.component.ts
@@ -38,7 +38,7 @@ const edgeColorCode = '#003d79';
 export class ResourceViewerComponent
   extends AbstractViewComponent<ResourceViewerView>
   implements OnInit, OnDestroy {
-  selectedNode: Node;
+  selectedNodeId: string;
   private subscriptionTheme: Subscription;
 
   layout = {
@@ -156,11 +156,11 @@ export class ResourceViewerComponent
   }
 
   selectNode(id: string) {
-    const nodes = this.v.config.nodes;
+    this.selectedNodeId = id;
+  }
 
-    if (nodes && nodes[id]) {
-      this.selectedNode = nodes[id];
-    }
+  selectedNode(): string {
+    return this.v?.config?.nodes[this.selectedNodeId];
   }
 
   openNode(event) {


### PR DESCRIPTION
Resource Viewer now initially selects proper object depending on current view. This is  important for showing the right context and it will be even more important as we start adding more info to the details pane. Additionally, this change tweaks the graph padding, so if one or two boxes are present, they will not take the whole view.  

Signed-off-by: Milan Klanjsek <mklanjsek@pivotal.io>

- Fixes #2408 
