### PR TITLE
Use findstr for windows when running verify command in build.go

### DIFF
--- a/build.go
+++ b/build.go
@@ -508,7 +508,14 @@ func pluginDir() string {
 }
 
 func verifyRegistry() {
-	cmd := newCmd("grep", nil, "-R", "build-artifactory.eng.vmware.com", "web")
+	var cmd *exec.Cmd
+
+	if runtime.GOOS == "windows" {
+		cmd = newCmd("findstr", nil, "/S", "/C:\"build-artifactory.eng.vmware.com\"", "web/*")
+	} else {
+		cmd = newCmd("grep", nil, "-R", "build-artifactory.eng.vmware.com", "web")
+	}
+
 	out, err := cmd.Output()
 	if exitError, ok := err.(*exec.ExitError); ok {
 		if exitError.ExitCode() > 1 {


### PR DESCRIPTION
**What this PR does / why we need it**:
Running `go run build.go verify` fails as `grep` command does not exist for windows. This change uses `findstr` command for windows and unblocks users to run other commands relying on `verifyRegistry`.
