### PR TITLE
Fixes errors when generating TypeScript components

### DIFF
--- a/pkg/view/tsgen/converter.go
+++ b/pkg/view/tsgen/converter.go
@@ -52,8 +52,16 @@ func (c *Converter) visit(w *gostrings.Builder, t reflect.Type, depth int) ([]st
 		}
 		componentNames = append(componentNames, names...)
 	case reflect.Map:
+		var keyString string = t.Key().String()
+		switch keyString {
+		// typing for validation steps causes errors with reflection, so we just lock string keys.
+		case "component.FormValidator":
+			keyString = "string"
+		}
+
 		// if a map is found, key the key and element to build a typescript object definition.
-		w.WriteString("{[key:" + t.Key().String() + "]:")
+		w.WriteString("{[key:" + keyString + "]:")
+
 		names, err := c.visit(w, t.Elem(), depth+1)
 		if err != nil {
 			return nil, err

--- a/pkg/view/tsgen/model.go
+++ b/pkg/view/tsgen/model.go
@@ -82,10 +82,12 @@ func (c Component) Referenced() []ImportReference {
 
 	var refs []ImportReference
 	for _, r := range list {
-		refs = append(refs, ImportReference{
-			Name:       r,
-			ImportName: strcase.KebabCase(r),
-		})
+		if c.Name != r { // Prevent nested/recursive component imports
+			refs = append(refs, ImportReference{
+				Name:       r,
+				ImportName: strcase.KebabCase(r),
+			})
+		}
 	}
 
 	return refs

--- a/pkg/view/tsgen/tsgen.go
+++ b/pkg/view/tsgen/tsgen.go
@@ -124,7 +124,7 @@ func (tg *TSGen) Reflect(names []string) (*Model, error) {
 
 	m := &Model{}
 	if err := gob.NewDecoder(&stdout).Decode(m); err != nil {
-		return nil, fmt.Errorf("decode reflet model: %w", err)
+		return nil, fmt.Errorf("decode reflect model: %w", err)
 	}
 
 	return m, nil


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, TypeScript component generation leads to TS components that do not compile, meaning that it is not possible to write plugins for the latest version of Octant in TypeScript. This PR fixes two bugs preventing TS component generation:

* Recursive/nested component types yielding incorrect code (`FormFieldConfig` is imported and redeclared, causing errors)
* Under specific conditions, variable names from Go code are interjected into the generated TypeScript files, causing errors

---

# Testing Steps:
- Follow the steps in https://github.com/vmware-tanzu/plugin-library-for-octant/tree/main/yeoman-generator to set up a TypeScript plugin on your local environment
- Inside your new plugin, replace `node_modules/@project-octant/plugin/helpers.ts` with the latest version ([available here](https://raw.githubusercontent.com/vmware-tanzu/plugin-library-for-octant/main/plugin/helpers.ts))
- Checkout this branch on your local environment
- Run `go run ./cmd/ts-component-gen/main.go -dest <directory> ` to generate TypeScript components, where `<directory>` is the path to `node_modules/@project-octant/plugin/components` inside your local TypeScript plugin
- Verify that the plugin compiles and displays correctly

---

**Which issue(s) this PR fixes**

- https://kubernetes.slack.com/archives/CM37M9FCG/p1624388160066200
- https://github.com/vmware-tanzu/octant/pull/2583 (redo of previous PR after consulting with @GuessWhoSamFoo)

