### PR TITLE
display expandable list of namespaces

### DIFF
--- a/web/src/app/modules/sugarloaf/components/smart/namespace/namespace.component.html
+++ b/web/src/app/modules/sugarloaf/components/smart/namespace/namespace.component.html
@@ -1,6 +1,6 @@
 <div class="app-namespace-selector">
   <ng-template [ngIf]="showDropdown" [ngIfElse]="hideDropdown">
-    <clr-dropdown class="dropdown-top" [clrCloseMenuOnItemClick]="true">
+    <clr-dropdown class="dropdown-top" [clrCloseMenuOnItemClick]="false">
       <button type="button" class="dropdown-button" clrDropdownTrigger>
         <clr-icon shape="namespace"></clr-icon>
         {{ currentNamespace }}
@@ -13,11 +13,11 @@
       >
         <label class="dropdown-header">Namespaces</label>
         <ng-container
-          *ngFor="let namespace of namespaces; trackBy: trackByIdentity"
+          *ngFor="let namespace of namespaces | slice : 0 : nsLimit; trackBy: trackByIdentity"
         >
           <button
             type="button"
-            class="dropdown-button"
+            class="dropdown-button ns-menu-item"
             [ngClass]="namespaceClass(namespace)"
             clrDropdownItem
             (click)="selectNamespace(namespace)"
@@ -26,6 +26,7 @@
             {{ namespace }}
           </button>
         </ng-container>
+        <button class="dropdown-button" *ngIf= "namespaces.length > defaultNsLimit" (click)="toggleShowMore()" clrDropdownItem> {{ nsLimit != namespaces.length ? 'SHOW MORE' : 'SHOW LESS' }}</button>
       </clr-dropdown-menu>
     </clr-dropdown>
   </ng-template>

--- a/web/src/app/modules/sugarloaf/components/smart/namespace/namespace.component.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/namespace/namespace.component.ts
@@ -25,6 +25,7 @@ import {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class NamespaceComponent implements OnInit, OnDestroy {
+  readonly defaultNsLimit = 10;
   namespaces: string[];
   currentNamespace = '';
   trackByIdentity = trackByIdentity;
@@ -32,6 +33,7 @@ export class NamespaceComponent implements OnInit, OnDestroy {
   selectedItem: Selection;
   activeUrl: string;
   showDropdown: boolean;
+  nsLimit = this.defaultNsLimit;
 
   private namespaceSubscription: Subscription;
 
@@ -92,6 +94,13 @@ export class NamespaceComponent implements OnInit, OnDestroy {
       return this.modules[this.selectedItem.module].name !== 'cluster-overview';
     }
     return true;
+  }
+
+  toggleShowMore(): void {
+    this.nsLimit =
+      this.nsLimit === this.namespaces.length
+        ? this.defaultNsLimit
+        : this.namespaces.length;
   }
 
   private routerLinkPath(namespace: string): string {


### PR DESCRIPTION
**What this PR does / why we need it**: Namespaces dropdown now shows a maximum of 10 namespaces initially with an option for user to see more namespaces. This feature is similar to the one provided generic dropdown component.

**Which issue(s) this PR fixes**
- Fixes #2548 
