### PR TITLE
Yaml Editor: Show Select File button only inside modal

### DIFF
--- a/web/src/app/modules/shared/components/presentation/select-file/select-file.component.ts
+++ b/web/src/app/modules/shared/components/presentation/select-file/select-file.component.ts
@@ -43,7 +43,6 @@ export class SelectFileComponent
     this.layout = view.config.layout;
     this.multiple = view.config.multiple;
     this.status = view.config.status;
-    this.status = view.config.status;
     this.statusMessage = view.config.statusMessage;
     this.action = view.config.action;
   }

--- a/web/src/app/modules/shared/components/smart/editor/editor.component.html
+++ b/web/src/app/modules/shared/components/smart/editor/editor.component.html
@@ -8,7 +8,9 @@
   </div>
 
   <div class="controls">
-    <app-view-select-file [view]= "selectFileView" (fileChanged)="inputFileChanged($event)"></app-view-select-file>
+    <div class="select-wrapper">
+      <app-view-select-file  *ngIf="!metadata" [view]= "selectFileView" (fileChanged)="inputFileChanged($event)"></app-view-select-file>
+    </div>
     <cds-button size="sm" action="outline" (click)="reset()" [disabled]="!isModified" >
       Reset
     </cds-button>

--- a/web/src/app/modules/shared/components/smart/editor/editor.component.scss
+++ b/web/src/app/modules/shared/components/smart/editor/editor.component.scss
@@ -11,7 +11,7 @@
 }
 
 .editor-container {
-  height: 90%;
+  height: calc(90% - 72px);
   display: flex;
   flex-direction: column;
 
@@ -25,7 +25,7 @@
 }
 
 ngx-monaco-editor {
-  height: 95%;
+  height: 100%;
 }
 
 .controls {
@@ -35,7 +35,7 @@ ngx-monaco-editor {
     margin-left: 16px;
   }
 
-  app-view-select-file {
+  .select-wrapper {
     flex: 1;
   }
 }

--- a/web/src/app/modules/shared/components/smart/editor/editor.component.ts
+++ b/web/src/app/modules/shared/components/smart/editor/editor.component.ts
@@ -42,7 +42,7 @@ export class EditorComponent
   private editorValue: string;
   private pristineValue: string;
   uri: string;
-  private metadata: { [p: string]: string };
+  metadata: { [p: string]: string };
 
   isModified = false;
 
@@ -132,7 +132,7 @@ export class EditorComponent
   }
 
   reset() {
-    this.selectFileComponent.reset();
+    this.selectFileComponent?.reset();
     this.value = this.pristineValue;
   }
 


### PR DESCRIPTION
Select file button should be visible only inside Apply Yaml modal. Fixed the issue and cleaned up the css styles to make sure the buttons show up properly in both scenarios.

Signed-off-by: Milan Klanjsek <mklanjsek@pivotal.io>
