### PR TITLE
Show octant route history in the header

### DIFF
--- a/changelogs/unreleased/2580-xtreme-vikram-yadav
+++ b/changelogs/unreleased/2580-xtreme-vikram-yadav
@@ -1,0 +1,1 @@
+Added Octant route history dropdown and updated page title

--- a/internal/api/breadcrumb.go
+++ b/internal/api/breadcrumb.go
@@ -39,6 +39,9 @@ func GenerateBreadcrumb(cm *ContentManager, contentPath string, state octant.Sta
 	parent, title := CreateNavigationBreadcrumb(navs, contentPath)
 	if title == nil {
 		return title
+	} else if parent.Title == "" {
+		title = append(title, component.NewText(path.Base(contentPath)))
+		return title
 	}
 
 	if strings.Contains(contentPath, crPath) {
@@ -75,6 +78,12 @@ func GenerateBreadcrumb(cm *ContentManager, contentPath string, state octant.Sta
 func CreateNavigationBreadcrumb(navs []navigation.Navigation, contentPath string) (LinkDefinition, []component.TitleComponent) {
 	var last LinkDefinition
 	var title []component.TitleComponent
+
+	// When there is a single non-nested navigation entry, then show it as a link.
+	if len(navs) == 1 && contentPath != navs[0].Path && strings.HasPrefix(contentPath, navs[0].Path) {
+		title = append(title, component.NewLink("", path.Base(navs[0].Title), path_util.PrefixedPath(navs[0].Path)))
+		return LinkDefinition{}, title
+	}
 
 	thisPath := contentPath
 	for {

--- a/internal/api/breadcrumb_test.go
+++ b/internal/api/breadcrumb_test.go
@@ -10,12 +10,12 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/vmware-tanzu/octant/internal/api"
 	"github.com/vmware-tanzu/octant/internal/util/json"
 	"github.com/vmware-tanzu/octant/pkg/navigation"
+	"github.com/vmware-tanzu/octant/pkg/view/component"
 )
 
 func Test_NavigationFromPathNamespace(t *testing.T) {
@@ -94,8 +94,6 @@ func Test_NavigationFromPathNamespace(t *testing.T) {
 			expectedItems: 0,
 		},
 	}
-	controller := gomock.NewController(t)
-	defer controller.Finish()
 	data, err := ioutil.ReadFile(filepath.Join("testdata", "namespace_navigation.json"))
 	require.NoError(t, err)
 	var namespaceNavigation []navigation.Navigation
@@ -192,8 +190,6 @@ func Test_NavigationFromPathCluster(t *testing.T) {
 			expectedItems: 0,
 		},
 	}
-	controller := gomock.NewController(t)
-	defer controller.Finish()
 	data, err := ioutil.ReadFile(filepath.Join("testdata", "cluster_navigation.json"))
 	require.NoError(t, err)
 	var namespaceNavigation []navigation.Navigation
@@ -287,8 +283,6 @@ func Test_CreateNavigationBreadcrumbNamespace(t *testing.T) {
 			expectedItems: 0,
 		},
 	}
-	controller := gomock.NewController(t)
-	defer controller.Finish()
 	data, err := ioutil.ReadFile(filepath.Join("testdata", "namespace_navigation.json"))
 	require.NoError(t, err)
 	var namespaceNavigation []navigation.Navigation
@@ -377,8 +371,6 @@ func Test_CreateNavigationBreadcrumbCluster(t *testing.T) {
 			expectedItems: 0,
 		},
 	}
-	controller := gomock.NewController(t)
-	defer controller.Finish()
 	data, err := ioutil.ReadFile(filepath.Join("testdata", "cluster_navigation.json"))
 	require.NoError(t, err)
 	var namespaceNavigation []navigation.Navigation
@@ -396,6 +388,43 @@ func Test_CreateNavigationBreadcrumbCluster(t *testing.T) {
 				require.Equal(t, test.lastTitle, last.Title)
 				require.Equal(t, test.lastUrl, last.Url)
 			}
+		})
+	}
+}
+
+func Test_CreateNavigationBreadcrumbApplications(t *testing.T) {
+	data, err := ioutil.ReadFile(filepath.Join("testdata", "application_navigation.json"))
+	require.NoError(t, err)
+	var namespaceNavigation []navigation.Navigation
+
+	err = json.Unmarshal([]byte(data), &namespaceNavigation)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(namespaceNavigation))
+
+	tests := []struct {
+		name          string
+		path          string
+		lastTitle     string
+		lastUrl       string
+		expectedTitle component.TitleComponent
+		expectedItems int
+	}{
+		{
+			name:          "Applications Detail Breadcumb",
+			path:          "workloads/namespace/milan/detail/simple-app",
+			expectedTitle: component.NewLink("", "Applications", "/workloads/namespace/milan"),
+			expectedItems: 1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			last, title := api.CreateNavigationBreadcrumb(namespaceNavigation, test.path)
+			require.Equal(t, test.expectedItems, len(title))
+			require.Equal(t, test.expectedTitle, title[0])
+			require.NotNil(t, title)
+			require.Equal(t, "", last.Title)
+			require.Equal(t, "", last.Url)
 		})
 	}
 }

--- a/internal/api/content_manager.go
+++ b/internal/api/content_manager.go
@@ -168,7 +168,7 @@ func (cm *ContentManager) runUpdate(state octant.State, s api.OctantClient) Poll
 
 		if ctx.Err() == nil {
 			if content.Path == state.GetContentPath() {
-				s.Send(CreateContentEvent(content.Response, state.GetNamespace(), contentPath, state.GetQueryParams()))
+				s.Send(CreateContentEvent(content.Response, getNamespace(state, contentPath, cm), contentPath, state.GetQueryParams()))
 			}
 
 		}
@@ -345,4 +345,13 @@ func moduloIndex(key string, options [][]string) []string {
 	h.Write([]byte(key))
 	i := int(h.Sum32()) % len(options)
 	return options[i]
+}
+
+func getNamespace(state octant.State, contentPath string, cm *ContentManager) string {
+	m, ok := cm.moduleManager.ModuleForContentPath(contentPath)
+	if ok && m.Name() == "cluster-overview" {
+		return ""
+	}
+
+	return state.GetNamespace()
 }

--- a/internal/api/testdata/application_navigation.json
+++ b/internal/api/testdata/application_navigation.json
@@ -1,0 +1,9 @@
+[
+  {
+    "title": "Applications",
+    "path": "workloads/namespace/milan",
+    "children": [],
+    "iconName": "application",
+    "isLoading": false
+  }
+]

--- a/internal/modules/workloads/detail_describer.go
+++ b/internal/modules/workloads/detail_describer.go
@@ -90,9 +90,8 @@ func (d *DetailDescriber) Describe(ctx context.Context, namespace string, option
 	}
 
 	workloadName := fmt.Sprintf(`
-### %s
 _%s_
-`, cur.Name, cur.Owner.GroupVersionKind())
+`, cur.Owner.GroupVersionKind())
 
 	headerSection := component.FlexLayoutSection{
 		{

--- a/pkg/view/component/dropdown.go
+++ b/pkg/view/component/dropdown.go
@@ -57,6 +57,7 @@ type DropdownConfig struct {
 	Action           string               `json:"action,omitempty"`
 	Selection        string               `json:"selection,omitempty"`
 	UseSelection     bool                 `json:"useSelection"`
+	ShowToggleIcon   bool                 `json:"showToggleIcon"`
 	Items            []DropdownItemConfig `json:"items"`
 }
 
@@ -114,6 +115,11 @@ func (t *Dropdown) SetDropdownUseSelection(sel bool) {
 	t.Config.UseSelection = sel
 }
 
+// SetDropdownShowToggleIcon defines if dropdown toggle caret icon is shown.
+func (t *Dropdown) SetDropdownShowToggleIcon(sti bool) {
+	t.Config.ShowToggleIcon = sti
+}
+
 // SupportsTitle designates this is a TextComponent.
 func (t *Dropdown) SupportsTitle() {}
 
@@ -138,6 +144,7 @@ func (t *DropdownConfig) UnmarshalJSON(data []byte) error {
 		Action           string               `json:"action,omitempty"`
 		Selection        string               `json:"selection,omitempty"`
 		UseSelection     bool                 `json:"useSelection,omitempty"`
+		ShowToggleIcon   bool                 `json:"showToggleIcon,omitempty"`
 		Items            []DropdownItemConfig `json:"items"`
 	}{}
 
@@ -150,6 +157,7 @@ func (t *DropdownConfig) UnmarshalJSON(data []byte) error {
 	t.Action = x.Action
 	t.Selection = x.Selection
 	t.UseSelection = x.UseSelection
+	t.ShowToggleIcon = x.ShowToggleIcon
 	t.Items = x.Items
 	return nil
 }

--- a/pkg/view/component/testdata/dropdown.json
+++ b/pkg/view/component/testdata/dropdown.json
@@ -8,6 +8,7 @@
     "type": "button",
     "action": "action.octant.dev/dropdownTest",
     "useSelection": false,
+    "showToggleIcon": false,
     "items": [
       {
         "name": "first",

--- a/web/src/app/modules/shared/components/presentation/dropdown/dropdown.component.html
+++ b/web/src/app/modules/shared/components/presentation/dropdown/dropdown.component.html
@@ -12,7 +12,7 @@
     </div>
     <div *ngIf="type == 'icon'" class="source" clrDropdownTrigger>
       <clr-icon [attr.shape]="title"></clr-icon>
-      <clr-icon shape="caret down"></clr-icon>
+      <clr-icon *ngIf="showToggleIcon" shape="caret down"></clr-icon>
     </div>
     <div *ngIf="type == 'label'" class="source" clrDropdownTrigger>
       {{title}}

--- a/web/src/app/modules/shared/components/presentation/dropdown/dropdown.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/dropdown/dropdown.component.spec.ts
@@ -52,6 +52,7 @@ describe('DropdownComponent', () => {
         type: 'button',
         action: 'action',
         useSelection: false,
+        showToggleIcon: false,
         items: [
           {
             name: 'item-header',
@@ -119,6 +120,7 @@ describe('DropdownComponent', () => {
         type: 'button',
         action: 'action',
         useSelection: false,
+        showToggleIcon: false,
         items: [
           {
             name: 'first',

--- a/web/src/app/modules/shared/components/presentation/dropdown/dropdown.component.ts
+++ b/web/src/app/modules/shared/components/presentation/dropdown/dropdown.component.ts
@@ -27,6 +27,7 @@ import { WebsocketService } from '../../../../../data/services/websocket/websock
 export class DropdownComponent extends AbstractViewComponent<DropdownView> {
   readonly defaultItemLimit = 10;
   useSelection = false;
+  showToggleIcon = true;
   selectedItem = '';
   url: string;
   position: string;
@@ -58,6 +59,7 @@ export class DropdownComponent extends AbstractViewComponent<DropdownView> {
     this.type = view.config.type;
     this.action = view.config.action;
     this.items = view.config.items;
+    this.showToggleIcon = view.config.showToggleIcon;
 
     this.items.forEach(item => {
       if (item.name === view.config.selection) {
@@ -100,7 +102,7 @@ export class DropdownComponent extends AbstractViewComponent<DropdownView> {
       });
     }
 
-    if (item.url && this.type === 'link') {
+    if (item.url && item.type === 'link') {
       setTimeout(() => {
         this.router.navigateByUrl(item.url);
       }, 0);

--- a/web/src/app/modules/shared/models/content.ts
+++ b/web/src/app/modules/shared/models/content.ts
@@ -7,6 +7,12 @@ export interface ContentResponse {
   currentPath: string;
 }
 
+export interface NamespacedTitle {
+  namespace: string;
+  title: string;
+  path: string;
+}
+
 export interface Content {
   extensionComponent: ExtensionView;
   viewComponents: View[];
@@ -106,6 +112,7 @@ export interface DropdownView extends View {
     action: string;
     selection?: string;
     useSelection: boolean;
+    showToggleIcon: boolean;
     items: DropdownItem[];
   };
 }

--- a/web/src/app/modules/shared/services/content/content.service.spec.ts
+++ b/web/src/app/modules/shared/services/content/content.service.spec.ts
@@ -20,12 +20,11 @@ import {
   Filter,
   LabelFilterService,
 } from '../label-filter/label-filter.service';
+import { Title } from '@angular/platform-browser';
 
 describe('ContentService', () => {
   let service: ContentService;
-  const mockRouter = {
-    navigate: jasmine.createSpy('navigate'),
-  };
+  const mockRouter = jasmine.createSpyObj('Router', ['navigate']);
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -39,6 +38,10 @@ describe('ContentService', () => {
         {
           provide: Router,
           useValue: mockRouter,
+        },
+        {
+          provide: Title,
+          useValue: jasmine.createSpyObj('Title', ['getTitle', 'setTitle']),
         },
       ],
     });

--- a/web/src/app/modules/shared/services/content/mock.ts
+++ b/web/src/app/modules/shared/services/content/mock.ts
@@ -1,0 +1,16 @@
+import { NamespacedTitle } from '../../models/content';
+import { BehaviorSubject } from 'rxjs';
+
+const emptyNsTitle: NamespacedTitle = {
+  namespace: '',
+  title: '',
+  path: '',
+};
+
+export class ContentServiceMock {
+  title = new BehaviorSubject<NamespacedTitle>(emptyNsTitle);
+
+  pushTitle(title: string, path: string, namespace: string) {
+    this.title.next({ namespace, title, path });
+  }
+}

--- a/web/src/app/modules/shared/services/history/history.service.spec.ts
+++ b/web/src/app/modules/shared/services/history/history.service.spec.ts
@@ -1,0 +1,126 @@
+import { TestBed } from '@angular/core/testing';
+import { doesNotMatch } from 'assert';
+import { ContentService } from '../content/content.service';
+import { ContentServiceMock } from '../content/mock';
+
+import { HistoryService } from './history.service';
+
+describe('HistoryService', () => {
+  let contentService;
+  let service: HistoryService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        HistoryService,
+        { provide: ContentService, useClass: ContentServiceMock },
+      ],
+    });
+
+    contentService = TestBed.inject(ContentService);
+    service = TestBed.inject(HistoryService);
+  });
+
+  afterEach(() => {
+    service.localStorage.clear();
+  });
+
+  it('emits last 10 entries at max', () => {
+    Array(20)
+      .fill(0)
+      .forEach((cp, i) =>
+        contentService.pushTitle(`title-${i}`, `path-${i}`, `ns-${i}`)
+      );
+
+    let expected = Array(10)
+      .fill(0)
+      .map((_, i) => {
+        return {
+          title: `title-${i + 10} | ns-${i + 10}`,
+          path: `path-${i + 10}`,
+        };
+      })
+      .reverse();
+
+    service.history.subscribe(h => {
+      expect(expected).toEqual(h);
+    });
+  });
+
+  it('does not update history when title is not available', () => {
+    let contentResponses = Array(2)
+      .fill(0)
+      .map((_, i) => {
+        return { title: `title-${i} | ns-${i}`, path: `path-${i}` };
+      })
+      .reverse();
+
+    Array(2)
+      .fill(0)
+      .forEach((_, i) => {
+        contentService.pushTitle(`title-${i}`, `path-${i}`, `ns-${i}`);
+      });
+    contentService.pushTitle(null, '/workloads/namespace/milan', 'default');
+
+    service.history.subscribe(h => {
+      expect(contentResponses).toEqual(h);
+    });
+  });
+
+  it('does not update history when path does not change', () => {
+    let contentResponses = Array(2)
+      .fill(0)
+      .map((_, i) => {
+        return { title: `title-${i} | ns-${i}`, path: `path-${i}` };
+      })
+      .reverse();
+
+    Array(2)
+      .fill(0)
+      .forEach((_, i) => {
+        contentService.pushTitle(`title-${i}`, `path-${i}`, `ns-${i}`);
+      });
+    contentService.pushTitle('title-1', 'path-1', 'ns-1');
+
+    service.history.subscribe(h => {
+      expect(contentResponses).toEqual(h);
+    });
+  });
+
+  it('does not include namespace when not available', () => {
+    let contentResponses = Array(2)
+      .fill(0)
+      .map((_, i) => {
+        return { title: `title-${i}`, path: `path-${i}` };
+      })
+      .reverse();
+
+    Array(2)
+      .fill(0)
+      .forEach((_, i) => {
+        contentService.pushTitle(`title-${i}`, `path-${i}`, '');
+      });
+
+    service.history.subscribe(h => {
+      expect(contentResponses).toEqual(h);
+    });
+  });
+
+  it('does not duplicate existing path from the history', () => {
+    Array(3)
+      .fill(0)
+      .forEach((_, i) => {
+        contentService.pushTitle(`title-${i}`, `path-${i}`, '');
+      });
+
+    contentService.pushTitle('title-1', 'path-1', '');
+
+    service.history.subscribe(h => {
+      expect([
+        { title: 'title-1', path: 'path-1' },
+        { title: 'title-2', path: 'path-2' },
+        { title: 'title-0', path: 'path-0' },
+      ]).toEqual(h);
+    });
+  });
+});

--- a/web/src/app/modules/shared/services/history/history.service.ts
+++ b/web/src/app/modules/shared/services/history/history.service.ts
@@ -1,0 +1,71 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { ContentService } from '../content/content.service';
+
+export interface ContentRoute {
+  title: string;
+  path: string;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class HistoryService {
+  localStorage: Storage;
+  history: BehaviorSubject<ContentRoute[]>;
+  private previousRoutes: ContentRoute[];
+  private HISTORY_SIZE = 10;
+  private STORAGE_KEY = '__octant_history';
+
+  constructor(private contentService: ContentService) {
+    this.localStorage = window.localStorage;
+    this.history = new BehaviorSubject<ContentRoute[]>([]);
+    this.previousRoutes = this.getHistory();
+    this.history.next(this.previousRoutes);
+
+    this.contentService.title.subscribe(nsTitle => {
+      if (
+        nsTitle.title?.length > 0 &&
+        nsTitle.path !== '' &&
+        nsTitle.path !== this.previousRoutes[0]?.path
+      ) {
+        const historyTitle = nsTitle.namespace
+          ? `${nsTitle.title} | ${nsTitle.namespace}`
+          : nsTitle.title;
+        const currentEntry = { title: historyTitle, path: nsTitle.path };
+        let newHistory: ContentRoute[];
+        let pr = this.getHistory();
+
+        if (pr.find(r => r.path === currentEntry.path)) {
+          const rest = pr.filter(r => r.path !== currentEntry.path);
+          newHistory = [currentEntry, ...rest];
+        } else {
+          newHistory = [currentEntry, ...pr].slice(0, this.HISTORY_SIZE);
+        }
+
+        this.saveHistory(newHistory);
+        this.history.next(newHistory);
+      }
+    });
+  }
+
+  getHistory() {
+    if (this.isLocalStorageSupported) {
+      return JSON.parse(this.localStorage.getItem(this.STORAGE_KEY)) || [];
+    }
+
+    return this.previousRoutes || [];
+  }
+
+  saveHistory(history: ContentRoute[]) {
+    if (this.isLocalStorageSupported) {
+      this.localStorage.setItem(this.STORAGE_KEY, JSON.stringify(history));
+    } else {
+      this.previousRoutes = history;
+    }
+  }
+
+  get isLocalStorageSupported(): boolean {
+    return !!this.localStorage;
+  }
+}

--- a/web/src/app/modules/shared/services/history/mock.ts
+++ b/web/src/app/modules/shared/services/history/mock.ts
@@ -1,0 +1,11 @@
+import { ContentResponse } from '../../models/content';
+import { BehaviorSubject } from 'rxjs';
+import { ContentRoute } from './history.service';
+
+export class HistoryServiceMock {
+  history = new BehaviorSubject<ContentRoute[]>([]);
+
+  pushHistory(history: ContentRoute[]) {
+    this.history.next(history);
+  }
+}

--- a/web/src/app/modules/sugarloaf/components/smart/container/container.component.html
+++ b/web/src/app/modules/sugarloaf/components/smart/container/container.component.html
@@ -17,6 +17,7 @@
       <div class="header-nav">
         <clr-icon *ngIf="isElectron" class="header-centered" (click)="back()" shape="caret left" size="24"></clr-icon>
         <clr-icon *ngIf="isElectron" class="header-centered" (click)="forward()" shape="caret right" size="24"></clr-icon>
+        <app-view-dropdown [view]="historyDropdownConfig"></app-view-dropdown>
         <div class="input-filter">
           <app-input-filter></app-input-filter>
         </div>


### PR DESCRIPTION
**What this PR does / why we need it**: 
- Updates page title to be more descriptive.
- Show a history dropdown in the header displaying the last 10 visited pages.
- Applications detail page has a generated breadcrumb and hence a title.

**Which issue(s) this PR fixes**
- Fixes #2472 
