### PR TITLE
Fix broken link to octant introduction on site

### DIFF
--- a/site/themes/octant/layouts/index.html
+++ b/site/themes/octant/layouts/index.html
@@ -5,7 +5,7 @@
 		<div class="bg-grey introduction">
 			<div class="wrapper grid two">
 				<div class="col">
-					<p class="strong"><a href="/posts/2019-08-12-octant-reveals-objects-running-in-kubernetes-clusters/">Introduction to Octant</a></p>
+					<p class="strong"><a href="/octant-reveals-objects-running-in-kubernetes-clusters/">Introduction to Octant</a></p>
 					<p>Learn about why Octant was created and how it aims to improve upon past attempts to create a Kubernetes dashboard.</p>
 				</div>
 				<div class="col">


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes link to "Introduction to Octant" on octant site.

**Which issue(s) this PR fixes**
- Fixes #2427 
