### PR TITLE
Return file metadata on file upload

### DIFF
--- a/build.go
+++ b/build.go
@@ -156,8 +156,8 @@ func main() {
 			Short: "server build to extraResources, skipping tests",
 			Run: func(cmd *cobra.Command, args []string) {
 				webDeps("--prefer-offline", "--no-audit")
-				webBuildElectron()
 				buildElectron()
+				webBuildElectron()
 			},
 		},
 		&cobra.Command{
@@ -276,7 +276,17 @@ func build() {
 	runCmd("go", nil, "build", "-tags", "embedded", "-mod=vendor", "-o", "build/"+artifact, GO_FLAGS, "-v", "./cmd/octant")
 }
 
+// buildElectron builds an Octant binary without web assets
 func buildElectron() {
+	cleanCmd := newCmd("npm", nil, "run", "clean")
+	cleanCmd.Stdout = os.Stdout
+	cleanCmd.Stderr = os.Stderr
+	cleanCmd.Stdin = os.Stdin
+	cleanCmd.Dir = "./web"
+	if err := cleanCmd.Run(); err != nil {
+		log.Fatalf("web-build-electron: create dist/octant/ : %s", err)
+	}
+
 	newPath := filepath.Join(".", "build")
 	os.MkdirAll(newPath, 0755)
 
@@ -367,14 +377,6 @@ func webBuildElectron() {
 	cmd.Dir = "./web"
 	if err := cmd.Run(); err != nil {
 		log.Fatalf("web-build-electron: build : %s", err)
-	}
-	cleanCmd := newCmd("npm", nil, "run", "clean")
-	cleanCmd.Stdout = os.Stdout
-	cleanCmd.Stderr = os.Stderr
-	cleanCmd.Stdin = os.Stdin
-	cleanCmd.Dir = "./web"
-	if err := cleanCmd.Run(); err != nil {
-		log.Fatalf("web-build-electron: create dist/octant/ : %s", err)
 	}
 }
 

--- a/web/src/app/modules/shared/components/presentation/select-file/select-file.component.html
+++ b/web/src/app/modules/shared/components/presentation/select-file/select-file.component.html
@@ -1,7 +1,7 @@
 <cds-form-group [layout]="layout">
   <cds-file>
     <label>{{label}}</label>
-    <input #fileInput type="file" [multiple]= "multiple" (change)="inputFileChanged($event)"/>
+    <input #fileInput type="file" [multiple]="multiple" (change)="inputFileChanged($event)"/>
     <cds-control-message *ngIf="status" [status]="status">{{statusMessage}}</cds-control-message>
   </cds-file>
 </cds-form-group>

--- a/web/src/app/modules/shared/components/presentation/select-file/select-file.component.ts
+++ b/web/src/app/modules/shared/components/presentation/select-file/select-file.component.ts
@@ -19,7 +19,7 @@ import { ElectronService } from '../../../services/electron/electron.service';
 type File = {
   name: string;
   type: string;
-  path: string;
+  path?: string;
   lastModified: number;
   size: number;
 };
@@ -70,13 +70,17 @@ export class SelectFileComponent
       }
       for (let i = 0; i < files.length; i++) {
         const file = files.item(i);
-        fileList.push({
+        let fileMetadata = {
           name: file.name,
           type: file.type,
-          path: file.path,
           lastModified: file.lastModified,
           size: file.size,
-        });
+        };
+
+        if (this.electronService.isElectron()) {
+          fileMetadata = { ...fileMetadata, ...{ path: file.path } };
+        }
+        fileList.push(fileMetadata);
       }
 
       if (this.action) {

--- a/web/src/stories/select.file.stories.mdx
+++ b/web/src/stories/select.file.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
 import { argTypesView } from "./helpers/helpers";
 
-export const selectFileDocs= { source: { code: `text := component.NewText("sampleText")`}}
+export const selectFileDocs= { source: { code: `selectFile := component.NewSelectFile("label", false, component.LayoutHorizontal, "action.octant.dev/uploadFile")`}}
 
 export const selectFileView = {
   metadata: {
@@ -26,7 +26,10 @@ export const SelectFileStoryTemplate = args => ({
 <h1>Select File component</h1>
 <h2>Description</h2>
 
-<p>The Select File component is used to select a file or multiple files from a file system</p>
+<p>The Select File component is used to select a file or multiple files from a file system.
+
+On electron, the file path is sent as part of the action payload whereas the binary will only send file metadata.
+</p>
 <h2>Example</h2>
 
 <Meta title="Components/Select File" argTypes = { argTypesView } />


### PR DESCRIPTION
Creates a type interface for files to send metadata and added types for typescript.

Also fixes build.go to work on a clean build environment because the ordering of commands were incorrect.

Signed-off-by: Sam Foo <foos@vmware.com>

