### PR TITLE
Avoid panic if a pod does not have an owner reference

### DIFF
--- a/internal/describer/tab.go
+++ b/internal/describer/tab.go
@@ -89,7 +89,7 @@ func ResourceViewerTab(ctx context.Context, object runtime.Object, options Optio
 	u := &unstructured.Unstructured{Object: m}
 
 	var selection = string(u.GetUID())
-	if u.GetKind() == "Pod" {
+	if u.GetKind() == "Pod" && len(u.GetOwnerReferences()) > 0 {
 		selection = fmt.Sprintf("%s pods", u.GetOwnerReferences()[0].Name)
 	}
 	resourceViewerComponent, err := resourceviewer.Create(ctx, options.Dash, options.Queryer, selection, u)


### PR DESCRIPTION
**What this PR does / why we need it**:
If a pod does not have any owner references, this will panic.

Signed-off-by: Sam Foo <foos@vmware.com>

