### PR TITLE
Add flag to disable cross origin check

### DIFF
--- a/changelogs/unreleased/2384-GuessWhoSamFoo
+++ b/changelogs/unreleased/2384-GuessWhoSamFoo
@@ -1,0 +1,1 @@
+Added flag to disable cross origin check

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -116,11 +116,11 @@ func rebindHandler(ctx context.Context, acceptedHosts []string) mux.MiddlewareFu
 			if disableCheckOrigin := viper.GetBool("disable-origin-check"); !disableCheckOrigin && !checkSameOrigin(r) {
 				logger := log.From(ctx)
 				logger.Debugf("check same origin failed")
-				httpErrors = append(httpErrors, "forbidden bag origin")
+				httpErrors = append(httpErrors, "forbidden bad origin")
 			}
 
 			if len(httpErrors) > 0 {
-				http.Error(w, strings.Join(httpErrors, ":"), http.StatusForbidden)
+				http.Error(w, strings.Join(httpErrors, ": "), http.StatusForbidden)
 				return
 			}
 

--- a/internal/commands/dash.go
+++ b/internal/commands/dash.go
@@ -167,6 +167,7 @@ func newOctantCmd(version string, gitCommit string, buildTime string) *cobra.Com
 	octantCmd.Flags().Float32P("client-qps", "", 200, "maximum QPS for client [DEV]")
 	octantCmd.Flags().IntP("client-burst", "", 400, "maximum burst for client throttle [DEV]")
 	octantCmd.Flags().BoolP("disable-open-browser", "", false, "disable automatic launching of the browser [DEV]")
+	octantCmd.Flags().BoolP("disable-origin-check", "", false, "disable cross origin resource check")
 	octantCmd.Flags().BoolP("enable-opencensus", "c", false, "enable open census [DEV]")
 	octantCmd.Flags().IntP("klog-verbosity", "", 0, "klog verbosity level [DEV]")
 	octantCmd.Flags().StringP("listener-addr", "", "", "listener address for the octant frontend [DEV]")


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds `--disable-origin-check` flag or `OCTANT_DISABLE_ORIGIN_CHECK` env var to skip checks in `rebindHandler`.

This is done instead of adding a configuration upgrader function in dash.go because we want to move away from using it as a catch-all.

cc @jamieklassen Let me know if this works for your use case

**Which issue(s) this PR fixes**
- Fixes #2384 

Signed-off-by: Sam Foo <foos@vmware.com>

