### PR TITLE
Added properties pane to Resource Viewer

### DIFF
--- a/changelogs/unreleased/2409-mklanjsek
+++ b/changelogs/unreleased/2409-mklanjsek
@@ -1,0 +1,1 @@
+Added properties pane to Resource Viewer

--- a/internal/modules/workloads/detail_describer.go
+++ b/internal/modules/workloads/detail_describer.go
@@ -41,7 +41,7 @@ func (d *DetailDescriber) loadWorkloads(ctx context.Context, namespace string, o
 		return nil, fmt.Errorf("create workload loader")
 	}
 
-	workloads, err := loader.Load(ctx, namespace)
+	workloads, err := loader.Load(ctx, namespace, options.Link)
 	if err != nil {
 		return nil, fmt.Errorf("load workloads")
 	}

--- a/internal/modules/workloads/home_describer.go
+++ b/internal/modules/workloads/home_describer.go
@@ -49,7 +49,7 @@ func loadCards(ctx context.Context, namespace string, options describer.Options)
 		return nil, false, fmt.Errorf("create card collector")
 	}
 
-	cards, fullMetrics, err := collector.Collect(ctx, namespace)
+	cards, fullMetrics, err := collector.Collect(ctx, namespace, options.Link)
 	if err != nil {
 		return nil, false, fmt.Errorf("collect workload cards: %w", err)
 

--- a/internal/objectstatus/apiservice.go
+++ b/internal/objectstatus/apiservice.go
@@ -8,6 +8,8 @@ package objectstatus
 import (
 	"context"
 
+	"github.com/vmware-tanzu/octant/internal/link"
+
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -19,7 +21,7 @@ import (
 
 // apiService creates status for an apiregistration.k8s.io/v1 apiservice.
 // This is not the final implementation. It is included to generate output.
-func apiService(_ context.Context, object runtime.Object, _ store.Store) (ObjectStatus, error) {
+func apiService(_ context.Context, object runtime.Object, _ store.Store, _ link.Interface) (ObjectStatus, error) {
 	if object == nil {
 		return ObjectStatus{}, errors.Errorf("apiservice is nil")
 	}

--- a/internal/objectstatus/apiservice_test.go
+++ b/internal/objectstatus/apiservice_test.go
@@ -9,6 +9,8 @@ import (
 	"context"
 	"testing"
 
+	linkFake "github.com/vmware-tanzu/octant/internal/link/fake"
+
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -84,6 +86,7 @@ func Test_apiService(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
+			linkInterface := linkFake.NewMockInterface(controller)
 			defer controller.Finish()
 
 			o := storeFake.NewMockStore(controller)
@@ -91,7 +94,7 @@ func Test_apiService(t *testing.T) {
 			object := tc.init(t, o)
 
 			ctx := context.Background()
-			status, err := apiService(ctx, object, o)
+			status, err := apiService(ctx, object, o, linkInterface)
 			if tc.isErr {
 				require.Error(t, err)
 				return

--- a/internal/objectstatus/cronjob.go
+++ b/internal/objectstatus/cronjob.go
@@ -8,16 +8,20 @@ package objectstatus
 import (
 	"context"
 
+	"strconv"
+
 	"github.com/pkg/errors"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 
+	"github.com/vmware-tanzu/octant/internal/link"
+
 	"github.com/vmware-tanzu/octant/pkg/store"
 	"github.com/vmware-tanzu/octant/pkg/view/component"
 )
 
-func cronJob(_ context.Context, object runtime.Object, _ store.Store) (ObjectStatus, error) {
+func cronJob(_ context.Context, object runtime.Object, _ store.Store, _ link.Interface) (ObjectStatus, error) {
 	if object == nil {
 		return ObjectStatus{}, errors.Errorf("cronjob is nil")
 	}
@@ -28,14 +32,19 @@ func cronJob(_ context.Context, object runtime.Object, _ store.Store) (ObjectSta
 		return ObjectStatus{}, errors.Wrap(err, "convert object to batch/v1beta1 cronjob")
 	}
 
+	properties := []component.Property{{Label: "Schedule", Value: component.NewText(cronjob.Spec.Schedule)}}
+
 	if cronjob.Spec.Suspend != nil && *cronjob.Spec.Suspend {
+		properties = append(properties, component.Property{Label: "Suspend", Value: component.NewText(strconv.FormatBool(*cronjob.Spec.Suspend))})
 		return ObjectStatus{
 			nodeStatus: component.NodeStatusWarning,
 			Details:    []component.Component{component.NewText("Cronjob is suspended")},
+			Properties: properties,
 		}, nil
 	}
 	return ObjectStatus{
 		nodeStatus: component.NodeStatusOK,
 		Details:    []component.Component{component.NewText("batch/v1beta1 CronJob is OK")},
+		Properties: properties,
 	}, nil
 }

--- a/internal/objectstatus/daemonset.go
+++ b/internal/objectstatus/daemonset.go
@@ -8,6 +8,10 @@ package objectstatus
 import (
 	"context"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/vmware-tanzu/octant/internal/link"
+
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -17,7 +21,7 @@ import (
 	"github.com/vmware-tanzu/octant/pkg/view/component"
 )
 
-func daemonSet(_ context.Context, object runtime.Object, _ store.Store) (ObjectStatus, error) {
+func daemonSet(_ context.Context, object runtime.Object, _ store.Store, _ link.Interface) (ObjectStatus, error) {
 	if object == nil {
 		return ObjectStatus{}, errors.Errorf("daemon set is nil")
 	}
@@ -30,21 +34,64 @@ func daemonSet(_ context.Context, object runtime.Object, _ store.Store) (ObjectS
 
 	status := ds.Status
 
+	var properties []component.Property
+
+	if selector := ds.Spec.Selector; selector != nil {
+		properties = append(properties, component.Property{Label: "Selectors", Value: getSelectors(selector)})
+	}
+
+	if nodeSelector := ds.Spec.Template.Spec.NodeSelector; nodeSelector != nil {
+		properties = append(properties, component.Property{Label: "Node Selectors", Value: getSelectorMap(nodeSelector)})
+	}
+
 	switch {
 	case status.NumberMisscheduled > 0:
 		return ObjectStatus{
 			nodeStatus: component.NodeStatusWarning,
 			Details:    []component.Component{component.NewText("Daemon Set pods are running on nodes that aren't supposed to run Daemon Set pods")},
+			Properties: properties,
 		}, nil
 	case status.DesiredNumberScheduled != status.NumberReady:
 		return ObjectStatus{
 			nodeStatus: component.NodeStatusWarning,
 			Details:    []component.Component{component.NewText("Daemon Set pods are not ready")},
+			Properties: properties,
 		}, nil
 	default:
 		return ObjectStatus{
 			nodeStatus: component.NodeStatusOK,
 			Details:    []component.Component{component.NewText("Daemon Set is OK")},
+			Properties: properties,
 		}, nil
 	}
+}
+
+func getSelectors(selector *metav1.LabelSelector) component.Component {
+	selectorComponent := component.NewSelectors(nil)
+	if selector == nil {
+		return selectorComponent
+	}
+
+	for k, v := range selector.MatchLabels {
+		selectorComponent.Add(component.NewLabelSelector(k, v))
+	}
+
+	for _, e := range selector.MatchExpressions {
+		es := component.NewExpressionSelector(e.Key, component.Operator(e.Operator), e.Values)
+		selectorComponent.Add(es)
+	}
+	return selectorComponent
+}
+
+func getSelectorMap(selector map[string]string) *component.Selectors {
+	s := component.NewSelectors(nil)
+	if len(selector) == 0 {
+		return s
+	}
+
+	for k, v := range selector {
+		s.Add(component.NewLabelSelector(k, v))
+	}
+
+	return s
 }

--- a/internal/objectstatus/daemonset_test.go
+++ b/internal/objectstatus/daemonset_test.go
@@ -9,6 +9,8 @@ import (
 	"context"
 	"testing"
 
+	linkFake "github.com/vmware-tanzu/octant/internal/link/fake"
+
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -37,6 +39,7 @@ func Test_daemonSet(t *testing.T) {
 			expected: ObjectStatus{
 				nodeStatus: component.NodeStatusOK,
 				Details:    []component.Component{component.NewText("Daemon Set is OK")},
+				Properties: []component.Property{{Label: "Selectors", Value: component.NewSelectors([]component.Selector{component.NewLabelSelector("name", "fluentd")})}},
 			},
 		},
 		{
@@ -49,6 +52,7 @@ func Test_daemonSet(t *testing.T) {
 			expected: ObjectStatus{
 				nodeStatus: component.NodeStatusWarning,
 				Details:    []component.Component{component.NewText("Daemon Set pods are running on nodes that aren't supposed to run Daemon Set pods")},
+				Properties: []component.Property{{Label: "Selectors", Value: component.NewSelectors([]component.Selector{component.NewLabelSelector("name", "fluentd")})}},
 			},
 		},
 		{
@@ -61,6 +65,7 @@ func Test_daemonSet(t *testing.T) {
 			expected: ObjectStatus{
 				nodeStatus: component.NodeStatusWarning,
 				Details:    []component.Component{component.NewText("Daemon Set pods are not ready")},
+				Properties: []component.Property{{Label: "Selectors", Value: component.NewSelectors([]component.Selector{component.NewLabelSelector("name", "fluentd")})}},
 			},
 		},
 		{
@@ -82,6 +87,7 @@ func Test_daemonSet(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
+			linkInterface := linkFake.NewMockInterface(controller)
 			defer controller.Finish()
 
 			o := storefake.NewMockStore(controller)
@@ -89,7 +95,7 @@ func Test_daemonSet(t *testing.T) {
 			object := tc.init(t, o)
 
 			ctx := context.Background()
-			status, err := daemonSet(ctx, object, o)
+			status, err := daemonSet(ctx, object, o, linkInterface)
 			if tc.isErr {
 				require.Error(t, err)
 				return

--- a/internal/objectstatus/deployment.go
+++ b/internal/objectstatus/deployment.go
@@ -35,7 +35,7 @@ func deploymentAppsV1(_ context.Context, object runtime.Object, _ store.Store, _
 
 	status := deployment.Status
 	properties := []component.Property{{Label: "Deployment Strategy", Value: component.NewText(string(deployment.Spec.Strategy.Type))},
-		{Label: "Selectors", Value: getSelector(deployment)}}
+		{Label: "Selectors", Value: GetSelectors(deployment.Spec.Selector)}}
 
 	switch {
 	case status.Replicas == status.UnavailableReplicas:
@@ -60,25 +60,4 @@ func deploymentAppsV1(_ context.Context, object runtime.Object, _ store.Store, _
 			Properties: properties,
 		}, nil
 	}
-}
-
-func getSelector(deployment *appsv1.Deployment) component.Component {
-	if selector := deployment.Spec.Selector; selector != nil {
-		var selectors []component.Selector
-
-		for _, lsr := range selector.MatchExpressions {
-			o, _ := component.MatchOperator(string(lsr.Operator))
-
-			es := component.NewExpressionSelector(lsr.Key, o, lsr.Values)
-			selectors = append(selectors, es)
-		}
-
-		for k, v := range selector.MatchLabels {
-			ls := component.NewLabelSelector(k, v)
-			selectors = append(selectors, ls)
-		}
-
-		return component.NewSelectors(selectors)
-	}
-	return component.NewText("None")
 }

--- a/internal/objectstatus/deployment.go
+++ b/internal/objectstatus/deployment.go
@@ -9,6 +9,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/vmware-tanzu/octant/internal/link"
+
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -20,7 +22,7 @@ import (
 
 // deploymentAppsV1 creates status for an v1/apps deployment. This is
 // not the final implementation. It is included to generate output.
-func deploymentAppsV1(_ context.Context, object runtime.Object, _ store.Store) (ObjectStatus, error) {
+func deploymentAppsV1(_ context.Context, object runtime.Object, _ store.Store, _ link.Interface) (ObjectStatus, error) {
 	if object == nil {
 		return ObjectStatus{}, errors.Errorf("deployment is nil")
 	}
@@ -32,17 +34,21 @@ func deploymentAppsV1(_ context.Context, object runtime.Object, _ store.Store) (
 	}
 
 	status := deployment.Status
+	properties := []component.Property{{Label: "Deployment Strategy", Value: component.NewText(string(deployment.Spec.Strategy.Type))},
+		{Label: "Selectors", Value: getSelector(deployment)}}
 
 	switch {
 	case status.Replicas == status.UnavailableReplicas:
 		return ObjectStatus{
 			nodeStatus: component.NodeStatusError,
 			Details:    []component.Component{component.NewText("No replicas exist for this deployment")},
+			Properties: properties,
 		}, nil
 	case status.Replicas == status.AvailableReplicas:
 		return ObjectStatus{
 			nodeStatus: component.NodeStatusOK,
 			Details:    []component.Component{component.NewText("Deployment is OK")},
+			Properties: properties,
 		}, nil
 	default:
 		return ObjectStatus{
@@ -51,6 +57,28 @@ func deploymentAppsV1(_ context.Context, object runtime.Object, _ store.Store) (
 				component.NewText(
 					fmt.Sprintf("Expected %d replicas, but %d are available",
 						status.Replicas, status.AvailableReplicas))},
+			Properties: properties,
 		}, nil
 	}
+}
+
+func getSelector(deployment *appsv1.Deployment) component.Component {
+	if selector := deployment.Spec.Selector; selector != nil {
+		var selectors []component.Selector
+
+		for _, lsr := range selector.MatchExpressions {
+			o, _ := component.MatchOperator(string(lsr.Operator))
+
+			es := component.NewExpressionSelector(lsr.Key, o, lsr.Values)
+			selectors = append(selectors, es)
+		}
+
+		for k, v := range selector.MatchLabels {
+			ls := component.NewLabelSelector(k, v)
+			selectors = append(selectors, ls)
+		}
+
+		return component.NewSelectors(selectors)
+	}
+	return component.NewText("None")
 }

--- a/internal/objectstatus/deployment_test.go
+++ b/internal/objectstatus/deployment_test.go
@@ -9,6 +9,8 @@ import (
 	"context"
 	"testing"
 
+	linkFake "github.com/vmware-tanzu/octant/internal/link/fake"
+
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -37,6 +39,8 @@ func Test_deploymentAppsV1(t *testing.T) {
 			expected: ObjectStatus{
 				nodeStatus: component.NodeStatusOK,
 				Details:    []component.Component{component.NewText("Deployment is OK")},
+				Properties: []component.Property{{Label: "Deployment Strategy", Value: component.NewText("RollingUpdate")},
+					{Label: "Selectors", Value: component.NewSelectors([]component.Selector{component.NewLabelSelector("app", "hello-node")})}},
 			},
 		},
 		{
@@ -49,6 +53,8 @@ func Test_deploymentAppsV1(t *testing.T) {
 			expected: ObjectStatus{
 				nodeStatus: component.NodeStatusError,
 				Details:    []component.Component{component.NewText("No replicas exist for this deployment")},
+				Properties: []component.Property{{Label: "Deployment Strategy", Value: component.NewText("RollingUpdate")},
+					{Label: "Selectors", Value: component.NewSelectors([]component.Selector{component.NewLabelSelector("app", "hello-node")})}},
 			},
 		},
 		{
@@ -61,6 +67,8 @@ func Test_deploymentAppsV1(t *testing.T) {
 			expected: ObjectStatus{
 				nodeStatus: component.NodeStatusWarning,
 				Details:    []component.Component{component.NewText("Expected 1 replicas, but 0 are available")},
+				Properties: []component.Property{{Label: "Deployment Strategy", Value: component.NewText("RollingUpdate")},
+					{Label: "Selectors", Value: component.NewSelectors([]component.Selector{component.NewLabelSelector("app", "hello-node")})}},
 			},
 		},
 		{
@@ -82,6 +90,7 @@ func Test_deploymentAppsV1(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
+			linkInterface := linkFake.NewMockInterface(controller)
 			defer controller.Finish()
 
 			o := storeFake.NewMockStore(controller)
@@ -89,7 +98,7 @@ func Test_deploymentAppsV1(t *testing.T) {
 			object := tc.init(t, o)
 
 			ctx := context.Background()
-			status, err := deploymentAppsV1(ctx, object, o)
+			status, err := deploymentAppsV1(ctx, object, o, linkInterface)
 			if tc.isErr {
 				require.Error(t, err)
 				return

--- a/internal/objectstatus/ingress.go
+++ b/internal/objectstatus/ingress.go
@@ -9,6 +9,9 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/vmware-tanzu/octant/internal/link"
+	"github.com/vmware-tanzu/octant/pkg/view/component"
+
 	"github.com/gobwas/glob"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -24,7 +27,7 @@ const (
 	ingressAlbActionAnnotation = "alb.ingress.kubernetes.io/actions."
 )
 
-func runIngressStatus(ctx context.Context, object runtime.Object, o store.Store) (ObjectStatus, error) {
+func runIngressStatus(ctx context.Context, object runtime.Object, o store.Store, _ link.Interface) (ObjectStatus, error) {
 	if object == nil {
 		return ObjectStatus{}, errors.Errorf("ingress is nil")
 	}
@@ -163,6 +166,12 @@ func (is *ingressStatus) run(ctx context.Context) (ObjectStatus, error) {
 		}
 	}
 
+	var backendText = "Not configured"
+	if backend := ingress.Spec.DefaultBackend; backend != nil {
+		backendText = backend.Service.Name
+	}
+
+	status.Properties = []component.Property{{Label: "Default Backend", Value: component.NewText(backendText)}}
 	return status, nil
 }
 

--- a/internal/objectstatus/job.go
+++ b/internal/objectstatus/job.go
@@ -14,10 +14,14 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 
+	"github.com/vmware-tanzu/octant/internal/conversion"
+	"github.com/vmware-tanzu/octant/internal/link"
+	"github.com/vmware-tanzu/octant/pkg/view/component"
+
 	"github.com/vmware-tanzu/octant/pkg/store"
 )
 
-func runJobStatus(_ context.Context, object runtime.Object, o store.Store) (ObjectStatus, error) {
+func runJobStatus(_ context.Context, object runtime.Object, o store.Store, _ link.Interface) (ObjectStatus, error) {
 	if object == nil {
 		return ObjectStatus{}, errors.Errorf("job is nil")
 	}
@@ -57,6 +61,10 @@ func runJobStatus(_ context.Context, object runtime.Object, o store.Store) (Obje
 		os.AddDetail("Job is in progress")
 	}
 
+	properties := []component.Property{{Label: "Completions", Value: component.NewText(conversion.PtrInt32ToString(job.Spec.Completions))},
+		{Label: "Parallelism", Value: component.NewText(conversion.PtrInt32ToString(job.Spec.Parallelism))}}
+
+	os.Properties = properties
 	return os, nil
 }
 

--- a/internal/objectstatus/objectstatus_test.go
+++ b/internal/objectstatus/objectstatus_test.go
@@ -9,6 +9,8 @@ import (
 	"context"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
 	"github.com/vmware-tanzu/octant/internal/link"
 	linkFake "github.com/vmware-tanzu/octant/internal/link/fake"
 
@@ -73,6 +75,7 @@ func Test_status(t *testing.T) {
 			defer controller.Finish()
 
 			o := storefake.NewMockStore(controller)
+			o.EXPECT().List(gomock.Any(), gomock.Any()).Return(&unstructured.UnstructuredList{}, false, nil).AnyTimes()
 
 			ctx := context.Background()
 			got, err := status(ctx, tc.object, o, tc.lookup, linkInterface)

--- a/internal/objectstatus/objectstatus_test.go
+++ b/internal/objectstatus/objectstatus_test.go
@@ -9,6 +9,9 @@ import (
 	"context"
 	"testing"
 
+	"github.com/vmware-tanzu/octant/internal/link"
+	linkFake "github.com/vmware-tanzu/octant/internal/link/fake"
+
 	"github.com/golang/mock/gomock"
 
 	"github.com/stretchr/testify/assert"
@@ -22,13 +25,16 @@ import (
 )
 
 func Test_status(t *testing.T) {
+	deployment := testutil.CreateDeployment("deployment")
 	deployObjectStatus := ObjectStatus{
 		nodeStatus: component.NodeStatusOK,
 		Details:    []component.Component{component.NewText("apps/v1 Deployment is OK")},
+		Properties: []component.Property{{Label: "Namespace", Value: component.NewText("namespace")},
+			{Label: "Created", Value: component.NewTimestamp(deployment.CreationTimestamp.Time)}},
 	}
 
 	lookup := statusLookup{
-		{apiVersion: "v1", kind: "Object"}: func(context.Context, runtime.Object, store.Store) (ObjectStatus, error) {
+		{apiVersion: "v1", kind: "Object"}: func(context.Context, runtime.Object, store.Store, link.Interface) (ObjectStatus, error) {
 			return deployObjectStatus, nil
 		},
 	}
@@ -42,7 +48,7 @@ func Test_status(t *testing.T) {
 	}{
 		{
 			name:     "in general",
-			object:   testutil.CreateDeployment("deployment"),
+			object:   deployment,
 			lookup:   lookup,
 			expected: deployObjectStatus,
 		},
@@ -63,12 +69,13 @@ func Test_status(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
+			linkInterface := linkFake.NewMockInterface(controller)
 			defer controller.Finish()
 
 			o := storefake.NewMockStore(controller)
 
 			ctx := context.Background()
-			got, err := status(ctx, tc.object, o, tc.lookup)
+			got, err := status(ctx, tc.object, o, tc.lookup, linkInterface)
 			if tc.isErr {
 				require.Error(t, err)
 				return

--- a/internal/objectstatus/persistent_volume.go
+++ b/internal/objectstatus/persistent_volume.go
@@ -9,6 +9,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/vmware-tanzu/octant/internal/link"
+
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -18,7 +20,7 @@ import (
 	"github.com/vmware-tanzu/octant/pkg/view/component"
 )
 
-func persistentVolume(ctx context.Context, object runtime.Object, o store.Store) (ObjectStatus, error) {
+func persistentVolume(ctx context.Context, object runtime.Object, o store.Store, _ link.Interface) (ObjectStatus, error) {
 	if object == nil {
 		return ObjectStatus{}, errors.Errorf("cronjob is nil")
 	}

--- a/internal/objectstatus/pod.go
+++ b/internal/objectstatus/pod.go
@@ -8,16 +8,20 @@ package objectstatus
 import (
 	"context"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 
+	"github.com/vmware-tanzu/octant/internal/link"
+
 	"github.com/vmware-tanzu/octant/pkg/store"
 	"github.com/vmware-tanzu/octant/pkg/view/component"
 )
 
-func pod(ctx context.Context, object runtime.Object, o store.Store) (ObjectStatus, error) {
+func pod(ctx context.Context, object runtime.Object, o store.Store, link link.Interface) (ObjectStatus, error) {
 	if object == nil {
 		return ObjectStatus{}, errors.Errorf("pod is nil")
 	}
@@ -46,6 +50,30 @@ func pod(ctx context.Context, object runtime.Object, o store.Store) (ObjectStatu
 	if len(pod.Spec.EphemeralContainers) > 0 {
 		status.nodeStatus = component.NodeStatusWarning
 		status.Details = append(status.Details, component.NewText("Ephemeral container is running"))
+	}
+
+	if link != nil {
+		serviceAccountLink, _ := link.ForGVK(pod.Namespace, "v1", "ServiceAccount", pod.Spec.ServiceAccountName, pod.Spec.ServiceAccountName)
+		status.Properties = []component.Property{{Label: "ServiceAccount", Value: serviceAccountLink}}
+
+		if nodeName := pod.Spec.NodeName; nodeName != "" {
+			nodeLink, _ := link.ForGVK("", "v1", "Node", pod.Spec.NodeName, pod.Spec.NodeName)
+			status.Properties = append(status.Properties, component.Property{Label: "Node", Value: nodeLink})
+		}
+
+		ownerReference := metav1.GetControllerOf(pod)
+		if ownerReference != nil {
+			controlledBy, err := link.ForGVK(
+				pod.Namespace,
+				ownerReference.APIVersion,
+				ownerReference.Kind,
+				ownerReference.Name,
+				ownerReference.Name,
+			)
+			if err == nil {
+				status.Properties = append(status.Properties, component.Property{Label: "Controlled By", Value: controlledBy})
+			}
+		}
 	}
 
 	return status, nil

--- a/internal/objectstatus/pod.go
+++ b/internal/objectstatus/pod.go
@@ -58,7 +58,7 @@ func pod(ctx context.Context, object runtime.Object, o store.Store, link link.In
 
 		if nodeName := pod.Spec.NodeName; nodeName != "" {
 			nodeLink, _ := link.ForGVK("", "v1", "Node", pod.Spec.NodeName, pod.Spec.NodeName)
-			status.Properties = append(status.Properties, component.Property{Label: "Node", Value: nodeLink})
+			status.AddProperty("Node", nodeLink)
 		}
 
 		ownerReference := metav1.GetControllerOf(pod)
@@ -71,7 +71,7 @@ func pod(ctx context.Context, object runtime.Object, o store.Store, link link.In
 				ownerReference.Name,
 			)
 			if err == nil {
-				status.Properties = append(status.Properties, component.Property{Label: "Controlled By", Value: controlledBy})
+				status.AddProperty("Controlled By", controlledBy)
 			}
 		}
 	}

--- a/internal/objectstatus/replicaset.go
+++ b/internal/objectstatus/replicaset.go
@@ -41,8 +41,8 @@ func replicaSetAppsV1(_ context.Context, object runtime.Object, _ store.Store, _
 	current := fmt.Sprintf("%d", replicaSet.Status.ReadyReplicas)
 	desired := fmt.Sprintf("%d", specReplicas)
 
-	properties := []component.Property{{Label: "Replica Status", Value: component.NewText(fmt.Sprintf("Current %s / Desired %s", current, desired))},
-		{Label: "Replicas", Value: component.NewText(fmt.Sprintf("%d", replicaSet.Status.Replicas))}}
+	properties := []component.Property{{Label: "Current Replicas", Value: component.NewText(current)},
+		{Label: "Desired Replicas", Value: component.NewText(desired)}}
 
 	switch {
 	case status.Replicas == 0 && specReplicas != 0:

--- a/internal/objectstatus/replicaset.go
+++ b/internal/objectstatus/replicaset.go
@@ -9,6 +9,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/vmware-tanzu/octant/internal/link"
+
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -20,7 +22,7 @@ import (
 
 // replicaSetAppsV1 creates status for an v1/apps replica set. This is
 // not the final implementation. It is included to generate output.
-func replicaSetAppsV1(_ context.Context, object runtime.Object, _ store.Store) (ObjectStatus, error) {
+func replicaSetAppsV1(_ context.Context, object runtime.Object, _ store.Store, _ link.Interface) (ObjectStatus, error) {
 	if object == nil {
 		return ObjectStatus{}, errors.Errorf("replica set is nil")
 	}
@@ -36,21 +38,29 @@ func replicaSetAppsV1(_ context.Context, object runtime.Object, _ store.Store) (
 	if r := replicaSet.Spec.Replicas; r != nil {
 		specReplicas = *r
 	}
+	current := fmt.Sprintf("%d", replicaSet.Status.ReadyReplicas)
+	desired := fmt.Sprintf("%d", specReplicas)
+
+	properties := []component.Property{{Label: "Replica Status", Value: component.NewText(fmt.Sprintf("Current %s / Desired %s", current, desired))},
+		{Label: "Replicas", Value: component.NewText(fmt.Sprintf("%d", replicaSet.Status.Replicas))}}
 
 	switch {
 	case status.Replicas == 0 && specReplicas != 0:
 		return ObjectStatus{
 			nodeStatus: component.NodeStatusError,
 			Details:    []component.Component{component.NewText("Replica Set has no replicas available")},
+			Properties: properties,
 		}, nil
 	case status.Replicas == status.AvailableReplicas:
 		return ObjectStatus{nodeStatus: component.NodeStatusOK,
-			Details: []component.Component{component.NewText("Replica Set is OK")},
+			Details:    []component.Component{component.NewText("Replica Set is OK")},
+			Properties: properties,
 		}, nil
 	default:
 		return ObjectStatus{
 			nodeStatus: component.NodeStatusWarning,
 			Details:    []component.Component{component.NewText(fmt.Sprintf("Expected %d replicas, but %d are available", status.Replicas, status.AvailableReplicas))},
+			Properties: properties,
 		}, nil
 	}
 

--- a/internal/objectstatus/replicaset_test.go
+++ b/internal/objectstatus/replicaset_test.go
@@ -39,8 +39,8 @@ func Test_replicaSetAppsV1(t *testing.T) {
 			expected: ObjectStatus{
 				nodeStatus: component.NodeStatusOK,
 				Details:    []component.Component{component.NewText("Replica Set is OK")},
-				Properties: []component.Property{{Label: "Replica Status", Value: component.NewText("Current 1 / Desired 1")},
-					{Label: "Replicas", Value: component.NewText("1")}},
+				Properties: []component.Property{{Label: "Current Replicas", Value: component.NewText("1")},
+					{Label: "Desired Replicas", Value: component.NewText("1")}},
 			},
 		},
 		{
@@ -53,8 +53,8 @@ func Test_replicaSetAppsV1(t *testing.T) {
 			expected: ObjectStatus{
 				nodeStatus: component.NodeStatusError,
 				Details:    []component.Component{component.NewText("Replica Set has no replicas available")},
-				Properties: []component.Property{{Label: "Replica Status", Value: component.NewText("Current 1 / Desired 1")},
-					{Label: "Replicas", Value: component.NewText("0")}},
+				Properties: []component.Property{{Label: "Current Replicas", Value: component.NewText("1")},
+					{Label: "Desired Replicas", Value: component.NewText("1")}},
 			},
 		},
 		{
@@ -67,8 +67,8 @@ func Test_replicaSetAppsV1(t *testing.T) {
 			expected: ObjectStatus{
 				nodeStatus: component.NodeStatusOK,
 				Details:    []component.Component{component.NewText("Replica Set is OK")},
-				Properties: []component.Property{{Label: "Replica Status", Value: component.NewText("Current 0 / Desired 0")},
-					{Label: "Replicas", Value: component.NewText("0")}},
+				Properties: []component.Property{{Label: "Current Replicas", Value: component.NewText("0")},
+					{Label: "Desired Replicas", Value: component.NewText("0")}},
 			},
 		},
 		{
@@ -81,8 +81,8 @@ func Test_replicaSetAppsV1(t *testing.T) {
 			expected: ObjectStatus{
 				nodeStatus: component.NodeStatusWarning,
 				Details:    []component.Component{component.NewText("Expected 1 replicas, but 0 are available")},
-				Properties: []component.Property{{Label: "Replica Status", Value: component.NewText("Current 1 / Desired 1")},
-					{Label: "Replicas", Value: component.NewText("1")}},
+				Properties: []component.Property{{Label: "Current Replicas", Value: component.NewText("1")},
+					{Label: "Desired Replicas", Value: component.NewText("1")}},
 			},
 		},
 		{

--- a/internal/objectstatus/replicationcontroller.go
+++ b/internal/objectstatus/replicationcontroller.go
@@ -8,6 +8,8 @@ package objectstatus
 import (
 	"context"
 
+	"github.com/vmware-tanzu/octant/internal/link"
+
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -17,7 +19,7 @@ import (
 	"github.com/vmware-tanzu/octant/pkg/view/component"
 )
 
-func replicationController(_ context.Context, object runtime.Object, _ store.Store) (ObjectStatus, error) {
+func replicationController(_ context.Context, object runtime.Object, _ store.Store, _ link.Interface) (ObjectStatus, error) {
 	if object == nil {
 		return ObjectStatus{}, errors.Errorf("replication controller is nil")
 	}

--- a/internal/objectstatus/replicationcontroller_test.go
+++ b/internal/objectstatus/replicationcontroller_test.go
@@ -9,6 +9,8 @@ import (
 	"context"
 	"testing"
 
+	linkFake "github.com/vmware-tanzu/octant/internal/link/fake"
+
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -70,6 +72,7 @@ func Test_replicationController(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
+			linkInterface := linkFake.NewMockInterface(controller)
 			defer controller.Finish()
 
 			o := storefake.NewMockStore(controller)
@@ -77,7 +80,7 @@ func Test_replicationController(t *testing.T) {
 			object := tc.init(t, o)
 
 			ctx := context.Background()
-			status, err := replicationController(ctx, object, o)
+			status, err := replicationController(ctx, object, o, linkInterface)
 			if tc.isErr {
 				require.Error(t, err)
 				return

--- a/internal/objectstatus/service.go
+++ b/internal/objectstatus/service.go
@@ -8,6 +8,8 @@ package objectstatus
 import (
 	"context"
 
+	"github.com/vmware-tanzu/octant/internal/link"
+
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -17,7 +19,7 @@ import (
 	"github.com/vmware-tanzu/octant/pkg/view/component"
 )
 
-func service(ctx context.Context, object runtime.Object, o store.Store) (ObjectStatus, error) {
+func service(ctx context.Context, object runtime.Object, o store.Store, _ link.Interface) (ObjectStatus, error) {
 	if object == nil {
 		return ObjectStatus{}, errors.Errorf("service is nil")
 	}
@@ -63,9 +65,12 @@ func service(ctx context.Context, object runtime.Object, o store.Store) (ObjectS
 			}, nil
 		}
 	}
+	properties := []component.Property{{Label: "Type", Value: component.NewText(string(service.Spec.Type))},
+		{Label: "Session Affinity", Value: component.NewText(string(service.Spec.SessionAffinity))}}
 
 	return ObjectStatus{
 		nodeStatus: component.NodeStatusOK,
 		Details:    []component.Component{component.NewText("Service is OK")},
+		Properties: properties,
 	}, nil
 }

--- a/internal/objectstatus/service_test.go
+++ b/internal/objectstatus/service_test.go
@@ -9,6 +9,8 @@ import (
 	"context"
 	"testing"
 
+	linkFake "github.com/vmware-tanzu/octant/internal/link/fake"
+
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -50,6 +52,8 @@ func Test_service(t *testing.T) {
 			expected: ObjectStatus{
 				nodeStatus: component.NodeStatusOK,
 				Details:    []component.Component{component.NewText("Service is OK")},
+				Properties: []component.Property{{Label: "Type", Value: component.NewText("ClusterIP")},
+					{Label: "Session Affinity", Value: component.NewText("None")}},
 			},
 		},
 		{
@@ -61,6 +65,8 @@ func Test_service(t *testing.T) {
 			expected: ObjectStatus{
 				nodeStatus: component.NodeStatusOK,
 				Details:    []component.Component{component.NewText("Service is OK")},
+				Properties: []component.Property{{Label: "Type", Value: component.NewText("ExternalName")},
+					{Label: "Session Affinity", Value: component.NewText("")}},
 			},
 		},
 		{
@@ -106,6 +112,7 @@ func Test_service(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
+			linkInterface := linkFake.NewMockInterface(controller)
 			defer controller.Finish()
 
 			o := storefake.NewMockStore(controller)
@@ -113,7 +120,7 @@ func Test_service(t *testing.T) {
 			object := tc.init(t, o)
 
 			ctx := context.Background()
-			status, err := service(ctx, object, o)
+			status, err := service(ctx, object, o, linkInterface)
 			if tc.isErr {
 				require.Error(t, err)
 				return

--- a/internal/objectstatus/statefulset_test.go
+++ b/internal/objectstatus/statefulset_test.go
@@ -9,6 +9,8 @@ import (
 	"context"
 	"testing"
 
+	linkFake "github.com/vmware-tanzu/octant/internal/link/fake"
+
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -37,6 +39,8 @@ func Test_statefulSet(t *testing.T) {
 			expected: ObjectStatus{
 				nodeStatus: component.NodeStatusOK,
 				Details:    []component.Component{component.NewText("Stateful Set is OK")},
+				Properties: []component.Property{{Label: "Replicas", Value: component.NewText("3 Desired / 3 Total")},
+					{Label: "Pod Management Policy", Value: component.NewText("OrderedReady")}},
 			},
 		},
 		{
@@ -49,6 +53,8 @@ func Test_statefulSet(t *testing.T) {
 			expected: ObjectStatus{
 				nodeStatus: component.NodeStatusWarning,
 				Details:    []component.Component{component.NewText("Stateful Set pods are not ready")},
+				Properties: []component.Property{{Label: "Replicas", Value: component.NewText("3 Desired / 3 Total")},
+					{Label: "Pod Management Policy", Value: component.NewText("OrderedReady")}},
 			},
 		},
 		{
@@ -70,6 +76,7 @@ func Test_statefulSet(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
+			linkInterface := linkFake.NewMockInterface(controller)
 			defer controller.Finish()
 
 			o := storefake.NewMockStore(controller)
@@ -77,7 +84,7 @@ func Test_statefulSet(t *testing.T) {
 			object := tc.init(t, o)
 
 			ctx := context.Background()
-			status, err := statefulSet(ctx, object, o)
+			status, err := statefulSet(ctx, object, o, linkInterface)
 			if tc.isErr {
 				require.Error(t, err)
 				return

--- a/internal/octant/workload_test.go
+++ b/internal/octant/workload_test.go
@@ -10,6 +10,9 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/vmware-tanzu/octant/internal/link"
+	linkFake "github.com/vmware-tanzu/octant/internal/link/fake"
+
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -226,8 +229,10 @@ func TestClusterWorkloadLoader(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			ctx := context.Background()
+			linkInterface := linkFake.NewMockInterface(controller)
+
 			wl, err := octant.NewClusterWorkloadLoader(c.objectStore, c.podMetricLoader, func(wl *octant.ClusterWorkloadLoader) {
-				wl.ObjectStatuser = func(context.Context, runtime.Object, store.Store) (status objectstatus.ObjectStatus, e error) {
+				wl.ObjectStatuser = func(context.Context, runtime.Object, store.Store, link.Interface) (status objectstatus.ObjectStatus, e error) {
 					objectStatus := objectstatus.ObjectStatus{}
 					return objectStatus, nil
 
@@ -235,7 +240,7 @@ func TestClusterWorkloadLoader(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			actual, err := wl.Load(ctx, c.namespace)
+			actual, err := wl.Load(ctx, c.namespace, linkInterface)
 			if c.isErr {
 				require.Error(t, err)
 				return

--- a/internal/printer/event_test.go
+++ b/internal/printer/event_test.go
@@ -384,7 +384,7 @@ func Test_eventsForObject(t *testing.T) {
 	o.EXPECT().List(gomock.Any(), gomock.Eq(key)).Return(events, false, nil)
 
 	ctx := context.Background()
-	got, err := eventsForObject(ctx, object, o)
+	got, err := store.EventsForObject(ctx, object, o)
 	require.NoError(t, err)
 
 	expected := &corev1.EventList{

--- a/internal/printer/object_table.go
+++ b/internal/printer/object_table.go
@@ -69,7 +69,7 @@ func (ol *ObjectTable) AddRowForObject(ctx context.Context, object runtime.Objec
 		row["_isDeleted"] = component.NewText("deleted")
 	}
 
-	status, err := objectstatus.Status(ctx, object, ol.store)
+	status, err := objectstatus.Status(ctx, object, ol.store, nil)
 	if err != nil {
 		return fmt.Errorf("get status for object: %w", err)
 	}

--- a/internal/resourceviewer/fake/mock_object_status.go
+++ b/internal/resourceviewer/fake/mock_object_status.go
@@ -11,6 +11,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 
+	link "github.com/vmware-tanzu/octant/internal/link"
 	objectstatus "github.com/vmware-tanzu/octant/internal/objectstatus"
 )
 
@@ -38,16 +39,16 @@ func (m *MockObjectStatus) EXPECT() *MockObjectStatusMockRecorder {
 }
 
 // Status mocks base method
-func (m *MockObjectStatus) Status(arg0 context.Context, arg1 runtime.Object) (*objectstatus.ObjectStatus, error) {
+func (m *MockObjectStatus) Status(arg0 context.Context, arg1 runtime.Object, arg2 link.Interface) (*objectstatus.ObjectStatus, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Status", arg0, arg1)
+	ret := m.ctrl.Call(m, "Status", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*objectstatus.ObjectStatus)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Status indicates an expected call of Status
-func (mr *MockObjectStatusMockRecorder) Status(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockObjectStatusMockRecorder) Status(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockObjectStatus)(nil).Status), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockObjectStatus)(nil).Status), arg0, arg1, arg2)
 }

--- a/internal/resourceviewer/handler.go
+++ b/internal/resourceviewer/handler.go
@@ -285,7 +285,7 @@ func (h *Handler) Nodes(ctx context.Context) (component.Nodes, error) {
 		pgn := podGroupNode{
 			objectStatus: h.objectStatus,
 		}
-		group, err := pgn.Create(ctx, podGroupName, objects)
+		group, err := pgn.Create(ctx, podGroupName, objects, h.link)
 		if err != nil {
 			return nil, err
 		}
@@ -415,7 +415,7 @@ func isObjectParent(child, parent runtime.Object) (bool, error) {
 }
 
 type ObjectStatus interface {
-	Status(ctx context.Context, object runtime.Object) (*objectstatus.ObjectStatus, error)
+	Status(ctx context.Context, object runtime.Object, link link.Interface) (*objectstatus.ObjectStatus, error)
 }
 
 type HandlerObjectStatus struct {
@@ -432,8 +432,8 @@ func NewHandlerObjectStatus(objectStore store.Store, pluginManager plugin.Manage
 	}
 }
 
-func (h *HandlerObjectStatus) Status(ctx context.Context, object runtime.Object) (*objectstatus.ObjectStatus, error) {
-	status, err := objectstatus.Status(ctx, object, h.objectStore)
+func (h *HandlerObjectStatus) Status(ctx context.Context, object runtime.Object, link link.Interface) (*objectstatus.ObjectStatus, error) {
+	status, err := objectstatus.Status(ctx, object, h.objectStore, link)
 	if err != nil {
 		return nil, err
 	}
@@ -444,6 +444,7 @@ func (h *HandlerObjectStatus) Status(ctx context.Context, object runtime.Object)
 	}
 
 	status.Details = append(status.Details, pluginStatus.ObjectStatus.Details...)
+	status.Properties = append(status.Properties, pluginStatus.ObjectStatus.Properties...)
 
 	return &status, nil
 }

--- a/internal/resourceviewer/handler_test.go
+++ b/internal/resourceviewer/handler_test.go
@@ -81,7 +81,7 @@ func TestHandler(t *testing.T) {
 
 	objectStatus := fake.NewMockObjectStatus(controller)
 	objectStatus.EXPECT().
-		Status(gomock.Any(), gomock.Any()).
+		Status(gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(&objectstatus.ObjectStatus{}, nil).
 		AnyTimes()
 
@@ -170,11 +170,11 @@ func TestHandler(t *testing.T) {
 	}
 
 	podStatus1 := component.NewPodStatus()
-	podStatus1.AddSummary(pod1.Name, nil, component.NodeStatusOK)
-	podStatus1.AddSummary(pod2.Name, nil, component.NodeStatusOK)
+	podStatus1.AddSummary(pod1.Name, nil, nil, component.NodeStatusOK)
+	podStatus1.AddSummary(pod2.Name, nil, nil, component.NodeStatusOK)
 
 	podStatus2 := component.NewPodStatus()
-	podStatus2.AddSummary(pod4.Name, nil, component.NodeStatusOK)
+	podStatus2.AddSummary(pod4.Name, nil, nil, component.NodeStatusOK)
 
 	expectedNodes := component.Nodes{
 		string(cr.UID): {

--- a/internal/resourceviewer/object_node.go
+++ b/internal/resourceviewer/object_node.go
@@ -49,7 +49,7 @@ func (o *objectNode) Create(ctx context.Context, object *unstructured.Unstructur
 		return nil, err
 	}
 
-	status, err := o.objectStatus.Status(ctx, object)
+	status, err := o.objectStatus.Status(ctx, object, o.link)
 	if err != nil {
 		return nil, err
 	}
@@ -59,6 +59,7 @@ func (o *objectNode) Create(ctx context.Context, object *unstructured.Unstructur
 		APIVersion: apiVersion,
 		Kind:       kind,
 		Status:     status.Status(),
+		Properties: status.Properties,
 		Details:    status.Details,
 		Path:       objectPath,
 	}

--- a/internal/resourceviewer/object_node_test.go
+++ b/internal/resourceviewer/object_node_test.go
@@ -30,7 +30,7 @@ func Test_objectNode(t *testing.T) {
 	pluginPrinter := pluginFake.NewMockManagerInterface(controller)
 	objectStatus := fake.NewMockObjectStatus(controller)
 	objectStatus.EXPECT().
-		Status(gomock.Any(), gomock.Any()).
+		Status(gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(&objectstatus.ObjectStatus{}, nil)
 
 	on := objectNode{

--- a/pkg/store/utils.go
+++ b/pkg/store/utils.go
@@ -1,0 +1,82 @@
+package store
+
+import (
+	"context"
+	"sort"
+
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/vmware-tanzu/octant/internal/util/kubernetes"
+)
+
+func EventsForObject(ctx context.Context, object runtime.Object, o Store) (*corev1.EventList, error) {
+	accessor := meta.NewAccessor()
+	namespace, err := accessor.Namespace(object)
+	if err != nil {
+		return nil, errors.Wrap(err, "get namespace for object")
+	}
+
+	apiVersion, err := accessor.APIVersion(object)
+	if err != nil {
+		return nil, errors.Wrap(err, "Get apiVersion for object")
+	}
+
+	kind, err := accessor.Kind(object)
+	if err != nil {
+		return nil, errors.Wrap(err, "get kind for object")
+	}
+
+	name, err := accessor.Name(object)
+	if err != nil {
+		return nil, errors.Wrap(err, "get name for object")
+	}
+
+	key := Key{
+		Namespace:  namespace,
+		APIVersion: "v1",
+		Kind:       "Event",
+	}
+
+	list, _, err := o.List(ctx, key)
+	if err != nil {
+		return nil, errors.Wrap(err, "list events for object")
+	}
+
+	eventList := &corev1.EventList{}
+
+	for _, unstructuredEvent := range list.Items {
+		event := &corev1.Event{}
+		err := kubernetes.FromUnstructured(&unstructuredEvent, event)
+		if err != nil {
+			return nil, err
+		}
+
+		involvedObject := event.InvolvedObject
+		if involvedObject.APIVersion == "autoscaling/v2beta2" || involvedObject.APIVersion == "autoscaling/v2beta1" {
+			involvedObject.APIVersion = "autoscaling/v1"
+		}
+
+		if involvedObject.Namespace == namespace &&
+			involvedObject.APIVersion == apiVersion &&
+			involvedObject.Kind == kind &&
+			involvedObject.Name == name {
+			eventList.Items = append(eventList.Items, *event)
+		}
+	}
+
+	sort.SliceStable(eventList.Items, func(i, j int) bool {
+		a := eventList.Items[i]
+		b := eventList.Items[j]
+
+		if b.LastTimestamp.After(a.LastTimestamp.Time) {
+			return true
+		}
+
+		return a.LastTimestamp.After(b.LastTimestamp.Time)
+	})
+
+	return eventList, nil
+}

--- a/pkg/view/component/pod_status_test.go
+++ b/pkg/view/component/pod_status_test.go
@@ -56,7 +56,7 @@ func Test_PodStatus_Marshal(t *testing.T) {
 func Test_PodStatus_AddSummary(t *testing.T) {
 	podStatus := NewPodStatus()
 
-	podStatus.AddSummary("name", []Component{NewText("details")}, NodeStatusOK)
+	podStatus.AddSummary("name", []Component{NewText("details")}, nil, NodeStatusOK)
 
 	expected := NewPodStatus()
 	expected.Config.Pods["name"] = PodSummary{
@@ -93,7 +93,7 @@ func Test_PodStatus_Status(t *testing.T) {
 			podStatus := NewPodStatus()
 
 			for i, status := range tc.statuses {
-				podStatus.AddSummary(fmt.Sprintf("%d", i), []Component{NewText("details")}, status)
+				podStatus.AddSummary(fmt.Sprintf("%d", i), []Component{NewText("details")}, nil, status)
 			}
 
 			assert.Equal(t, tc.expected, podStatus.Status())

--- a/web/src/app/modules/shared/components/presentation/cytoscape/cytoscape.component.ts
+++ b/web/src/app/modules/shared/components/presentation/cytoscape/cytoscape.component.ts
@@ -55,7 +55,9 @@ export class CytoscapeComponent implements OnChanges, OnDestroy {
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    this.render();
+    if (changes.zoom || changes.elements || changes.style || changes.layout) {
+      this.render();
+    }
   }
 
   ngOnDestroy(): void {

--- a/web/src/app/modules/shared/components/presentation/object-status/object-status.component.html
+++ b/web/src/app/modules/shared/components/presentation/object-status/object-status.component.html
@@ -20,4 +20,25 @@
       </div>
     </div>
   </div>
+  <div class="properties">
+    <div>
+      <table class="table table-vertical">
+      <tbody>
+      <tr >
+        <th>Version</th>
+        <td>{{node.apiVersion}}</td>
+      </tr>
+      <tr>
+        <th>Kind</th>
+        <td>{{node.kind}}</td>
+      </tr>
+      <tr *ngFor="let prop of node.properties; trackBy: propertiesTrackBy">
+        <th>{{prop.label}}</th>
+        <td><app-view-container [view]="prop.value"></app-view-container></td>
+      </tr>
+      </tbody>
+    </table>
+    </div>
+  </div>
+
 </div>

--- a/web/src/app/modules/shared/components/presentation/object-status/object-status.component.scss
+++ b/web/src/app/modules/shared/components/presentation/object-status/object-status.component.scss
@@ -9,3 +9,33 @@
 .node-status {
   list-style-type: none;
 }
+
+:host ::ng-deep .properties table {
+  width: 100%;
+  table-layout: fixed;
+
+  th {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  td {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: block;
+
+    .selectors-container, .labels-container {
+      display: block;
+    }
+
+    .selectors-container .label, .labels-container .label {
+      margin-top: 4px;
+      margin-bottom: 0px;
+    }
+  }
+}
+
+.status div.card div.card-block div {
+  text-overflow: ellipsis;
+  overflow: hidden;
+}

--- a/web/src/app/modules/shared/components/presentation/object-status/object-status.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/object-status/object-status.component.spec.ts
@@ -9,6 +9,7 @@ import {
   OverlayScrollbarsComponent,
   OverlayscrollbarsModule,
 } from 'overlayscrollbars-ngx';
+import { View } from '../../../models/content';
 
 describe('ObjectStatusComponent', () => {
   let component: ObjectStatusComponent;
@@ -31,5 +32,35 @@ describe('ObjectStatusComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should show properties table', () => {
+    component.node = {
+      apiVersion: 'v1',
+      details: [],
+      kind: 'Pod',
+      name: 'test-pod',
+      path: undefined,
+      properties: [
+        {
+          label: 'test',
+          value: {
+            metadata: { type: 'text' },
+            config: { value: 'property text' },
+          } as View,
+        },
+      ],
+      status: 'pod status',
+    };
+    fixture.detectChanges();
+
+    const root: HTMLElement = fixture.nativeElement;
+    const el: SVGPathElement = root.querySelector('.properties');
+
+    expect(component).toBeTruthy();
+    expect(el).not.toBeNull();
+    expect(el.innerHTML).toContain('Pod');
+    expect(el.innerHTML).toContain('v1');
+    expect(el.innerHTML).toContain('property text');
   });
 });

--- a/web/src/app/modules/shared/components/presentation/object-status/object-status.component.ts
+++ b/web/src/app/modules/shared/components/presentation/object-status/object-status.component.ts
@@ -28,7 +28,11 @@ export class ObjectStatusComponent {
     ];
   }
 
-  detailsTrackBy(index, item) {
+  detailsTrackBy(index, _) {
+    return index;
+  }
+
+  propertiesTrackBy(index, _) {
     return index;
   }
 }

--- a/web/src/app/modules/shared/models/content.ts
+++ b/web/src/app/modules/shared/models/content.ts
@@ -278,12 +278,18 @@ export interface Edge {
   edge: string;
 }
 
+export interface Property {
+  label: string;
+  value: View;
+}
+
 export interface Node {
   name: string;
   apiVersion: string;
   kind: string;
   status: string;
   details: View[];
+  properties: Property[];
   path: LinkView;
 }
 


### PR DESCRIPTION
Properties are now displayed for selected node in Resource Viewer: 

![Screen Shot 2021-05-20 at 2 20 39 PM](https://user-images.githubusercontent.com/34245594/119044021-ea1d4b80-b976-11eb-9c35-85f60856752e.png)

Properties are created and merged together like this:
1. `Version` and `Kind` are always present at the top. These were already passed down to client, so they are simply just directly added there,
2. `Namespace`, `Created` and `Labels` (if present) are added for all resource types,
3. Next group depends on resource type, for example for Pods we are adding `Service Account`, `Node` and `Controlled By` fields,
4. Lastly, at the very bottom are properties that are added by plugins. In screenshot above, you can see that our sample plugin has added the `ID` field (example how to do that is included for plugin authors),

**Special notes for your reviewer**:
Please let me know if there are certain properties that are better suited for a specific resource. We may need a second pass to tweak what exactly shows up for each resource type.

Signed-off-by: Milan Klanjsek <mklanjsek@pivotal.io>

- Fixes #2409
