### PR TITLE
Make properties pane resizable

### DIFF
--- a/web/src/app/modules/shared/components/presentation/object-status/object-status.component.scss
+++ b/web/src/app/modules/shared/components/presentation/object-status/object-status.component.scss
@@ -29,8 +29,7 @@
     }
 
     .selectors-container .label, .labels-container .label {
-      margin-top: 4px;
-      margin-bottom: 0px;
+      margin: 4px 2px 0px 0px;
     }
   }
 }

--- a/web/src/app/modules/shared/components/presentation/resource-viewer/resource-viewer.component.html
+++ b/web/src/app/modules/shared/components/presentation/resource-viewer/resource-viewer.component.html
@@ -1,23 +1,19 @@
-<div class="resourceViewer">
-  <div class="clr-row">
-    <div class="clr-col-9">
-      <div class="view-container">
-        <app-cytoscape
-          [elements]="graphData"
-          [layout]="layout"
-          [zoom]="zoom"
-          [style]="style"
-          [selectedNodeId]="selectedNodeId"
-          (select)="nodeChange($event)"
-          (doubleClick)="openNode($event)"
-        >
-        </app-cytoscape>
-      </div>
-    </div>
-    <div class="clr-col-3">
-      <div class="status-container">
-        <app-view-object-status [node]="selectedNode()"></app-view-object-status>
-      </div>
-    </div>
+<div #resourceViewer class="resourceViewer" mwlResizable [resizeCursors]="resizeCursors()"
+     (resizing)="updateSliderPosition($event)" (resizeStart)="resizeStart()" (resizeEnd)="resizeEnd()">
+  <div #viewContainer class="view-container">
+    <app-cytoscape
+      [elements]="graphData"
+      [layout]="layout"
+      [zoom]="zoom"
+      [style]="style"
+      [selectedNodeId]="selectedNodeId"
+      (select)="nodeChange($event)"
+      (doubleClick)="openNode($event)"
+    >
+    </app-cytoscape>
+  </div>
+  <div class="gutter" mwlResizeHandle [resizeEdges]="resizeEdges"></div>
+  <div #statusContainer class="status-container">
+    <app-view-object-status [node]="selectedNode()"></app-view-object-status>
   </div>
 </div>

--- a/web/src/app/modules/shared/components/presentation/resource-viewer/resource-viewer.component.scss
+++ b/web/src/app/modules/shared/components/presentation/resource-viewer/resource-viewer.component.scss
@@ -3,23 +3,41 @@
  */
 
 body {
+  --gutter-background-color: #eee;
+  --gutter-background-hover-color: #0079b8;
   --statusContainer-bg-color: #eee;
 }
 body.dark {
+  --gutter-background-color: #25333d;
+  --gutter-background-hover-color: #495a67;
   --statusContainer-bg-color: #0f181c;
 }
 .resourceViewer {
+  display: flex;
+  flex-direction: row;
+
   .view-container {
     height: 100vh;
-    width: 100%;
-    float: left;
+    width: 75%;
     overflow: auto;
     overflow-y: hidden;
   }
 
+  .gutter {
+    height: 100vh;
+    width: 4px;
+    flex: 1 1 4px;
+    background: var(--gutter-background-color);
+  }
+
+  .gutter:hover {
+    cursor: ew-resize;
+    background: var(--gutter-background-hover-color);
+  }
+
   .status-container {
     height: 100vh;
-    width: 100%;
+    width: 25%;
     padding: 1rem;
     background-color: var(--statusContainer-bg-color);
   }


### PR DESCRIPTION
Resource Viewer properties sometimes contain long fields that are not easy to read. To address that, Properties pane is now resizable. By default, it takes  25% of parent width and can be resized to contain anything from 20% - 70%.

https://user-images.githubusercontent.com/34245594/120484547-6d27a400-c370-11eb-8a53-bfb57d3dfaa7.mov

Also tweaked css parameters to address minor cosmetic issues.  

Signed-off-by: Milan Klanjsek <mklanjsek@pivotal.io>
