### PR TITLE
Use cds typography color for modals

### DIFF
--- a/web/src/styles.scss
+++ b/web/src/styles.scss
@@ -40,3 +40,9 @@ app-view-card cds-alert-group {
 cds-modal-content app-alert {
   width: 100%;
 }
+
+// TODO: Migrate text to use cds color.
+cds-modal-content app-view-text {
+  color: var(--cds-global-typography-color-500);
+}
+


### PR DESCRIPTION
I tried to apply this for all text, port, containers, and timestamp components but it seemed too aggressive or maybe it looks foreign because of being accustomed to the old. However, this is a reasonable start to address contrast issues in modals.

![image](https://user-images.githubusercontent.com/10288252/121379827-41b93200-c8f9-11eb-8fb8-c1e30d0961b1.png)

![image](https://user-images.githubusercontent.com/10288252/121380127-7a590b80-c8f9-11eb-9b4f-7b9eb7308314.png)

Signed-off-by: Sam Foo <foos@vmware.com>
