### PR TITLE
Rename Expandable Row Detail TS Component Config Variable

### DIFF
--- a/pkg/view/component/row_detail.go
+++ b/pkg/view/component/row_detail.go
@@ -23,7 +23,7 @@ type ExpandableRowDetail struct {
 	Config ExpandableRowDetailConfig `json:"config"`
 }
 
-// ExpandableDetailConfig is a configuration for an expandable row detail.
+// ExpandableRowDetailConfig is a configuration for an expandable row detail.
 type ExpandableRowDetailConfig struct {
 	Replace bool        `json:"replace"`
 	Body    []Component `json:"body"`

--- a/pkg/view/component/row_detail.go
+++ b/pkg/view/component/row_detail.go
@@ -20,17 +20,17 @@ func (t TableRow) AddExpandableDetail(details *ExpandableRowDetail) {
 type ExpandableRowDetail struct {
 	Base
 
-	Config ExpandableDetailConfig `json:"config"`
+	Config ExpandableRowDetailConfig `json:"config"`
 }
 
 // ExpandableDetailConfig is a configuration for an expandable row detail.
-type ExpandableDetailConfig struct {
+type ExpandableRowDetailConfig struct {
 	Replace bool        `json:"replace"`
 	Body    []Component `json:"body"`
 }
 
 // UnmarshalJSON unmarshals an expandable row detail config from JSON.
-func (e *ExpandableDetailConfig) UnmarshalJSON(data []byte) error {
+func (e *ExpandableRowDetailConfig) UnmarshalJSON(data []byte) error {
 	x := struct {
 		Body    []TypedObject `json:"body"`
 		Replace bool          `json:"replace"`
@@ -63,7 +63,7 @@ var _ Component = &ExpandableRowDetail{}
 func NewExpandableRowDetail(body ...Component) *ExpandableRowDetail {
 	e := ExpandableRowDetail{
 		Base: newBase(TypeExpandableRowDetail, nil),
-		Config: ExpandableDetailConfig{
+		Config: ExpandableRowDetailConfig{
 			Body:    body,
 			Replace: false,
 		},

--- a/pkg/view/component/row_detail_test.go
+++ b/pkg/view/component/row_detail_test.go
@@ -52,7 +52,7 @@ func TestTableTow_ExpandableDetail_Marshal(t *testing.T) {
 			name: "in general",
 			input: &ExpandableRowDetail{
 				Base: newBase(TypeExpandableRowDetail, nil),
-				Config: ExpandableDetailConfig{
+				Config: ExpandableRowDetailConfig{
 					Body: []Component{
 						NewText("test"),
 					},
@@ -64,7 +64,7 @@ func TestTableTow_ExpandableDetail_Marshal(t *testing.T) {
 			name: "in general",
 			input: &ExpandableRowDetail{
 				Base: newBase(TypeExpandableRowDetail, nil),
-				Config: ExpandableDetailConfig{
+				Config: ExpandableRowDetailConfig{
 					Body: []Component{
 						NewText("test"),
 						NewText("test2"),

--- a/pkg/view/component/unmarshal_test.go
+++ b/pkg/view/component/unmarshal_test.go
@@ -186,7 +186,7 @@ func Test_unmarshal(t *testing.T) {
 			configFile: "config_expandable_row_detail.json",
 			objectType: "expandableRowDetail",
 			expected: &ExpandableRowDetail{
-				Config: ExpandableDetailConfig{
+				Config: ExpandableRowDetailConfig{
 					Body:    []Component{NewText("test")},
 					Replace: true,
 				},


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is part of a larger update to the TypeScript Plugin library. While attempting to update the TypeScript components available in the library, a specific component (`ExpandableRowDetail`) failed to build, specifically because its configuration name did not match the format that the generator expected (it was looking for `Config ExpandableRowDetailConfig` when the config was actually just named `ExpandableDetailConfig`). Merging this PR will allow us to update the TypeScript component library such that it works correctly in new TypeScript-based plugins going forward. 

[Relevant comment](https://github.com/vmware-tanzu/plugin-library-for-octant/pull/21#issuecomment-852148257
) in `vmware-tanzu/plugin-library-for-octant` by @GuessWhoSamFoo

**Which issue(s) this PR fixes**
- Fixes https://github.com/vmware-tanzu/plugin-library-for-octant/issues/20

**Special notes for your reviewer**:

I investigated adding some additional error handling to better inform developers when these naming conflicts emerge, but realized that this could be somewhat complicated because the template generating process involves running commands, so the error message might need to be passed through a standard input and then parsed. 

**Release note**:
```
release-note
```

☝️ not sure if this section needs to be filled out, please let me know if there's info I should put here 
