### PR TITLE
errors - explictly check for AccessErrors for CRDs and Events

### DIFF
--- a/internal/describer/describer.go
+++ b/internal/describer/describer.go
@@ -91,7 +91,7 @@ func LoadObjects(ctx context.Context, objectStore store.Store, errorStore oerror
 					found := errorStore.Add(ae)
 					if !found {
 						logger := log.From(ctx)
-						logger.WithErr(ae).Errorf("load object")
+						logger.WithErr(ae).Errorf("LoadObjects")
 					}
 					return &unstructured.UnstructuredList{}, nil
 				}

--- a/internal/modules/applications/application_describer.go
+++ b/internal/modules/applications/application_describer.go
@@ -3,7 +3,6 @@ package applications
 import (
 	"context"
 	"sort"
-	"strings"
 
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
@@ -128,7 +127,7 @@ func loadAppObjects(ctx context.Context, dashConfig config.Dash, namespace, name
 	resourceLists, err := discoveryClient.ServerPreferredResources()
 	if err != nil {
 		//TODO: determine the best way to handle these types of errors for all resources, not just metrics.
-		if discovery.IsGroupDiscoveryFailedError(err) && strings.Contains(err.Error(), "metrics") {
+		if discovery.IsGroupDiscoveryFailedError(err) {
 			logger := log.From(ctx)
 			logger.Debugf("preferred resources: %w", err)
 		} else {

--- a/internal/objectstore/dynamic_cache.go
+++ b/internal/objectstore/dynamic_cache.go
@@ -25,6 +25,7 @@ import (
 	sigyaml "sigs.k8s.io/yaml"
 
 	"github.com/vmware-tanzu/octant/internal/cluster"
+	oerrors "github.com/vmware-tanzu/octant/internal/errors"
 	"github.com/vmware-tanzu/octant/internal/log"
 	"github.com/vmware-tanzu/octant/pkg/store"
 )
@@ -420,7 +421,8 @@ func (d *DynamicCache) listerForResource(ctx context.Context, key store.Key) (li
 	)
 
 	if d.isUnwatched(ctx, gvr) {
-		return nil, fmt.Errorf("unable to get Lister for %s, watcher was unable to start", gvr)
+		err = fmt.Errorf("unable to get Lister for %s, watcher was unable to start", gvr)
+		return nil, oerrors.NewAccessError(key, "List", err)
 	}
 
 	ii := d.forResource(ctx, gvr, nil)

--- a/internal/printer/customresourcedefinition.go
+++ b/internal/printer/customresourcedefinition.go
@@ -116,7 +116,7 @@ func CustomResourceDefinitionVersionList(
 	resourceLists, err := discoveryClient.ServerPreferredResources()
 	if err != nil {
 		//TODO: determine the best way to handle these types of errors for all resources, not just metrics.
-		if discovery.IsGroupDiscoveryFailedError(err) && strings.Contains(err.Error(), "metrics") {
+		if discovery.IsGroupDiscoveryFailedError(err) {
 			logger := log.From(ctx)
 			logger.Debugf("preferred resources: %w", err)
 		} else {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -60,7 +60,7 @@
         "ansi-colors": "4.1.1",
         "autoprefixer": "10.2.4",
         "babel-loader": "8.2.2",
-        "browserslist": "^4.16.5",
+        "browserslist": "^4.9.1",
         "cacache": "15.0.5",
         "caniuse-lite": "^1.0.30001032",
         "circular-dependency-plugin": "5.2.2",
@@ -961,6 +961,21 @@
             "@babel/helper-validator-option": "^7.14.5",
             "browserslist": "^4.16.6",
             "semver": "^6.3.0"
+          },
+          "dependencies": {
+            "browserslist": {
+              "version": "4.16.6",
+              "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
+              "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
+              "dev": true,
+              "requires": {
+                "caniuse-lite": "^1.0.30001219",
+                "colorette": "^1.2.2",
+                "electron-to-chromium": "^1.3.723",
+                "escalade": "^3.1.1",
+                "node-releases": "^1.1.71"
+              }
+            }
           }
         },
         "@babel/helper-function-name": {
@@ -1143,6 +1158,18 @@
             "to-fast-properties": "^2.0.0"
           }
         },
+        "caniuse-lite": {
+          "version": "1.0.30001243",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001243.tgz",
+          "integrity": "sha512-vNxw9mkTBtkmLFnJRv/2rhs1yufpDfCkBZexG3Y0xdOH2Z/eE/85E4Dl5j1YUN34nZVsSp6vVRFQRrez9wJMRA==",
+          "dev": true
+        },
+        "colorette": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+          "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
+          "dev": true
+        },
         "gensync": {
           "version": "1.0.0-beta.2",
           "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -1241,7 +1268,7 @@
       "requires": {
         "@babel/compat-data": "^7.13.0",
         "@babel/helper-validator-option": "^7.12.17",
-        "browserslist": "^4.16.5",
+        "browserslist": "^4.14.5",
         "semver": "7.0.0"
       },
       "dependencies": {
@@ -5507,6 +5534,12 @@
         "schema-utils": "^2.7.0"
       }
     },
+    "@leichtgewicht/ip-codec": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.2.tgz",
+      "integrity": "sha512-PjsLKLzJ0jWM1iM4xdYkrMyonAHP4kHGiXm81FRNfcnjToQA9UOknwZE28bxq0AGmEAMVBPSuuHurzla2wyYyA==",
+      "dev": true
+    },
     "@malept/cross-spawn-promise": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-1.1.1.tgz",
@@ -6202,7 +6235,7 @@
           "integrity": "sha512-6Eem455JsSMJY6Kpd3EyWE+n5hC+g9bSyHr9K9U2zqZb7+02+hObQ2c0+8iDk/mNF+8r1MhY44WypKJAkySIYA==",
           "dev": true,
           "requires": {
-            "hosted-git-info": "^3.0.8",
+            "hosted-git-info": "^4.0.1",
             "semver": "^7.3.4",
             "validate-npm-package-name": "^3.0.0"
           },
@@ -6755,7 +6788,7 @@
           "integrity": "sha512-XrvP4VVHdRBCdX1S3WXVD8+RyG9qeb1D5Sn1DeLiG2xfSpzellk5k54xbUERJ3M5DggQxes39UGOTP8CFrEGbg==",
           "dev": true,
           "requires": {
-            "browserslist": "^4.16.5",
+            "browserslist": "^4.12.0",
             "caniuse-lite": "^1.0.30001109",
             "colorette": "^1.2.1",
             "normalize-range": "^0.1.2",
@@ -6985,7 +7018,7 @@
           "integrity": "sha512-XrvP4VVHdRBCdX1S3WXVD8+RyG9qeb1D5Sn1DeLiG2xfSpzellk5k54xbUERJ3M5DggQxes39UGOTP8CFrEGbg==",
           "dev": true,
           "requires": {
-            "browserslist": "^4.16.5",
+            "browserslist": "^4.12.0",
             "caniuse-lite": "^1.0.30001109",
             "colorette": "^1.2.1",
             "normalize-range": "^0.1.2",
@@ -10441,6 +10474,15 @@
             "universalify": "^2.0.0"
           }
         },
+        "hosted-git-info": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.8.tgz",
+          "integrity": "sha512-aXpmwoOhRBrw6X3j0h5RloK4x1OzsxMPyxqIHyNfSe2pypkVTZFpEiRoSipPEPlMrh0HW/XsjkJ5WgnCirpNUw==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
         "is-ci": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.0.tgz",
@@ -11131,7 +11173,7 @@
       "integrity": "sha512-DCCdUQiMD+P/as8m3XkeTUkUKuuRqLGcwD0nll7wevhqoJfMRpJlkFd1+MQh1pvupjiQuip42lc/VFvfUTMSKw==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.16.5",
+        "browserslist": "^4.16.1",
         "caniuse-lite": "^1.0.30001181",
         "colorette": "^1.2.1",
         "fraction.js": "^4.0.13",
@@ -12004,33 +12046,6 @@
         "pako": "~1.0.5"
       }
     },
-    "browserslist": {
-      "version": "4.16.6",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
-      "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
-      "dev": true,
-      "requires": {
-        "caniuse-lite": "^1.0.30001219",
-        "colorette": "^1.2.2",
-        "electron-to-chromium": "^1.3.723",
-        "escalade": "^3.1.1",
-        "node-releases": "^1.1.71"
-      },
-      "dependencies": {
-        "caniuse-lite": {
-          "version": "1.0.30001239",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001239.tgz",
-          "integrity": "sha512-cyBkXJDMeI4wthy8xJ2FvDU6+0dtcZSJW3voUF8+e9f1bBeuvyZfc3PNbkOETyhbR+dGCPzn9E7MA3iwzusOhQ==",
-          "dev": true
-        },
-        "colorette": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
-          "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
-          "dev": true
-        }
-      }
-    },
     "browserstack": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/browserstack/-/browserstack-1.6.0.tgz",
@@ -12432,7 +12447,7 @@
       "integrity": "sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.16.5",
+        "browserslist": "^4.0.0",
         "caniuse-lite": "^1.0.0",
         "lodash.memoize": "^4.1.2",
         "lodash.uniq": "^4.5.0"
@@ -12530,13 +12545,13 @@
     "character-entities": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
-      "integrity": "sha1-4Sw5Obfq9OWxXnrUxeKOHUjFsWs=",
+      "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==",
       "dev": true
     },
     "character-entities-legacy": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
-      "integrity": "sha1-lLwYRdznClu50uzHSHJWYSk9j8E=",
+      "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
       "dev": true
     },
     "character-reference-invalid": {
@@ -13518,7 +13533,7 @@
       "integrity": "sha512-YK6fwFjCOKWwGnjFUR3c544YsnA/7DoLL0ysncuOJ4pwbriAtOpvM2bygdlcXbvQCQZ7bBU9CL4t7tGl7ETRpQ==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.16.5",
+        "browserslist": "^4.16.3",
         "semver": "7.0.0"
       },
       "dependencies": {
@@ -15626,6 +15641,18 @@
             "string-width": "^4.2.0",
             "y18n": "^5.0.5",
             "yargs-parser": "^20.2.2"
+          },
+          "dependencies": {
+            "yargs-parser": {
+              "version": "18.1.3",
+              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+              "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+              "dev": true,
+              "requires": {
+                "camelcase": "^5.0.0",
+                "decamelize": "^1.2.0"
+              }
+            }
           }
         }
       }
@@ -18009,15 +18036,6 @@
         "react-is": "^16.7.0"
       }
     },
-    "hosted-git-info": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.2.tgz",
-      "integrity": "sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==",
-      "dev": true,
-      "requires": {
-        "lru-cache": "^6.0.0"
-      }
-    },
     "hpack.js": {
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
@@ -19667,7 +19685,7 @@
           "requires": {
             "@babel/compat-data": "^7.13.15",
             "@babel/helper-validator-option": "^7.12.17",
-            "browserslist": "^4.16.5",
+            "browserslist": "^4.14.5",
             "semver": "^6.3.0"
           },
           "dependencies": {
@@ -20386,6 +20404,18 @@
             "string-width": "^4.2.0",
             "y18n": "^5.0.5",
             "yargs-parser": "^20.2.2"
+          },
+          "dependencies": {
+            "yargs-parser": {
+              "version": "18.1.3",
+              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+              "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+              "dev": true,
+              "requires": {
+                "camelcase": "^5.0.0",
+                "decamelize": "^1.2.0"
+              }
+            }
           }
         }
       }
@@ -20453,7 +20483,7 @@
       "integrity": "sha512-+IESj8bNN+oHvVdEpkuHQU9jgUGdnH74TvmGrGOKb4nGJHNUSzjsriD0E/6Jn6dt5JmQDvl2vGNJFWVFlGsArQ==",
       "requires": {
         "async": "^0.9.0",
-        "merge": "^2.1.1",
+        "merge": "^1.2.0",
         "ncp": "^2.0.0"
       },
       "dependencies": {
@@ -21965,17 +21995,17 @@
       "integrity": "sha512-ji6J5enbMyGRHIAkAOu3WdV8nggqviKCEKtXcOqfphZZtQrmHKycfynJ2V7eVPUA4NhJ6V7Wf4TmGbTwKE9B6g==",
       "dev": true,
       "requires": {
-        "dns-packet": "^5.2.2",
+        "dns-packet": "^1.3.1",
         "thunky": "^1.0.2"
       },
       "dependencies": {
         "dns-packet": {
-          "version": "5.2.4",
-          "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.2.4.tgz",
-          "integrity": "sha512-vgu5Bx5IV8mXmh/9cn1lzn+J7okFlXe1vBRp+kCBJXg1nBED6Z/Q4e+QaDxQRSozMr14p/VQmdXwsf/I2wGjUA==",
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.3.0.tgz",
+          "integrity": "sha512-Nce7YLu6YCgWRvOmDBsJMo9M5/jV3lEZ5vUWnWXYmwURvPylHvq7nkDWhNmk1ZQoZZOP7oQh/S0lSxbisKOfHg==",
           "dev": true,
           "requires": {
-            "ip": "^1.1.5"
+            "@leichtgewicht/ip-codec": "^2.0.1"
           }
         }
       }
@@ -22298,7 +22328,7 @@
       "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "^3.0.8",
+        "hosted-git-info": "^2.1.4",
         "resolve": "^1.10.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
@@ -22417,7 +22447,7 @@
       "integrity": "sha512-/ep6QDxBkm9HvOhOg0heitSd7JHA1U7y1qhhlRlteYYAi9Pdb/ZV7FW5aHpkrpM8+P+4p/jjR8zCyKPBMBjSig==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "^3.0.8",
+        "hosted-git-info": "^3.0.6",
         "semver": "^7.0.0",
         "validate-npm-package-name": "^3.0.0"
       },
@@ -23762,7 +23792,7 @@
       "integrity": "sha512-Yt84+5V6CgS/AhK7d7MA58vG8dSZ7+ytlRtWLaQhag3HXOncTfmYpuUOX4cDoXjvLfw1sHRCHMiBjYhc35CymQ==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.16.5",
+        "browserslist": "^4.16.0",
         "color": "^3.1.1",
         "postcss-value-parser": "^4.1.0"
       },
@@ -24010,7 +24040,7 @@
       "integrity": "sha512-TfsXbKjNYCGfUPEXGIGPySnMiJbdS+3gcVeV8gwmJP4RajyKZHW8E0FYDL1WmggTj3hi+m+WUCAvqRpX2ut4Kg==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.16.5",
+        "browserslist": "^4.16.0",
         "caniuse-api": "^3.0.0",
         "cssnano-utils": "^2.0.0",
         "postcss-selector-parser": "^6.0.4",
@@ -24083,7 +24113,7 @@
       "dev": true,
       "requires": {
         "alphanum-sort": "^1.0.2",
-        "browserslist": "^4.16.5",
+        "browserslist": "^4.16.0",
         "cssnano-utils": "^2.0.0",
         "postcss-value-parser": "^4.1.0",
         "uniqs": "^2.0.0"
@@ -24246,7 +24276,7 @@
       "integrity": "sha512-2CpVoz/67rXU5s9tsPZDxG1YGS9OFHwoY9gsLAzrURrCxTAb0H7Vp87/62LvVPgRWTa5ZmvgmqTp2rL8tlm72A==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.16.5",
+        "browserslist": "^4.16.0",
         "postcss-value-parser": "^4.1.0"
       },
       "dependencies": {
@@ -24325,7 +24355,7 @@
       "integrity": "sha512-wR6pXUaFbSMG1oCKx8pKVA+rnSXCHlca5jMrlmkmif+uig0HNUTV9oGN5kjKsM3mATQAldv2PF9Tbl2vqLFjnA==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.16.5",
+        "browserslist": "^4.16.0",
         "caniuse-api": "^3.0.0"
       },
       "dependencies": {
@@ -25100,7 +25130,7 @@
       "requires": {
         "@babel/code-frame": "7.10.4",
         "address": "1.1.2",
-        "browserslist": "^4.16.5",
+        "browserslist": "4.14.2",
         "chalk": "2.4.2",
         "cross-spawn": "7.0.3",
         "detect-port-alt": "1.1.6",
@@ -28430,7 +28460,7 @@
       "integrity": "sha512-QOWm6XivDLb+fqffTZP8jrmPmPITVChl2KCY2R05nsCWwLi3VGhCdVc3IVGNwd1zzTt1jPd67zIKjpQfxzQZeA==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.16.5",
+        "browserslist": "^4.16.0",
         "postcss-selector-parser": "^6.0.4"
       },
       "dependencies": {
@@ -31587,7 +31617,7 @@
             "string-width": "^3.0.0",
             "which-module": "^2.0.0",
             "y18n": "^4.0.0",
-            "yargs-parser": "^18.1.2"
+            "yargs-parser": "^13.1.2"
           },
           "dependencies": {
             "yargs-parser": {
@@ -32232,12 +32262,6 @@
           }
         }
       }
-    },
-    "yargs-parser": {
-      "version": "20.2.7",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
-      "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==",
-      "dev": true
     },
     "yauzl": {
       "version": "2.10.0",

--- a/web/package.json
+++ b/web/package.json
@@ -134,7 +134,7 @@
     "karma-spec-reporter": "0.0.32",
     "marked": "^2.0.1",
     "npm-force-resolutions": "0.0.10",
-    "prettier": "^2.2.1",
+    "prettier": "~2.2.1",
     "protractor": "~7.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",


### PR DESCRIPTION
Signed-off-by: Wayne Witzel III <wayne@riotousliving.com>


**What this PR does / why we need it**:
Octant is currently broken with respect to partial resource loading on overview and summary pages.

Currently when attempting to load overview and summary pages if any single item in the listing fails, the entire content response is replaced with an error page. In the case of Overview pages, an emptyContentResponse is used and the page is stuck with the loading icon, even though some of the state was able to be fetched.

**Special notes for your reviewer**:
This fix is not ideal and a bit of shotgun anti-pattern, but it also unbreaks a lot of users in the short term and it important for restoring the functionality of Octant
