### PR TITLE
show kube config path in preferences

### DIFF
--- a/changelogs/unreleased/2478-xtreme-vikram-yadav
+++ b/changelogs/unreleased/2478-xtreme-vikram-yadav
@@ -1,0 +1,1 @@
+Updated preferences to show local path to kube config

--- a/internal/api/context_manager_test.go
+++ b/internal/api/context_manager_test.go
@@ -50,8 +50,8 @@ func TestContext_GenerateContexts(t *testing.T) {
 	dashConfig.EXPECT().Logger().Return(logger).AnyTimes()
 
 	poller := api.NewSingleRunPoller()
-	generatorFunc := func(ctx context.Context, state octant.State) (event.Event, error) {
-		return ev, nil
+	generatorFunc := func(ctx context.Context, state octant.State) ([]event.Event, error) {
+		return []event.Event{ev}, nil
 	}
 	manager := api.NewContextManager(dashConfig,
 		api.WithContextGenerator(generatorFunc),

--- a/internal/api/helper_manager_test.go
+++ b/internal/api/helper_manager_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/vmware-tanzu/octant/internal/api/fake"
 	configFake "github.com/vmware-tanzu/octant/internal/config/fake"
 	"github.com/vmware-tanzu/octant/internal/log"
-	"github.com/vmware-tanzu/octant/internal/octant"
 	octantFake "github.com/vmware-tanzu/octant/internal/octant/fake"
 )
 
@@ -28,10 +27,15 @@ func TestHelperManager_GenerateContent(t *testing.T) {
 	state := octantFake.NewMockState(controller)
 	octantClient := fake.NewMockOctantClient(controller)
 
-	ev := event.Event{
-		Type: "event.octant.dev/buildInfo",
+	bev := event.Event{
+		Type: event.EventTypeBuildInfo,
 	}
-	octantClient.EXPECT().Send(ev)
+	octantClient.EXPECT().Send(bev)
+
+	kEv := event.Event{
+		Type: event.EventTypeKubeConfigPath,
+	}
+	octantClient.EXPECT().Send(kEv)
 
 	logger := log.NopLogger()
 
@@ -39,8 +43,8 @@ func TestHelperManager_GenerateContent(t *testing.T) {
 	dashConfig.EXPECT().Logger().Return(logger).AnyTimes()
 
 	poller := api.NewSingleRunPoller()
-	generatorFunc := func(ctx context.Context, state octant.State) (event.Event, error) {
-		return ev, nil
+	generatorFunc := func(ctx context.Context) ([]event.Event, error) {
+		return []event.Event{bev, kEv}, nil
 	}
 
 	manager := api.NewHelperStateManager(dashConfig,

--- a/internal/config/dash.go
+++ b/internal/config/dash.go
@@ -144,6 +144,8 @@ type Dash interface {
 	ModuleManager() module.ManagerInterface
 
 	BuildInfo() (string, string, string)
+
+	KubeConfigPath() string
 }
 
 // UseFSContext is used to indicate a context switch to the file system Kubeconfig context
@@ -161,6 +163,7 @@ type Live struct {
 	portForwarder        portforward.PortForwarder
 	restConfigOptions    cluster.RESTConfigOptions
 	buildInfo            BuildInfo
+	kubeConfigPath       string
 	contextChosenInUI    bool
 }
 
@@ -178,6 +181,7 @@ func NewLiveConfig(
 	portForwarder portforward.PortForwarder,
 	restConfigOptions cluster.RESTConfigOptions,
 	buildInfo BuildInfo,
+	kubeConfigPath string,
 	contextChosenInUI bool,
 ) *Live {
 	l := &Live{
@@ -191,6 +195,7 @@ func NewLiveConfig(
 		portForwarder:        portForwarder,
 		restConfigOptions:    restConfigOptions,
 		buildInfo:            buildInfo,
+		kubeConfigPath:       kubeConfigPath,
 		contextChosenInUI:    contextChosenInUI,
 	}
 
@@ -333,4 +338,8 @@ func (l *Live) ModuleManager() module.ManagerInterface {
 // BuildInfo returns build ldflag strings for version, commit hash, and build time
 func (l *Live) BuildInfo() (string, string, string) {
 	return l.buildInfo.Version, l.buildInfo.Commit, l.buildInfo.Time
+}
+
+func (l *Live) KubeConfigPath() string {
+	return l.kubeConfigPath
 }

--- a/internal/config/dash_test.go
+++ b/internal/config/dash_test.go
@@ -104,6 +104,7 @@ func TestLiveConfig(t *testing.T) {
 		portForwarder,
 		restConfigOptions,
 		buildInfo,
+		"",
 		false,
 	)
 
@@ -152,6 +153,7 @@ func TestLiveConfig_UseContext_WithContextChosenByUISetToTrue(t *testing.T) {
 		portForwarder,
 		restConfigOptions,
 		buildInfo,
+		"",
 		true, // contextChosenInUI
 	)
 
@@ -209,6 +211,7 @@ func TestLiveConfig_UseContext_WithContextChosenByUISetToFalse(t *testing.T) {
 		portForwarder,
 		restConfigOptions,
 		buildInfo,
+		"",
 		false, // contextChosenInUI
 	)
 

--- a/internal/config/fake/mock_dash.go
+++ b/internal/config/fake/mock_dash.go
@@ -21,30 +21,30 @@ import (
 	store "github.com/vmware-tanzu/octant/pkg/store"
 )
 
-// MockDash is a mock of Dash interface
+// MockDash is a mock of Dash interface.
 type MockDash struct {
 	ctrl     *gomock.Controller
 	recorder *MockDashMockRecorder
 }
 
-// MockDashMockRecorder is the mock recorder for MockDash
+// MockDashMockRecorder is the mock recorder for MockDash.
 type MockDashMockRecorder struct {
 	mock *MockDash
 }
 
-// NewMockDash creates a new mock instance
+// NewMockDash creates a new mock instance.
 func NewMockDash(ctrl *gomock.Controller) *MockDash {
 	mock := &MockDash{ctrl: ctrl}
 	mock.recorder = &MockDashMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockDash) EXPECT() *MockDashMockRecorder {
 	return m.recorder
 }
 
-// BuildInfo mocks base method
+// BuildInfo mocks base method.
 func (m *MockDash) BuildInfo() (string, string, string) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BuildInfo")
@@ -54,13 +54,13 @@ func (m *MockDash) BuildInfo() (string, string, string) {
 	return ret0, ret1, ret2
 }
 
-// BuildInfo indicates an expected call of BuildInfo
+// BuildInfo indicates an expected call of BuildInfo.
 func (mr *MockDashMockRecorder) BuildInfo() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildInfo", reflect.TypeOf((*MockDash)(nil).BuildInfo))
 }
 
-// CRDWatcher mocks base method
+// CRDWatcher mocks base method.
 func (m *MockDash) CRDWatcher() config.CRDWatcher {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CRDWatcher")
@@ -68,13 +68,13 @@ func (m *MockDash) CRDWatcher() config.CRDWatcher {
 	return ret0
 }
 
-// CRDWatcher indicates an expected call of CRDWatcher
+// CRDWatcher indicates an expected call of CRDWatcher.
 func (mr *MockDashMockRecorder) CRDWatcher() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CRDWatcher", reflect.TypeOf((*MockDash)(nil).CRDWatcher))
 }
 
-// ClusterClient mocks base method
+// ClusterClient mocks base method.
 func (m *MockDash) ClusterClient() cluster.ClientInterface {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ClusterClient")
@@ -82,13 +82,13 @@ func (m *MockDash) ClusterClient() cluster.ClientInterface {
 	return ret0
 }
 
-// ClusterClient indicates an expected call of ClusterClient
+// ClusterClient indicates an expected call of ClusterClient.
 func (mr *MockDashMockRecorder) ClusterClient() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterClient", reflect.TypeOf((*MockDash)(nil).ClusterClient))
 }
 
-// Contexts mocks base method
+// Contexts mocks base method.
 func (m *MockDash) Contexts() []kubeconfig.Context {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Contexts")
@@ -96,13 +96,13 @@ func (m *MockDash) Contexts() []kubeconfig.Context {
 	return ret0
 }
 
-// Contexts indicates an expected call of Contexts
+// Contexts indicates an expected call of Contexts.
 func (mr *MockDashMockRecorder) Contexts() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Contexts", reflect.TypeOf((*MockDash)(nil).Contexts))
 }
 
-// CurrentContext mocks base method
+// CurrentContext mocks base method.
 func (m *MockDash) CurrentContext() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CurrentContext")
@@ -110,13 +110,13 @@ func (m *MockDash) CurrentContext() string {
 	return ret0
 }
 
-// CurrentContext indicates an expected call of CurrentContext
+// CurrentContext indicates an expected call of CurrentContext.
 func (mr *MockDashMockRecorder) CurrentContext() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CurrentContext", reflect.TypeOf((*MockDash)(nil).CurrentContext))
 }
 
-// DefaultNamespace mocks base method
+// DefaultNamespace mocks base method.
 func (m *MockDash) DefaultNamespace() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DefaultNamespace")
@@ -124,13 +124,13 @@ func (m *MockDash) DefaultNamespace() string {
 	return ret0
 }
 
-// DefaultNamespace indicates an expected call of DefaultNamespace
+// DefaultNamespace indicates an expected call of DefaultNamespace.
 func (mr *MockDashMockRecorder) DefaultNamespace() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DefaultNamespace", reflect.TypeOf((*MockDash)(nil).DefaultNamespace))
 }
 
-// ErrorStore mocks base method
+// ErrorStore mocks base method.
 func (m *MockDash) ErrorStore() errors.ErrorStore {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ErrorStore")
@@ -138,13 +138,27 @@ func (m *MockDash) ErrorStore() errors.ErrorStore {
 	return ret0
 }
 
-// ErrorStore indicates an expected call of ErrorStore
+// ErrorStore indicates an expected call of ErrorStore.
 func (mr *MockDashMockRecorder) ErrorStore() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ErrorStore", reflect.TypeOf((*MockDash)(nil).ErrorStore))
 }
 
-// Logger mocks base method
+// KubeConfigPath mocks base method.
+func (m *MockDash) KubeConfigPath() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "KubeConfigPath")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// KubeConfigPath indicates an expected call of KubeConfigPath.
+func (mr *MockDashMockRecorder) KubeConfigPath() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KubeConfigPath", reflect.TypeOf((*MockDash)(nil).KubeConfigPath))
+}
+
+// Logger mocks base method.
 func (m *MockDash) Logger() log.Logger {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Logger")
@@ -152,13 +166,13 @@ func (m *MockDash) Logger() log.Logger {
 	return ret0
 }
 
-// Logger indicates an expected call of Logger
+// Logger indicates an expected call of Logger.
 func (mr *MockDashMockRecorder) Logger() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Logger", reflect.TypeOf((*MockDash)(nil).Logger))
 }
 
-// ModuleManager mocks base method
+// ModuleManager mocks base method.
 func (m *MockDash) ModuleManager() module.ManagerInterface {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModuleManager")
@@ -166,13 +180,13 @@ func (m *MockDash) ModuleManager() module.ManagerInterface {
 	return ret0
 }
 
-// ModuleManager indicates an expected call of ModuleManager
+// ModuleManager indicates an expected call of ModuleManager.
 func (mr *MockDashMockRecorder) ModuleManager() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModuleManager", reflect.TypeOf((*MockDash)(nil).ModuleManager))
 }
 
-// ObjectPath mocks base method
+// ObjectPath mocks base method.
 func (m *MockDash) ObjectPath(arg0, arg1, arg2, arg3 string) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ObjectPath", arg0, arg1, arg2, arg3)
@@ -181,13 +195,13 @@ func (m *MockDash) ObjectPath(arg0, arg1, arg2, arg3 string) (string, error) {
 	return ret0, ret1
 }
 
-// ObjectPath indicates an expected call of ObjectPath
+// ObjectPath indicates an expected call of ObjectPath.
 func (mr *MockDashMockRecorder) ObjectPath(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ObjectPath", reflect.TypeOf((*MockDash)(nil).ObjectPath), arg0, arg1, arg2, arg3)
 }
 
-// ObjectStore mocks base method
+// ObjectStore mocks base method.
 func (m *MockDash) ObjectStore() store.Store {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ObjectStore")
@@ -195,13 +209,13 @@ func (m *MockDash) ObjectStore() store.Store {
 	return ret0
 }
 
-// ObjectStore indicates an expected call of ObjectStore
+// ObjectStore indicates an expected call of ObjectStore.
 func (mr *MockDashMockRecorder) ObjectStore() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ObjectStore", reflect.TypeOf((*MockDash)(nil).ObjectStore))
 }
 
-// PluginManager mocks base method
+// PluginManager mocks base method.
 func (m *MockDash) PluginManager() plugin.ManagerInterface {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PluginManager")
@@ -209,13 +223,13 @@ func (m *MockDash) PluginManager() plugin.ManagerInterface {
 	return ret0
 }
 
-// PluginManager indicates an expected call of PluginManager
+// PluginManager indicates an expected call of PluginManager.
 func (mr *MockDashMockRecorder) PluginManager() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PluginManager", reflect.TypeOf((*MockDash)(nil).PluginManager))
 }
 
-// PortForwarder mocks base method
+// PortForwarder mocks base method.
 func (m *MockDash) PortForwarder() portforward.PortForwarder {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PortForwarder")
@@ -223,25 +237,25 @@ func (m *MockDash) PortForwarder() portforward.PortForwarder {
 	return ret0
 }
 
-// PortForwarder indicates an expected call of PortForwarder
+// PortForwarder indicates an expected call of PortForwarder.
 func (mr *MockDashMockRecorder) PortForwarder() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PortForwarder", reflect.TypeOf((*MockDash)(nil).PortForwarder))
 }
 
-// SetContextChosenInUI mocks base method
+// SetContextChosenInUI mocks base method.
 func (m *MockDash) SetContextChosenInUI(arg0 bool) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetContextChosenInUI", arg0)
 }
 
-// SetContextChosenInUI indicates an expected call of SetContextChosenInUI
+// SetContextChosenInUI indicates an expected call of SetContextChosenInUI.
 func (mr *MockDashMockRecorder) SetContextChosenInUI(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetContextChosenInUI", reflect.TypeOf((*MockDash)(nil).SetContextChosenInUI), arg0)
 }
 
-// UseContext mocks base method
+// UseContext mocks base method.
 func (m *MockDash) UseContext(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UseContext", arg0, arg1)
@@ -249,13 +263,13 @@ func (m *MockDash) UseContext(arg0 context.Context, arg1 string) error {
 	return ret0
 }
 
-// UseContext indicates an expected call of UseContext
+// UseContext indicates an expected call of UseContext.
 func (mr *MockDashMockRecorder) UseContext(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UseContext", reflect.TypeOf((*MockDash)(nil).UseContext), arg0, arg1)
 }
 
-// UseFSContext mocks base method
+// UseFSContext mocks base method.
 func (m *MockDash) UseFSContext(arg0 context.Context) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UseFSContext", arg0)
@@ -263,13 +277,13 @@ func (m *MockDash) UseFSContext(arg0 context.Context) error {
 	return ret0
 }
 
-// UseFSContext indicates an expected call of UseFSContext
+// UseFSContext indicates an expected call of UseFSContext.
 func (mr *MockDashMockRecorder) UseFSContext(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UseFSContext", reflect.TypeOf((*MockDash)(nil).UseFSContext), arg0)
 }
 
-// Validate mocks base method
+// Validate mocks base method.
 func (m *MockDash) Validate() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Validate")
@@ -277,7 +291,7 @@ func (m *MockDash) Validate() error {
 	return ret0
 }
 
-// Validate indicates an expected call of Validate
+// Validate indicates an expected call of Validate.
 func (mr *MockDashMockRecorder) Validate() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Validate", reflect.TypeOf((*MockDash)(nil).Validate))

--- a/internal/config/fake/mock_dash.go
+++ b/internal/config/fake/mock_dash.go
@@ -21,30 +21,30 @@ import (
 	store "github.com/vmware-tanzu/octant/pkg/store"
 )
 
-// MockDash is a mock of Dash interface.
+// MockDash is a mock of Dash interface
 type MockDash struct {
 	ctrl     *gomock.Controller
 	recorder *MockDashMockRecorder
 }
 
-// MockDashMockRecorder is the mock recorder for MockDash.
+// MockDashMockRecorder is the mock recorder for MockDash
 type MockDashMockRecorder struct {
 	mock *MockDash
 }
 
-// NewMockDash creates a new mock instance.
+// NewMockDash creates a new mock instance
 func NewMockDash(ctrl *gomock.Controller) *MockDash {
 	mock := &MockDash{ctrl: ctrl}
 	mock.recorder = &MockDashMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockDash) EXPECT() *MockDashMockRecorder {
 	return m.recorder
 }
 
-// BuildInfo mocks base method.
+// BuildInfo mocks base method
 func (m *MockDash) BuildInfo() (string, string, string) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BuildInfo")
@@ -54,13 +54,13 @@ func (m *MockDash) BuildInfo() (string, string, string) {
 	return ret0, ret1, ret2
 }
 
-// BuildInfo indicates an expected call of BuildInfo.
+// BuildInfo indicates an expected call of BuildInfo
 func (mr *MockDashMockRecorder) BuildInfo() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildInfo", reflect.TypeOf((*MockDash)(nil).BuildInfo))
 }
 
-// CRDWatcher mocks base method.
+// CRDWatcher mocks base method
 func (m *MockDash) CRDWatcher() config.CRDWatcher {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CRDWatcher")
@@ -68,13 +68,13 @@ func (m *MockDash) CRDWatcher() config.CRDWatcher {
 	return ret0
 }
 
-// CRDWatcher indicates an expected call of CRDWatcher.
+// CRDWatcher indicates an expected call of CRDWatcher
 func (mr *MockDashMockRecorder) CRDWatcher() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CRDWatcher", reflect.TypeOf((*MockDash)(nil).CRDWatcher))
 }
 
-// ClusterClient mocks base method.
+// ClusterClient mocks base method
 func (m *MockDash) ClusterClient() cluster.ClientInterface {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ClusterClient")
@@ -82,13 +82,13 @@ func (m *MockDash) ClusterClient() cluster.ClientInterface {
 	return ret0
 }
 
-// ClusterClient indicates an expected call of ClusterClient.
+// ClusterClient indicates an expected call of ClusterClient
 func (mr *MockDashMockRecorder) ClusterClient() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterClient", reflect.TypeOf((*MockDash)(nil).ClusterClient))
 }
 
-// Contexts mocks base method.
+// Contexts mocks base method
 func (m *MockDash) Contexts() []kubeconfig.Context {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Contexts")
@@ -96,13 +96,13 @@ func (m *MockDash) Contexts() []kubeconfig.Context {
 	return ret0
 }
 
-// Contexts indicates an expected call of Contexts.
+// Contexts indicates an expected call of Contexts
 func (mr *MockDashMockRecorder) Contexts() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Contexts", reflect.TypeOf((*MockDash)(nil).Contexts))
 }
 
-// CurrentContext mocks base method.
+// CurrentContext mocks base method
 func (m *MockDash) CurrentContext() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CurrentContext")
@@ -110,13 +110,13 @@ func (m *MockDash) CurrentContext() string {
 	return ret0
 }
 
-// CurrentContext indicates an expected call of CurrentContext.
+// CurrentContext indicates an expected call of CurrentContext
 func (mr *MockDashMockRecorder) CurrentContext() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CurrentContext", reflect.TypeOf((*MockDash)(nil).CurrentContext))
 }
 
-// DefaultNamespace mocks base method.
+// DefaultNamespace mocks base method
 func (m *MockDash) DefaultNamespace() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DefaultNamespace")
@@ -124,13 +124,13 @@ func (m *MockDash) DefaultNamespace() string {
 	return ret0
 }
 
-// DefaultNamespace indicates an expected call of DefaultNamespace.
+// DefaultNamespace indicates an expected call of DefaultNamespace
 func (mr *MockDashMockRecorder) DefaultNamespace() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DefaultNamespace", reflect.TypeOf((*MockDash)(nil).DefaultNamespace))
 }
 
-// ErrorStore mocks base method.
+// ErrorStore mocks base method
 func (m *MockDash) ErrorStore() errors.ErrorStore {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ErrorStore")
@@ -138,13 +138,13 @@ func (m *MockDash) ErrorStore() errors.ErrorStore {
 	return ret0
 }
 
-// ErrorStore indicates an expected call of ErrorStore.
+// ErrorStore indicates an expected call of ErrorStore
 func (mr *MockDashMockRecorder) ErrorStore() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ErrorStore", reflect.TypeOf((*MockDash)(nil).ErrorStore))
 }
 
-// KubeConfigPath mocks base method.
+// KubeConfigPath mocks base method
 func (m *MockDash) KubeConfigPath() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "KubeConfigPath")
@@ -152,13 +152,13 @@ func (m *MockDash) KubeConfigPath() string {
 	return ret0
 }
 
-// KubeConfigPath indicates an expected call of KubeConfigPath.
+// KubeConfigPath indicates an expected call of KubeConfigPath
 func (mr *MockDashMockRecorder) KubeConfigPath() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KubeConfigPath", reflect.TypeOf((*MockDash)(nil).KubeConfigPath))
 }
 
-// Logger mocks base method.
+// Logger mocks base method
 func (m *MockDash) Logger() log.Logger {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Logger")
@@ -166,13 +166,13 @@ func (m *MockDash) Logger() log.Logger {
 	return ret0
 }
 
-// Logger indicates an expected call of Logger.
+// Logger indicates an expected call of Logger
 func (mr *MockDashMockRecorder) Logger() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Logger", reflect.TypeOf((*MockDash)(nil).Logger))
 }
 
-// ModuleManager mocks base method.
+// ModuleManager mocks base method
 func (m *MockDash) ModuleManager() module.ManagerInterface {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModuleManager")
@@ -180,13 +180,13 @@ func (m *MockDash) ModuleManager() module.ManagerInterface {
 	return ret0
 }
 
-// ModuleManager indicates an expected call of ModuleManager.
+// ModuleManager indicates an expected call of ModuleManager
 func (mr *MockDashMockRecorder) ModuleManager() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModuleManager", reflect.TypeOf((*MockDash)(nil).ModuleManager))
 }
 
-// ObjectPath mocks base method.
+// ObjectPath mocks base method
 func (m *MockDash) ObjectPath(arg0, arg1, arg2, arg3 string) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ObjectPath", arg0, arg1, arg2, arg3)
@@ -195,13 +195,13 @@ func (m *MockDash) ObjectPath(arg0, arg1, arg2, arg3 string) (string, error) {
 	return ret0, ret1
 }
 
-// ObjectPath indicates an expected call of ObjectPath.
+// ObjectPath indicates an expected call of ObjectPath
 func (mr *MockDashMockRecorder) ObjectPath(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ObjectPath", reflect.TypeOf((*MockDash)(nil).ObjectPath), arg0, arg1, arg2, arg3)
 }
 
-// ObjectStore mocks base method.
+// ObjectStore mocks base method
 func (m *MockDash) ObjectStore() store.Store {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ObjectStore")
@@ -209,13 +209,13 @@ func (m *MockDash) ObjectStore() store.Store {
 	return ret0
 }
 
-// ObjectStore indicates an expected call of ObjectStore.
+// ObjectStore indicates an expected call of ObjectStore
 func (mr *MockDashMockRecorder) ObjectStore() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ObjectStore", reflect.TypeOf((*MockDash)(nil).ObjectStore))
 }
 
-// PluginManager mocks base method.
+// PluginManager mocks base method
 func (m *MockDash) PluginManager() plugin.ManagerInterface {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PluginManager")
@@ -223,13 +223,13 @@ func (m *MockDash) PluginManager() plugin.ManagerInterface {
 	return ret0
 }
 
-// PluginManager indicates an expected call of PluginManager.
+// PluginManager indicates an expected call of PluginManager
 func (mr *MockDashMockRecorder) PluginManager() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PluginManager", reflect.TypeOf((*MockDash)(nil).PluginManager))
 }
 
-// PortForwarder mocks base method.
+// PortForwarder mocks base method
 func (m *MockDash) PortForwarder() portforward.PortForwarder {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PortForwarder")
@@ -237,25 +237,25 @@ func (m *MockDash) PortForwarder() portforward.PortForwarder {
 	return ret0
 }
 
-// PortForwarder indicates an expected call of PortForwarder.
+// PortForwarder indicates an expected call of PortForwarder
 func (mr *MockDashMockRecorder) PortForwarder() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PortForwarder", reflect.TypeOf((*MockDash)(nil).PortForwarder))
 }
 
-// SetContextChosenInUI mocks base method.
+// SetContextChosenInUI mocks base method
 func (m *MockDash) SetContextChosenInUI(arg0 bool) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetContextChosenInUI", arg0)
 }
 
-// SetContextChosenInUI indicates an expected call of SetContextChosenInUI.
+// SetContextChosenInUI indicates an expected call of SetContextChosenInUI
 func (mr *MockDashMockRecorder) SetContextChosenInUI(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetContextChosenInUI", reflect.TypeOf((*MockDash)(nil).SetContextChosenInUI), arg0)
 }
 
-// UseContext mocks base method.
+// UseContext mocks base method
 func (m *MockDash) UseContext(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UseContext", arg0, arg1)
@@ -263,13 +263,13 @@ func (m *MockDash) UseContext(arg0 context.Context, arg1 string) error {
 	return ret0
 }
 
-// UseContext indicates an expected call of UseContext.
+// UseContext indicates an expected call of UseContext
 func (mr *MockDashMockRecorder) UseContext(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UseContext", reflect.TypeOf((*MockDash)(nil).UseContext), arg0, arg1)
 }
 
-// UseFSContext mocks base method.
+// UseFSContext mocks base method
 func (m *MockDash) UseFSContext(arg0 context.Context) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UseFSContext", arg0)
@@ -277,13 +277,13 @@ func (m *MockDash) UseFSContext(arg0 context.Context) error {
 	return ret0
 }
 
-// UseFSContext indicates an expected call of UseFSContext.
+// UseFSContext indicates an expected call of UseFSContext
 func (mr *MockDashMockRecorder) UseFSContext(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UseFSContext", reflect.TypeOf((*MockDash)(nil).UseFSContext), arg0)
 }
 
-// Validate mocks base method.
+// Validate mocks base method
 func (m *MockDash) Validate() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Validate")
@@ -291,7 +291,7 @@ func (m *MockDash) Validate() error {
 	return ret0
 }
 
-// Validate indicates an expected call of Validate.
+// Validate indicates an expected call of Validate
 func (mr *MockDashMockRecorder) Validate() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Validate", reflect.TypeOf((*MockDash)(nil).Validate))

--- a/internal/config/fake/mock_kubecontextdecorator.go
+++ b/internal/config/fake/mock_kubecontextdecorator.go
@@ -9,34 +9,35 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+
 	cluster "github.com/vmware-tanzu/octant/internal/cluster"
 	kubeconfig "github.com/vmware-tanzu/octant/internal/kubeconfig"
 )
 
-// MockKubeContextDecorator is a mock of KubeContextDecorator interface.
+// MockKubeContextDecorator is a mock of KubeContextDecorator interface
 type MockKubeContextDecorator struct {
 	ctrl     *gomock.Controller
 	recorder *MockKubeContextDecoratorMockRecorder
 }
 
-// MockKubeContextDecoratorMockRecorder is the mock recorder for MockKubeContextDecorator.
+// MockKubeContextDecoratorMockRecorder is the mock recorder for MockKubeContextDecorator
 type MockKubeContextDecoratorMockRecorder struct {
 	mock *MockKubeContextDecorator
 }
 
-// NewMockKubeContextDecorator creates a new mock instance.
+// NewMockKubeContextDecorator creates a new mock instance
 func NewMockKubeContextDecorator(ctrl *gomock.Controller) *MockKubeContextDecorator {
 	mock := &MockKubeContextDecorator{ctrl: ctrl}
 	mock.recorder = &MockKubeContextDecoratorMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockKubeContextDecorator) EXPECT() *MockKubeContextDecoratorMockRecorder {
 	return m.recorder
 }
 
-// ClusterClient mocks base method.
+// ClusterClient mocks base method
 func (m *MockKubeContextDecorator) ClusterClient() cluster.ClientInterface {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ClusterClient")
@@ -44,13 +45,13 @@ func (m *MockKubeContextDecorator) ClusterClient() cluster.ClientInterface {
 	return ret0
 }
 
-// ClusterClient indicates an expected call of ClusterClient.
+// ClusterClient indicates an expected call of ClusterClient
 func (mr *MockKubeContextDecoratorMockRecorder) ClusterClient() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterClient", reflect.TypeOf((*MockKubeContextDecorator)(nil).ClusterClient))
 }
 
-// Contexts mocks base method.
+// Contexts mocks base method
 func (m *MockKubeContextDecorator) Contexts() []kubeconfig.Context {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Contexts")
@@ -58,13 +59,13 @@ func (m *MockKubeContextDecorator) Contexts() []kubeconfig.Context {
 	return ret0
 }
 
-// Contexts indicates an expected call of Contexts.
+// Contexts indicates an expected call of Contexts
 func (mr *MockKubeContextDecoratorMockRecorder) Contexts() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Contexts", reflect.TypeOf((*MockKubeContextDecorator)(nil).Contexts))
 }
 
-// CurrentContext mocks base method.
+// CurrentContext mocks base method
 func (m *MockKubeContextDecorator) CurrentContext() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CurrentContext")
@@ -72,13 +73,13 @@ func (m *MockKubeContextDecorator) CurrentContext() string {
 	return ret0
 }
 
-// CurrentContext indicates an expected call of CurrentContext.
+// CurrentContext indicates an expected call of CurrentContext
 func (mr *MockKubeContextDecoratorMockRecorder) CurrentContext() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CurrentContext", reflect.TypeOf((*MockKubeContextDecorator)(nil).CurrentContext))
 }
 
-// SwitchContext mocks base method.
+// SwitchContext mocks base method
 func (m *MockKubeContextDecorator) SwitchContext(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SwitchContext", arg0, arg1)
@@ -86,7 +87,7 @@ func (m *MockKubeContextDecorator) SwitchContext(arg0 context.Context, arg1 stri
 	return ret0
 }
 
-// SwitchContext indicates an expected call of SwitchContext.
+// SwitchContext indicates an expected call of SwitchContext
 func (mr *MockKubeContextDecoratorMockRecorder) SwitchContext(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SwitchContext", reflect.TypeOf((*MockKubeContextDecorator)(nil).SwitchContext), arg0, arg1)

--- a/internal/config/fake/mock_kubecontextdecorator.go
+++ b/internal/config/fake/mock_kubecontextdecorator.go
@@ -9,35 +9,34 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-
 	cluster "github.com/vmware-tanzu/octant/internal/cluster"
 	kubeconfig "github.com/vmware-tanzu/octant/internal/kubeconfig"
 )
 
-// MockKubeContextDecorator is a mock of KubeContextDecorator interface
+// MockKubeContextDecorator is a mock of KubeContextDecorator interface.
 type MockKubeContextDecorator struct {
 	ctrl     *gomock.Controller
 	recorder *MockKubeContextDecoratorMockRecorder
 }
 
-// MockKubeContextDecoratorMockRecorder is the mock recorder for MockKubeContextDecorator
+// MockKubeContextDecoratorMockRecorder is the mock recorder for MockKubeContextDecorator.
 type MockKubeContextDecoratorMockRecorder struct {
 	mock *MockKubeContextDecorator
 }
 
-// NewMockKubeContextDecorator creates a new mock instance
+// NewMockKubeContextDecorator creates a new mock instance.
 func NewMockKubeContextDecorator(ctrl *gomock.Controller) *MockKubeContextDecorator {
 	mock := &MockKubeContextDecorator{ctrl: ctrl}
 	mock.recorder = &MockKubeContextDecoratorMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockKubeContextDecorator) EXPECT() *MockKubeContextDecoratorMockRecorder {
 	return m.recorder
 }
 
-// ClusterClient mocks base method
+// ClusterClient mocks base method.
 func (m *MockKubeContextDecorator) ClusterClient() cluster.ClientInterface {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ClusterClient")
@@ -45,13 +44,13 @@ func (m *MockKubeContextDecorator) ClusterClient() cluster.ClientInterface {
 	return ret0
 }
 
-// ClusterClient indicates an expected call of ClusterClient
+// ClusterClient indicates an expected call of ClusterClient.
 func (mr *MockKubeContextDecoratorMockRecorder) ClusterClient() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterClient", reflect.TypeOf((*MockKubeContextDecorator)(nil).ClusterClient))
 }
 
-// Contexts mocks base method
+// Contexts mocks base method.
 func (m *MockKubeContextDecorator) Contexts() []kubeconfig.Context {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Contexts")
@@ -59,13 +58,13 @@ func (m *MockKubeContextDecorator) Contexts() []kubeconfig.Context {
 	return ret0
 }
 
-// Contexts indicates an expected call of Contexts
+// Contexts indicates an expected call of Contexts.
 func (mr *MockKubeContextDecoratorMockRecorder) Contexts() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Contexts", reflect.TypeOf((*MockKubeContextDecorator)(nil).Contexts))
 }
 
-// CurrentContext mocks base method
+// CurrentContext mocks base method.
 func (m *MockKubeContextDecorator) CurrentContext() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CurrentContext")
@@ -73,13 +72,13 @@ func (m *MockKubeContextDecorator) CurrentContext() string {
 	return ret0
 }
 
-// CurrentContext indicates an expected call of CurrentContext
+// CurrentContext indicates an expected call of CurrentContext.
 func (mr *MockKubeContextDecoratorMockRecorder) CurrentContext() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CurrentContext", reflect.TypeOf((*MockKubeContextDecorator)(nil).CurrentContext))
 }
 
-// SwitchContext mocks base method
+// SwitchContext mocks base method.
 func (m *MockKubeContextDecorator) SwitchContext(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SwitchContext", arg0, arg1)
@@ -87,7 +86,7 @@ func (m *MockKubeContextDecorator) SwitchContext(arg0 context.Context, arg1 stri
 	return ret0
 }
 
-// SwitchContext indicates an expected call of SwitchContext
+// SwitchContext indicates an expected call of SwitchContext.
 func (mr *MockKubeContextDecoratorMockRecorder) SwitchContext(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SwitchContext", reflect.TypeOf((*MockKubeContextDecorator)(nil).SwitchContext), arg0, arg1)

--- a/internal/event/context.go
+++ b/internal/event/context.go
@@ -48,7 +48,7 @@ func NewContextsGenerator(kubeContextStore KubeContextStore, options ...ContextG
 	return kcg
 }
 
-func (g *ContextsGenerator) Event(ctx context.Context) (event.Event, error) {
+func (g *ContextsGenerator) Events(ctx context.Context) ([]event.Event, error) {
 	resp := kubeContextsResponse{
 		CurrentContext: g.KubeContextStore.CurrentContext(),
 		Contexts:       g.KubeContextStore.Contexts(),
@@ -63,7 +63,7 @@ func (g *ContextsGenerator) Event(ctx context.Context) (event.Event, error) {
 		Data: resp,
 	}
 
-	return e, nil
+	return []event.Event{e}, nil
 }
 
 func (ContextsGenerator) ScheduleDelay() time.Duration {

--- a/internal/event/context_test.go
+++ b/internal/event/context_test.go
@@ -31,9 +31,10 @@ func Test_kubeContextGenerator(t *testing.T) {
 	assert.Equal(t, "kubeConfig", kgc.Name())
 
 	ctx := context.Background()
-	e, err := kgc.Event(ctx)
+	evs, err := kgc.Events(ctx)
 	require.NoError(t, err)
 
+	e := evs[0]
 	assert.Equal(t, event.EventTypeKubeConfig, e.Type)
 
 	resp := kubeContextsResponse{

--- a/internal/event/helper.go
+++ b/internal/event/helper.go
@@ -21,6 +21,10 @@ type buildInfoResponse struct {
 	Time    string `json:"time"`
 }
 
+type kubeConfigPathResponse struct {
+	Path string `json:"path"`
+}
+
 type HelperGeneratorOption func(generator *HelperGenerator)
 
 type HelperGenerator struct {
@@ -41,7 +45,7 @@ func NewHelperGenerator(dashConfig config.Dash, options ...HelperGeneratorOption
 	return hg
 }
 
-func (h *HelperGenerator) Event(ctx context.Context) (event.Event, error) {
+func (h *HelperGenerator) Events(ctx context.Context) ([]event.Event, error) {
 	version, commit, time := h.DashConfig.BuildInfo()
 
 	resp := buildInfoResponse{
@@ -50,12 +54,17 @@ func (h *HelperGenerator) Event(ctx context.Context) (event.Event, error) {
 		Time:    time,
 	}
 
-	e := event.Event{
+	buildInfoEvent := event.Event{
 		Type: event.EventTypeBuildInfo,
 		Data: resp,
 	}
 
-	return e, nil
+	kubeConfigPathEvent := event.Event{
+		Type: event.EventTypeKubeConfigPath,
+		Data: kubeConfigPathResponse{h.DashConfig.KubeConfigPath()},
+	}
+
+	return []event.Event{buildInfoEvent, kubeConfigPathEvent}, nil
 }
 
 func (HelperGenerator) ScheduleDelay() time.Duration {

--- a/internal/octant/fake/mock_generator.go
+++ b/internal/octant/fake/mock_generator.go
@@ -10,33 +10,34 @@ import (
 	time "time"
 
 	gomock "github.com/golang/mock/gomock"
+
 	event "github.com/vmware-tanzu/octant/pkg/event"
 )
 
-// MockGenerator is a mock of Generator interface.
+// MockGenerator is a mock of Generator interface
 type MockGenerator struct {
 	ctrl     *gomock.Controller
 	recorder *MockGeneratorMockRecorder
 }
 
-// MockGeneratorMockRecorder is the mock recorder for MockGenerator.
+// MockGeneratorMockRecorder is the mock recorder for MockGenerator
 type MockGeneratorMockRecorder struct {
 	mock *MockGenerator
 }
 
-// NewMockGenerator creates a new mock instance.
+// NewMockGenerator creates a new mock instance
 func NewMockGenerator(ctrl *gomock.Controller) *MockGenerator {
 	mock := &MockGenerator{ctrl: ctrl}
 	mock.recorder = &MockGeneratorMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockGenerator) EXPECT() *MockGeneratorMockRecorder {
 	return m.recorder
 }
 
-// Events mocks base method.
+// Events mocks base method
 func (m *MockGenerator) Events(arg0 context.Context) ([]event.Event, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Events", arg0)
@@ -45,13 +46,13 @@ func (m *MockGenerator) Events(arg0 context.Context) ([]event.Event, error) {
 	return ret0, ret1
 }
 
-// Events indicates an expected call of Events.
+// Events indicates an expected call of Events
 func (mr *MockGeneratorMockRecorder) Events(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Events", reflect.TypeOf((*MockGenerator)(nil).Events), arg0)
 }
 
-// Name mocks base method.
+// Name mocks base method
 func (m *MockGenerator) Name() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Name")
@@ -59,13 +60,13 @@ func (m *MockGenerator) Name() string {
 	return ret0
 }
 
-// Name indicates an expected call of Name.
+// Name indicates an expected call of Name
 func (mr *MockGeneratorMockRecorder) Name() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockGenerator)(nil).Name))
 }
 
-// ScheduleDelay mocks base method.
+// ScheduleDelay mocks base method
 func (m *MockGenerator) ScheduleDelay() time.Duration {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ScheduleDelay")
@@ -73,7 +74,7 @@ func (m *MockGenerator) ScheduleDelay() time.Duration {
 	return ret0
 }
 
-// ScheduleDelay indicates an expected call of ScheduleDelay.
+// ScheduleDelay indicates an expected call of ScheduleDelay
 func (mr *MockGeneratorMockRecorder) ScheduleDelay() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ScheduleDelay", reflect.TypeOf((*MockGenerator)(nil).ScheduleDelay))

--- a/internal/octant/fake/mock_generator.go
+++ b/internal/octant/fake/mock_generator.go
@@ -10,49 +10,48 @@ import (
 	time "time"
 
 	gomock "github.com/golang/mock/gomock"
-
 	event "github.com/vmware-tanzu/octant/pkg/event"
 )
 
-// MockGenerator is a mock of Generator interface
+// MockGenerator is a mock of Generator interface.
 type MockGenerator struct {
 	ctrl     *gomock.Controller
 	recorder *MockGeneratorMockRecorder
 }
 
-// MockGeneratorMockRecorder is the mock recorder for MockGenerator
+// MockGeneratorMockRecorder is the mock recorder for MockGenerator.
 type MockGeneratorMockRecorder struct {
 	mock *MockGenerator
 }
 
-// NewMockGenerator creates a new mock instance
+// NewMockGenerator creates a new mock instance.
 func NewMockGenerator(ctrl *gomock.Controller) *MockGenerator {
 	mock := &MockGenerator{ctrl: ctrl}
 	mock.recorder = &MockGeneratorMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockGenerator) EXPECT() *MockGeneratorMockRecorder {
 	return m.recorder
 }
 
-// Event mocks base method
-func (m *MockGenerator) Event(arg0 context.Context) (event.Event, error) {
+// Events mocks base method.
+func (m *MockGenerator) Events(arg0 context.Context) ([]event.Event, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Event", arg0)
-	ret0, _ := ret[0].(event.Event)
+	ret := m.ctrl.Call(m, "Events", arg0)
+	ret0, _ := ret[0].([]event.Event)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// Event indicates an expected call of Event
-func (mr *MockGeneratorMockRecorder) Event(arg0 interface{}) *gomock.Call {
+// Events indicates an expected call of Events.
+func (mr *MockGeneratorMockRecorder) Events(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Event", reflect.TypeOf((*MockGenerator)(nil).Event), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Events", reflect.TypeOf((*MockGenerator)(nil).Events), arg0)
 }
 
-// Name mocks base method
+// Name mocks base method.
 func (m *MockGenerator) Name() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Name")
@@ -60,13 +59,13 @@ func (m *MockGenerator) Name() string {
 	return ret0
 }
 
-// Name indicates an expected call of Name
+// Name indicates an expected call of Name.
 func (mr *MockGeneratorMockRecorder) Name() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockGenerator)(nil).Name))
 }
 
-// ScheduleDelay mocks base method
+// ScheduleDelay mocks base method.
 func (m *MockGenerator) ScheduleDelay() time.Duration {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ScheduleDelay")
@@ -74,7 +73,7 @@ func (m *MockGenerator) ScheduleDelay() time.Duration {
 	return ret0
 }
 
-// ScheduleDelay indicates an expected call of ScheduleDelay
+// ScheduleDelay indicates an expected call of ScheduleDelay.
 func (mr *MockGeneratorMockRecorder) ScheduleDelay() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ScheduleDelay", reflect.TypeOf((*MockGenerator)(nil).ScheduleDelay))

--- a/internal/octant/generator.go
+++ b/internal/octant/generator.go
@@ -17,7 +17,7 @@ import (
 // Generator generates events.
 type Generator interface {
 	// Event generates events using the returned channel.
-	Event(ctx context.Context) (event.Event, error)
+	Events(ctx context.Context) ([]event.Event, error)
 
 	// ScheduleDelay is how long to wait before scheduling this generator again.
 	ScheduleDelay() time.Duration

--- a/pkg/dash/dash.go
+++ b/pkg/dash/dash.go
@@ -472,6 +472,7 @@ func (r *Runner) initAPI(ctx context.Context, logger log.Logger, opts ...RunnerO
 		portForwarder,
 		restConfigOptions,
 		buildInfo,
+		options.KubeConfig,
 		false,
 	)
 

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -15,6 +15,9 @@ const (
 	// EventTypeBuildInfo is a buildInfo event
 	EventTypeBuildInfo EventType = "event.octant.dev/buildInfo"
 
+	// EventTypeKubeConfigPath carries location of kube config with it
+	EventTypeKubeConfigPath EventType = "event.octant.dev/kubeConfigPath"
+
 	// EventTypeContent is a content event.
 	EventTypeContent EventType = "event.octant.dev/content"
 
@@ -94,6 +97,22 @@ func CreateEvent(eventType EventType, fields map[string]interface{}) Event {
 	return Event{
 		Type: eventType,
 		Data: fields,
+	}
+}
+
+func FindEvent(events []Event, evType EventType) (Event, error) {
+	var result Event
+
+	for _, evt := range events {
+		if evt.Type == evType {
+			result = evt
+		}
+	}
+
+	if (result == Event{}) {
+		return result, fmt.Errorf("Could not find event of type: %s", evType)
+	} else {
+		return result, nil
 	}
 }
 

--- a/pkg/event/event_test.go
+++ b/pkg/event/event_test.go
@@ -1,0 +1,22 @@
+package event_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/vmware-tanzu/octant/pkg/event"
+)
+
+func TestFindEvent(t *testing.T) {
+	assert := assert.New(t)
+	ev := event.CreateEvent(event.EventTypeAlert, make(map[string]interface{}))
+	events := []event.Event{ev}
+
+	res, err := event.FindEvent(events, event.EventTypeAlert)
+	assert.Equal(ev, res)
+	assert.Nil(err)
+
+	res, err = event.FindEvent(events, event.EventTypeAppLogs)
+	assert.NotNil(err)
+}

--- a/web/src/app/modules/shared/components/presentation/preferences/preferences.component.html
+++ b/web/src/app/modules/shared/components/presentation/preferences/preferences.component.html
@@ -37,7 +37,7 @@
                         <label>{{ r.label }}</label>
                       </clr-radio-wrapper>
                     </ng-container>
-                    <ng-container *ngSwitchCase="'text'">
+                    <ng-container *ngSwitchCase="'input'">
                       <div class="clr-form-control">
                         <label
                           [for]="'section.' + element.name"
@@ -69,6 +69,11 @@
                           >{{ r.label }}</option>
                         </select>
                       </clr-select-container>
+                    </ng-container>
+                    <ng-container *ngSwitchCase="'text'">
+                      <span cds-text="regular">
+                        <app-view-text [view]="element.textConfig"></app-view-text>
+                      </span>
                     </ng-container>
                     <div *ngSwitchDefault>
                       <p>not sure what to do with {{ element.type }}</p>

--- a/web/src/app/modules/shared/components/presentation/preferences/preferences.component.html
+++ b/web/src/app/modules/shared/components/presentation/preferences/preferences.component.html
@@ -71,7 +71,7 @@
                       </clr-select-container>
                     </ng-container>
                     <ng-container *ngSwitchCase="'text'">
-                      <span cds-text="regular">
+                      <span cds-text="body">
                         <app-view-text [view]="element.textConfig"></app-view-text>
                       </span>
                     </ng-container>

--- a/web/src/app/modules/shared/components/presentation/text/text.component.scss
+++ b/web/src/app/modules/shared/components/presentation/text/text.component.scss
@@ -5,3 +5,8 @@
 .button-container {
   float: right;
 }
+
+cds-icon-button {
+  position: relative;  
+  top: -9px;
+}

--- a/web/src/app/modules/shared/models/preference.ts
+++ b/web/src/app/modules/shared/models/preference.ts
@@ -1,4 +1,8 @@
-export type PreferenceElement = RadioElement | TextElement | LabelDropDown;
+export type PreferenceElement =
+  | RadioElement
+  | InputElement
+  | LabelDropDown
+  | TextElement;
 
 export enum Operation {
   Equal = 'Equal',
@@ -52,11 +56,21 @@ export interface LabelDropDown extends Element {
   };
 }
 
-export interface TextElement extends Element {
-  type: 'text';
+export interface InputElement extends Element {
+  type: 'input';
   config: {
     label: string;
     placeholder: string;
+  };
+}
+
+export interface TextElement extends Element {
+  type: 'text';
+  textConfig: {
+    config: {
+      value: string;
+      clipboardValue: string;
+    };
   };
 }
 

--- a/web/src/app/modules/shared/services/helper/helper.service.ts
+++ b/web/src/app/modules/shared/services/helper/helper.service.ts
@@ -13,6 +13,10 @@ export interface BuildInfoMessage {
   time: string;
 }
 
+export interface KubeConfigPathMessage {
+  path: string;
+}
+
 @Injectable({
   providedIn: 'root',
 })
@@ -20,6 +24,7 @@ export class HelperService {
   private version = new BehaviorSubject<string>('');
   private commit = new BehaviorSubject<string>('');
   private time = new BehaviorSubject<string>('');
+  private kubeConfigPath = new BehaviorSubject<string>('');
 
   constructor(
     private router: Router,
@@ -31,6 +36,14 @@ export class HelperService {
       this.commit.next(update.commit);
       this.time.next(update.time);
     });
+
+    websocketService.registerHandler(
+      'event.octant.dev/kubeConfigPath',
+      data => {
+        const update = data as KubeConfigPathMessage;
+        this.kubeConfigPath.next(update.path);
+      }
+    );
   }
 
   buildVersion() {
@@ -43,5 +56,9 @@ export class HelperService {
 
   buildTime() {
     return this.time;
+  }
+
+  localKubeConfigPath() {
+    return this.kubeConfigPath;
   }
 }

--- a/web/src/app/modules/shared/services/preferences/preferences.service.ts
+++ b/web/src/app/modules/shared/services/preferences/preferences.service.ts
@@ -18,7 +18,8 @@ import { PreferencesEntry } from './preferences.entry';
 })
 export class PreferencesService implements OnDestroy {
   private electronStore: any;
-  private kubeConfigPath: string;
+  private kubeConfigPathText: string;
+  private kubeConfigFullPath: string;
 
   public preferences: Map<string, PreferencesEntry<any>> = new Map();
   public preferencesOpened: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(
@@ -156,7 +157,14 @@ export class PreferencesService implements OnDestroy {
   }
 
   public setKubeConfigPath(path: string) {
-    this.kubeConfigPath = path;
+    this.kubeConfigFullPath = path;
+    this.kubeConfigPathText = path;
+    if (path.length > 35) {
+      this.kubeConfigPathText = `${path.substring(0, 17)}...${path.substring(
+        path.length - 17,
+        path.length
+      )}`;
+    }
   }
 
   updateTheme() {
@@ -336,8 +344,8 @@ export class PreferencesService implements OnDestroy {
               value: '',
               textConfig: {
                 config: {
-                  value: this.kubeConfigPath || 'unknown',
-                  clipboardValue: this.kubeConfigPath || 'unknown',
+                  value: this.kubeConfigPathText || 'unknown',
+                  clipboardValue: this.kubeConfigFullPath || 'unknown',
                 },
               },
             },

--- a/web/src/app/modules/shared/services/preferences/preferences.service.ts
+++ b/web/src/app/modules/shared/services/preferences/preferences.service.ts
@@ -18,6 +18,7 @@ import { PreferencesEntry } from './preferences.entry';
 })
 export class PreferencesService implements OnDestroy {
   private electronStore: any;
+  private kubeConfigPath: string;
 
   public preferences: Map<string, PreferencesEntry<any>> = new Map();
   public preferencesOpened: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(
@@ -86,6 +87,7 @@ export class PreferencesService implements OnDestroy {
         ''
       )
     );
+
     this.updateTheme();
   }
 
@@ -153,6 +155,10 @@ export class PreferencesService implements OnDestroy {
     };
   }
 
+  public setKubeConfigPath(path: string) {
+    this.kubeConfigPath = path;
+  }
+
   updateTheme() {
     if (
       this.themeService.themeType.value !==
@@ -197,7 +203,7 @@ export class PreferencesService implements OnDestroy {
             },
             {
               name: 'development.frontendUrl',
-              type: 'text',
+              type: 'input',
               value: this.preferences.get('development.frontendUrl').subject
                 .value,
               disableConditions: [
@@ -283,7 +289,7 @@ export class PreferencesService implements OnDestroy {
                 title: [
                   {
                     metadata: {
-                      type: 'text',
+                      type: 'input',
                     },
                     config: {
                       value: pageSize,
@@ -317,6 +323,22 @@ export class PreferencesService implements OnDestroy {
                     label: '100',
                   },
                 ],
+              },
+            },
+          ],
+        },
+        {
+          name: 'Current Kube Config Path',
+          elements: [
+            {
+              type: 'text',
+              name: 'general.kubeConfig',
+              value: '',
+              textConfig: {
+                config: {
+                  value: this.kubeConfigPath || 'unknown',
+                  clipboardValue: this.kubeConfigPath || 'unknown',
+                },
               },
             },
           ],

--- a/web/src/app/modules/sugarloaf/components/smart/container/container.component.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/container/container.component.ts
@@ -14,6 +14,7 @@ import { NavigationService } from '../../../../shared/services/navigation/naviga
 import { ElectronService } from '../../../../shared/services/electron/electron.service';
 import { Subscription } from 'rxjs';
 import { PreferencesService } from '../../../../shared/services/preferences/preferences.service';
+import { HelperService } from '../../../../shared/services/helper/helper.service';
 
 @Component({
   selector: 'app-root',
@@ -26,8 +27,10 @@ export class ContainerComponent implements OnInit, OnDestroy {
 
   preferencesOpened = false;
   preferences: Preferences;
+  kubeConfigPath: string;
 
   private subscriptionPreferencesOpened: Subscription;
+  private localKubeConfigPath: Subscription;
 
   isElectron = false;
 
@@ -41,7 +44,8 @@ export class ContainerComponent implements OnInit, OnDestroy {
     private navigationService: NavigationService,
     private preferencesService: PreferencesService,
     private electronService: ElectronService,
-    private iconService: IconService
+    private iconService: IconService,
+    private helperService: HelperService
   ) {
     iconService.load({
       iconName: 'octant-logo',
@@ -60,10 +64,17 @@ export class ContainerComponent implements OnInit, OnDestroy {
     );
 
     this.websocketService.open();
+    this.localKubeConfigPath = this.helperService
+      .localKubeConfigPath()
+      .subscribe(path => {
+        this.preferencesService.setKubeConfigPath(path);
+        this.preferences = this.preferencesService.getPreferences();
+      });
   }
 
   ngOnDestroy(): void {
     this.subscriptionPreferencesOpened.unsubscribe();
+    this.localKubeConfigPath.unsubscribe();
   }
 
   preferencesChanged(update: any) {


### PR DESCRIPTION
**What this PR does / why we need it**: This PR assists the user in finding the local path to kube config which is used by octant. It is useful is case when the user has uploaded the config manually via loading api and a temporary kube config file is created and stored in the temp directory.

**Which issue(s) this PR fixes**
- Fixes #1893 

**Special notes for your reviewer**:
Steps for reproduction/acceptance:
```
Given kube config exists in a default location(~/.kube/config)
When the user starts octant
And the user opens preferences
Then the user sees the local kube config path with icon to copy to clipboard
```
```
Given kube config does not exist in a default location(~/.kube/config)
When the user starts octant
And the user pastes the kube config in the modal
And the user opens preferences
Then the user sees the local kube config path with icon to copy to clipboard
```

Some implementation decisions:

The `octant.generator` interface now returns multiple events which extends a *_manager's capability to perform multiple small computations and stream back multiple results as events. A managers setup is an overkill for implementing small features. This approach helps with testing by keeping the handlerFunc usage the same as before and avoids generator classes doing duplicated work.
