### PR TITLE
Fix bug where actions are not passed to components

### DIFF
--- a/changelogs/unreleased/2458-GuessWhoSamFoo
+++ b/changelogs/unreleased/2458-GuessWhoSamFoo
@@ -1,0 +1,1 @@
+Fixed bug where actions were not passed to components

--- a/web/src/app/modules/shared/models/form-helper.spec.ts
+++ b/web/src/app/modules/shared/models/form-helper.spec.ts
@@ -1,0 +1,69 @@
+import { FormHelper } from './form-helper';
+
+describe('FormHelper', () => {
+  let formHelper: FormHelper;
+
+  beforeEach(() => {
+    formHelper = new FormHelper();
+  });
+
+  it('converts number', () => {
+    expect(
+      formHelper.transformValue({
+        configuration: null,
+        value: 3,
+        name: '',
+        type: 'number',
+        error: null,
+        label: null,
+        placeholder: null,
+        validators: null,
+      })
+    ).toEqual(3);
+  });
+
+  it('converts stringed number', () => {
+    expect(
+      formHelper.transformValue({
+        configuration: null,
+        value: '123',
+        name: '',
+        type: 'number',
+        error: null,
+        label: null,
+        placeholder: null,
+        validators: null,
+      })
+    ).toEqual(123);
+  });
+
+  it('converts text', () => {
+    expect(
+      formHelper.transformValue({
+        configuration: null,
+        value: 'hello',
+        name: '',
+        type: 'text',
+        error: null,
+        label: null,
+        placeholder: null,
+        validators: null,
+      })
+    ).toEqual('hello');
+  });
+
+  it('converts NaN', () => {
+    expect(
+      formHelper.transformValue({
+        configuration: null,
+        value: NaN,
+        name: '',
+        type: 'number',
+        error: null,
+        label: null,
+        placeholder: null,
+        validators: null,
+      })
+    ).toEqual(0);
+  });
+});

--- a/web/src/app/modules/shared/models/form-helper.ts
+++ b/web/src/app/modules/shared/models/form-helper.ts
@@ -1,9 +1,12 @@
 import {
   FormArray,
+  FormBuilder,
   FormControl,
+  FormGroup,
   ValidatorFn,
   Validators,
 } from '@angular/forms';
+import { ActionField, ActionForm } from './content';
 
 export interface Choice {
   label: string;
@@ -26,7 +29,7 @@ const validationNeedParams = {
 
 // Class responsible to create a Form Group and add Validations Functions to form control
 export class FormHelper {
-  createFromGroup(form, formBuilder) {
+  createFromGroup(form: ActionForm, formBuilder: FormBuilder): FormGroup {
     if (!form) {
       return;
     }
@@ -52,7 +55,7 @@ export class FormHelper {
     return formBuilder.group(controls);
   }
 
-  transformValue(field): any {
+  transformValue(field: ActionField): any {
     if (field.type === 'number') {
       if (field.value === '') {
         return null;
@@ -60,6 +63,7 @@ export class FormHelper {
       const value = +field.value;
       return Number.isNaN(value) ? 0 : value;
     }
+    return field.value;
   }
 
   // Receive a hash with the validation name and the expected


### PR DESCRIPTION
**What this PR does / why we need it**:
Non-numbered action form fields were filtered by the transform function.

**Which issue(s) this PR fixes**
- Fixes #2458 

Signed-off-by: Sam Foo <foos@vmware.com>

