### PR TITLE
Bump prettier to 2.3.2

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "octant",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5556,6 +5556,19 @@
             "semver": "^6.3.0"
           },
           "dependencies": {
+            "browserslist": {
+              "version": "4.16.6",
+              "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
+              "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
+              "dev": true,
+              "requires": {
+                "caniuse-lite": "^1.0.30001219",
+                "colorette": "^1.2.2",
+                "electron-to-chromium": "^1.3.723",
+                "escalade": "^3.1.1",
+                "node-releases": "^1.1.71"
+              }
+            },
             "semver": {
               "version": "6.3.0",
               "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -6372,6 +6385,12 @@
             "picomatch": "^2.0.4"
           }
         },
+        "caniuse-lite": {
+          "version": "1.0.30001245",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001245.tgz",
+          "integrity": "sha512-768fM9j1PKXpOCKws6eTo3RHmvTUsG9UrpT4WoREFeZgJBTi4/X9g565azS/rVUGtqb8nt7FjLeF5u4kukERnA==",
+          "dev": true
+        },
         "chalk": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
@@ -6433,6 +6452,12 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
+        "colorette": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+          "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
+          "dev": true
+        },
         "colors": {
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
@@ -6455,6 +6480,19 @@
             "semver": "7.0.0"
           },
           "dependencies": {
+            "browserslist": {
+              "version": "4.16.6",
+              "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
+              "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
+              "dev": true,
+              "requires": {
+                "caniuse-lite": "^1.0.30001219",
+                "colorette": "^1.2.2",
+                "electron-to-chromium": "^1.3.723",
+                "escalade": "^3.1.1",
+                "node-releases": "^1.1.71"
+              }
+            },
             "semver": {
               "version": "7.0.0",
               "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
@@ -8501,6 +8539,12 @@
             "yocto-queue": "^0.1.0"
           }
         },
+        "prettier": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
+          "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+          "dev": true
+        },
         "regenerator-runtime": {
           "version": "0.13.7",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
@@ -8624,6 +8668,35 @@
             "num2fraction": "^1.2.2",
             "postcss": "^7.0.32",
             "postcss-value-parser": "^4.1.0"
+          },
+          "dependencies": {
+            "browserslist": {
+              "version": "4.16.6",
+              "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
+              "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
+              "dev": true,
+              "requires": {
+                "caniuse-lite": "^1.0.30001219",
+                "colorette": "^1.2.2",
+                "electron-to-chromium": "^1.3.723",
+                "escalade": "^3.1.1",
+                "node-releases": "^1.1.71"
+              },
+              "dependencies": {
+                "caniuse-lite": {
+                  "version": "1.0.30001245",
+                  "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001245.tgz",
+                  "integrity": "sha512-768fM9j1PKXpOCKws6eTo3RHmvTUsG9UrpT4WoREFeZgJBTi4/X9g565azS/rVUGtqb8nt7FjLeF5u4kukERnA==",
+                  "dev": true
+                },
+                "colorette": {
+                  "version": "1.2.2",
+                  "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+                  "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
+                  "dev": true
+                }
+              }
+            }
           }
         },
         "postcss": {
@@ -9049,6 +9122,35 @@
             "num2fraction": "^1.2.2",
             "postcss": "^7.0.32",
             "postcss-value-parser": "^4.1.0"
+          },
+          "dependencies": {
+            "browserslist": {
+              "version": "4.16.6",
+              "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
+              "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
+              "dev": true,
+              "requires": {
+                "caniuse-lite": "^1.0.30001219",
+                "colorette": "^1.2.2",
+                "electron-to-chromium": "^1.3.723",
+                "escalade": "^3.1.1",
+                "node-releases": "^1.1.71"
+              },
+              "dependencies": {
+                "caniuse-lite": {
+                  "version": "1.0.30001245",
+                  "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001245.tgz",
+                  "integrity": "sha512-768fM9j1PKXpOCKws6eTo3RHmvTUsG9UrpT4WoREFeZgJBTi4/X9g565azS/rVUGtqb8nt7FjLeF5u4kukERnA==",
+                  "dev": true
+                },
+                "colorette": {
+                  "version": "1.2.2",
+                  "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+                  "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
+                  "dev": true
+                }
+              }
+            }
           }
         },
         "babel-plugin-polyfill-corejs3": {
@@ -9534,6 +9636,12 @@
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
           "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "prettier": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
+          "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
           "dev": true
         },
         "regenerator-runtime": {
@@ -10692,6 +10800,12 @@
             "universalify": "^2.0.0"
           }
         },
+        "prettier": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
+          "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+          "dev": true
+        },
         "regenerator-runtime": {
           "version": "0.13.7",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
@@ -11253,6 +11367,12 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
           "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+          "dev": true
+        },
+        "prettier": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
+          "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
           "dev": true
         },
         "regenerator-runtime": {
@@ -13746,6 +13866,18 @@
         "core-js-compat": "^3.14.0"
       },
       "dependencies": {
+        "caniuse-lite": {
+          "version": "1.0.30001245",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001245.tgz",
+          "integrity": "sha512-768fM9j1PKXpOCKws6eTo3RHmvTUsG9UrpT4WoREFeZgJBTi4/X9g565azS/rVUGtqb8nt7FjLeF5u4kukERnA==",
+          "dev": true
+        },
+        "colorette": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+          "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
+          "dev": true
+        },
         "core-js-compat": {
           "version": "3.15.2",
           "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.15.2.tgz",
@@ -13754,6 +13886,21 @@
           "requires": {
             "browserslist": "^4.16.6",
             "semver": "7.0.0"
+          },
+          "dependencies": {
+            "browserslist": {
+              "version": "4.16.6",
+              "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
+              "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
+              "dev": true,
+              "requires": {
+                "caniuse-lite": "^1.0.30001219",
+                "colorette": "^1.2.2",
+                "electron-to-chromium": "^1.3.723",
+                "escalade": "^3.1.1",
+                "node-releases": "^1.1.71"
+              }
+            }
           }
         },
         "semver": {
@@ -14361,33 +14508,6 @@
       "dev": true,
       "requires": {
         "pako": "~1.0.5"
-      }
-    },
-    "browserslist": {
-      "version": "4.16.6",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
-      "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
-      "dev": true,
-      "requires": {
-        "caniuse-lite": "^1.0.30001219",
-        "colorette": "^1.2.2",
-        "electron-to-chromium": "^1.3.723",
-        "escalade": "^3.1.1",
-        "node-releases": "^1.1.71"
-      },
-      "dependencies": {
-        "caniuse-lite": {
-          "version": "1.0.30001244",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001244.tgz",
-          "integrity": "sha512-Wb4UFZPkPoJoKKVfELPWytRzpemjP/s0pe22NriANru1NoI+5bGNxzKtk7edYL8rmCWTfQO8eRiF0pn1Dqzx7Q==",
-          "dev": true
-        },
-        "colorette": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
-          "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
-          "dev": true
-        }
       }
     },
     "browserstack": {
@@ -20339,12 +20459,6 @@
         "react-is": "^16.7.0"
       }
     },
-    "hosted-git-info": {
-      "version": "2.8.9",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
-      "dev": true
-    },
     "hpack.js": {
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
@@ -24407,6 +24521,15 @@
         "validate-npm-package-license": "^3.0.1"
       },
       "dependencies": {
+        "hosted-git-info": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.8.tgz",
+          "integrity": "sha512-aXpmwoOhRBrw6X3j0h5RloK4x1OzsxMPyxqIHyNfSe2pypkVTZFpEiRoSipPEPlMrh0HW/XsjkJ5WgnCirpNUw==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -26509,9 +26632,9 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
     },
     "prettier": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
-      "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
+      "integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
       "dev": true
     },
     "pretty-bytes": {
@@ -27246,16 +27369,23 @@
           "dev": true
         },
         "browserslist": {
-          "version": "4.14.2",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.2.tgz",
-          "integrity": "sha512-HI4lPveGKUR0x2StIz+2FXfDk9SfVMrxn6PLh1JeGUwcuoDkdKZebWiyLRJ68iIPDpMI4JLVDf7S7XzslgWOhw==",
+          "version": "4.16.6",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
+          "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
           "dev": true,
           "requires": {
-            "caniuse-lite": "^1.0.30001125",
-            "electron-to-chromium": "^1.3.564",
-            "escalade": "^3.0.2",
-            "node-releases": "^1.1.61"
+            "caniuse-lite": "^1.0.30001219",
+            "colorette": "^1.2.2",
+            "electron-to-chromium": "^1.3.723",
+            "escalade": "^3.1.1",
+            "node-releases": "^1.1.71"
           }
+        },
+        "colorette": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+          "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
+          "dev": true
         },
         "cross-spawn": {
           "version": "7.0.3",

--- a/web/package.json
+++ b/web/package.json
@@ -134,7 +134,7 @@
     "karma-spec-reporter": "0.0.32",
     "marked": "^2.0.1",
     "npm-force-resolutions": "0.0.10",
-    "prettier": "~2.2.1",
+    "prettier": "^2.3.2",
     "protractor": "~7.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/web/src/app/modules/shared/components/abstract-view/abstract-view.component.ts
+++ b/web/src/app/modules/shared/components/abstract-view/abstract-view.component.ts
@@ -11,16 +11,17 @@ import { View } from '../../models/content';
 @Directive()
 // tslint:disable-next-line:directive-class-suffix
 export abstract class AbstractViewComponent<T>
-  implements OnInit, AfterViewInit {
+  implements OnInit, AfterViewInit
+{
   v: T;
 
   @Input() set view(v: View) {
-    this.v = (v as unknown) as T;
+    this.v = v as unknown as T;
     this.update();
   }
 
   get view() {
-    return (this.v as unknown) as View;
+    return this.v as unknown as View;
   }
 
   @Output() viewInit: EventEmitter<void> = new EventEmitter<void>();

--- a/web/src/app/modules/shared/components/form-view-container/form-view-container.component.spec.ts
+++ b/web/src/app/modules/shared/components/form-view-container/form-view-container.component.spec.ts
@@ -117,9 +117,9 @@ describe('FormViewContainerComponent', () => {
       );
       fixture.detectChanges();
 
-      const selected = (component.formGroup.get(
-        name
-      ) as FormArray).getRawValue();
+      const selected = (
+        component.formGroup.get(name) as FormArray
+      ).getRawValue();
       expect(selected[0]).toEqual('a');
       expect(element.querySelector('cds-select')).not.toBeNull();
     });
@@ -155,9 +155,9 @@ describe('FormViewContainerComponent', () => {
       );
       fixture.detectChanges();
 
-      const selected = (component.formGroup.get(
-        name
-      ) as FormArray).getRawValue();
+      const selected = (
+        component.formGroup.get(name) as FormArray
+      ).getRawValue();
       expect(selected[0]).toEqual(undefined);
       expect(element.querySelector('cds-select')).not.toBeNull();
     });

--- a/web/src/app/modules/shared/components/presentation/accordion/accordion.component.ts
+++ b/web/src/app/modules/shared/components/presentation/accordion/accordion.component.ts
@@ -15,7 +15,8 @@ import { ViewService } from '../../../services/view/view.service';
 })
 export class AccordionComponent
   extends AbstractViewComponent<AccordionView>
-  implements OnInit {
+  implements OnInit
+{
   rows: AccordionRow[];
   title: string;
   allowMultipleExpanded: boolean;

--- a/web/src/app/modules/shared/components/presentation/content-filter/content-filter.component.ts
+++ b/web/src/app/modules/shared/components/presentation/content-filter/content-filter.component.ts
@@ -10,7 +10,8 @@ import trackByIdentity from 'src/app/util/trackBy/trackByIdentity';
   styleUrls: ['./content-filter.component.scss'],
 })
 export class ContentFilterComponent
-  implements ClrDatagridFilterInterface<TableRow>, OnInit {
+  implements ClrDatagridFilterInterface<TableRow>, OnInit
+{
   @Input() filter: TableFilter;
   @Input() column: string;
 

--- a/web/src/app/modules/shared/components/presentation/content-text-filter/content-text-filter.component.ts
+++ b/web/src/app/modules/shared/components/presentation/content-text-filter/content-text-filter.component.ts
@@ -18,7 +18,8 @@ import { RelativePipe } from '../../../pipes/relative/relative.pipe';
   styleUrls: ['./content-text-filter.component.scss'],
 })
 export class ContentTextFilterComponent
-  implements ClrDatagridFilterInterface<TableRow>, OnInit {
+  implements ClrDatagridFilterInterface<TableRow>, OnInit
+{
   @Input() column: string;
   @ViewChild('search') search: ElementRef;
 
@@ -67,9 +68,9 @@ export class ContentTextFilterComponent
           container => container.name
         );
       case 'labels':
-        return Object.entries(
-          row.data[column].config.labels
-        ).map((labels: any[]) => labels.join(':'));
+        return Object.entries(row.data[column].config.labels).map(
+          (labels: any[]) => labels.join(':')
+        );
       case 'selectors':
         return row.data[column].config.selectors.map(
           selector => selector.config.key + ':' + selector.config.value

--- a/web/src/app/modules/shared/components/presentation/datagrid/datagrid.component.ts
+++ b/web/src/app/modules/shared/components/presentation/datagrid/datagrid.component.ts
@@ -45,7 +45,8 @@ import { Subscription } from 'rxjs';
 })
 export class DatagridComponent
   extends AbstractViewComponent<TableView>
-  implements OnDestroy {
+  implements OnDestroy
+{
   timeStampComparator = new TimestampComparator();
   sortOrder: ClrDatagridSortOrder = ClrDatagridSortOrder.UNSORTED;
 

--- a/web/src/app/modules/shared/components/presentation/json-editor/json-editor.component.ts
+++ b/web/src/app/modules/shared/components/presentation/json-editor/json-editor.component.ts
@@ -22,7 +22,8 @@ import { JSONEditorView } from '../../../models/content';
 })
 export class JSONEditorComponent
   extends AbstractViewComponent<JSONEditorView>
-  implements AfterViewChecked {
+  implements AfterViewChecked
+{
   container: HTMLElement;
   id: string;
   options = {

--- a/web/src/app/modules/shared/components/presentation/modal/modal.component.ts
+++ b/web/src/app/modules/shared/components/presentation/modal/modal.component.ts
@@ -28,7 +28,8 @@ interface Choice {
 })
 export class ModalComponent
   extends AbstractViewComponent<ModalView>
-  implements OnInit, OnDestroy {
+  implements OnInit, OnDestroy
+{
   @ViewChild('modalAppForm') modalAppForm: FormComponent;
 
   title: TitleView[];

--- a/web/src/app/modules/shared/components/presentation/overflow-labels/overflow-labels.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/overflow-labels/overflow-labels.component.spec.ts
@@ -68,8 +68,9 @@ describe('OverflowLabelsComponent', () => {
       ['keyOne']: 'valueOne',
     };
     fixture.detectChanges();
-    const firstLabel = fixture.debugElement.query(By.css('.label'))
-      .nativeElement;
+    const firstLabel = fixture.debugElement.query(
+      By.css('.label')
+    ).nativeElement;
 
     firstLabel.click();
     expect(component.filterLabel).toHaveBeenCalledWith('keyOne', 'valueOne');

--- a/web/src/app/modules/shared/components/presentation/pod-status/pod-status.component.ts
+++ b/web/src/app/modules/shared/components/presentation/pod-status/pod-status.component.ts
@@ -35,14 +35,12 @@ export class PodStatusComponent extends AbstractViewComponent<PodStatusView> {
     if (pods) {
       this.podStatuses = Object.keys(pods)
         .sort()
-        .map(
-          (podName: string): PodStatus => {
-            return {
-              name: podName,
-              status: pods[podName].status,
-            };
-          }
-        );
+        .map((podName: string): PodStatus => {
+          return {
+            name: podName,
+            status: pods[podName].status,
+          };
+        });
     }
   }
 }

--- a/web/src/app/modules/shared/components/presentation/ports/ports.component.ts
+++ b/web/src/app/modules/shared/components/presentation/ports/ports.component.ts
@@ -22,7 +22,8 @@ import { AbstractViewComponent } from '../../abstract-view/abstract-view.compone
 })
 export class PortsComponent
   extends AbstractViewComponent<PortsView>
-  implements OnDestroy {
+  implements OnDestroy
+{
   private previousView: PortsView;
 
   @Output() portLoad: EventEmitter<boolean> = new EventEmitter(true);

--- a/web/src/app/modules/shared/components/presentation/resource-viewer/octant.style.ts
+++ b/web/src/app/modules/shared/components/presentation/resource-viewer/octant.style.ts
@@ -1,16 +1,19 @@
 import { Stylesheet } from 'cytoscape';
 
-const svgHealthy = color => `<svg version="1.1" width="36" height="36" viewBox="0 0 36 36" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
+const svgHealthy =
+  color => `<svg version="1.1" width="36" height="36" viewBox="0 0 36 36" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
     <title>check-circle-solid</title>
     <path d="M30,18A12,12,0,1,1,18,6,12,12,0,0,1,30,18Zm-4.77-2.16a1.4,1.4,0,0,0-2-2l-6.77,6.77L13,17.16a1.4,1.4,0,0,0-2,2l5.45,5.45Z" fill="${color}"></path>
     <rect x="0" y="0" width="36" height="36" fill-opacity="0"/></svg>`;
 
-const svgWarning = color => `<svg version="1.1" width="36" height="36" viewBox="0 0 36 36" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
+const svgWarning =
+  color => `<svg version="1.1" width="36" height="36" viewBox="0 0 36 36" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
     <title>exclamation-triangle-solid</title>
     <path d="M30.33,25.54,20.59,7.6a3,3,0,0,0-5.27,0L5.57,25.54A3,3,0,0,0,8.21,30H27.69a3,3,0,0,0,2.64-4.43ZM16.46,12.74a1.49,1.49,0,0,1,3,0v6.89a1.49,1.49,0,1,1-3,0ZM18,26.25a1.72,1.72,0,1,1,1.72-1.72A1.72,1.72,0,0,1,18,26.25Z" fill="${color}"></path>
     <rect x="0" y="0" width="36" height="36" fill-opacity="0"/></svg>`;
 
-const svgError = color => `<svg version="1.1" width="36" height="36" viewBox="0 0 36 36" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
+const svgError =
+  color => `<svg version="1.1" width="36" height="36" viewBox="0 0 36 36" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
     <title>exclamation-circle-solid</title>
     <path d="M18,6A12,12,0,1,0,30,18,12,12,0,0,0,18,6Zm-1.49,6a1.49,1.49,0,0,1,3,0v6.89a1.49,1.49,0,1,1-3,0ZM18,25.5a1.72,1.72,0,1,1,1.72-1.72A1.72,1.72,0,0,1,18,25.5Z" fill="${color}"></path>
     <rect x="0" y="0" width="36" height="36" fill-opacity="0"/></svg>`;

--- a/web/src/app/modules/shared/components/presentation/resource-viewer/resource-viewer.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/resource-viewer/resource-viewer.component.spec.ts
@@ -34,7 +34,7 @@ describe('ResourceViewerComponent', () => {
   });
 
   it('should show node labels', done => {
-    component.view = ({
+    component.view = {
       config: {
         nodes: {
           '16428c94-a848-47d5-b1e3-c8245b57959b': {
@@ -55,15 +55,14 @@ describe('ResourceViewerComponent', () => {
               },
               config: {
                 value: 'metadata-proxy-v0.1',
-                ref:
-                  '/overview/namespace/kube-system/workloads/daemon-sets/metadata-proxy-v0.1',
+                ref: '/overview/namespace/kube-system/workloads/daemon-sets/metadata-proxy-v0.1',
               },
             },
             hasChildren: false,
           },
         },
       },
-    } as unknown) as ResourceViewerView;
+    } as unknown as ResourceViewerView;
 
     fixture.detectChanges();
 

--- a/web/src/app/modules/shared/components/presentation/resource-viewer/resource-viewer.component.ts
+++ b/web/src/app/modules/shared/components/presentation/resource-viewer/resource-viewer.component.ts
@@ -46,7 +46,8 @@ const defaultZoom = {
 })
 export class ResourceViewerComponent
   extends AbstractViewComponent<ResourceViewerView>
-  implements OnInit, OnDestroy {
+  implements OnInit, OnDestroy
+{
   selectedNodeId: string;
   private subscriptionTheme: Subscription;
   resizeEdges = { left: true, right: true };

--- a/web/src/app/modules/shared/components/presentation/select-file/select-file.component.ts
+++ b/web/src/app/modules/shared/components/presentation/select-file/select-file.component.ts
@@ -30,7 +30,8 @@ type File = {
 })
 export class SelectFileComponent
   extends AbstractViewComponent<SelectFileView>
-  implements OnInit {
+  implements OnInit
+{
   label: string;
   multiple: boolean;
   layout: string;

--- a/web/src/app/modules/shared/components/presentation/stepper/stepper.component.spec.ts
+++ b/web/src/app/modules/shared/components/presentation/stepper/stepper.component.spec.ts
@@ -78,15 +78,13 @@ describe('StepperComponent', () => {
     'should submit form after completing each step',
     waitForAsync(() => {
       fixture.whenStable().then(() => {
-        let nextButton = fixture.debugElement.nativeElement.querySelector(
-          '.next'
-        );
+        let nextButton =
+          fixture.debugElement.nativeElement.querySelector('.next');
         nextButton.click();
         fixture.detectChanges();
 
-        nextButton = fixture.debugElement.nativeElement.querySelector(
-          '.submit'
-        );
+        nextButton =
+          fixture.debugElement.nativeElement.querySelector('.submit');
         nextButton.click();
         fixture.detectChanges();
 

--- a/web/src/app/modules/shared/components/presentation/stepper/stepper.component.ts
+++ b/web/src/app/modules/shared/components/presentation/stepper/stepper.component.ts
@@ -18,7 +18,8 @@ interface Choice {
 })
 export class StepperComponent
   extends AbstractViewComponent<StepperView>
-  implements OnInit {
+  implements OnInit
+{
   @Output()
   submit: EventEmitter<FormGroup> = new EventEmitter(true);
 

--- a/web/src/app/modules/shared/components/presentation/text/text.component.ts
+++ b/web/src/app/modules/shared/components/presentation/text/text.component.ts
@@ -21,7 +21,8 @@ import { parse } from 'marked';
 })
 export class TextComponent
   extends AbstractViewComponent<TextView>
-  implements OnInit {
+  implements OnInit
+{
   value: string | SafeHtml;
   clipboardValue: string;
   copied: boolean;

--- a/web/src/app/modules/shared/components/presentation/timeline/timeline.component.ts
+++ b/web/src/app/modules/shared/components/presentation/timeline/timeline.component.ts
@@ -14,7 +14,8 @@ import { TimelineStep, TimelineView } from '../../../models/content';
 })
 export class TimelineComponent
   extends AbstractViewComponent<TimelineView>
-  implements OnInit {
+  implements OnInit
+{
   vertical: boolean;
   steps: TimelineStep[];
   constructor() {

--- a/web/src/app/modules/shared/components/presentation/timestamp/timestamp.component.ts
+++ b/web/src/app/modules/shared/components/presentation/timestamp/timestamp.component.ts
@@ -16,7 +16,8 @@ import { AbstractViewComponent } from '../../abstract-view/abstract-view.compone
 })
 export class TimestampComponent
   extends AbstractViewComponent<TimestampView>
-  implements OnDestroy {
+  implements OnDestroy
+{
   timestamp: number;
   humanReadable: string;
 

--- a/web/src/app/modules/shared/components/smart/editor/editor.component.ts
+++ b/web/src/app/modules/shared/components/smart/editor/editor.component.ts
@@ -25,7 +25,8 @@ interface Options {
 })
 export class EditorComponent
   extends AbstractViewComponent<EditorView>
-  implements OnInit, OnDestroy {
+  implements OnInit, OnDestroy
+{
   set value(v: string) {
     if (v !== this.editorValue) {
       this.isModified = true;

--- a/web/src/app/modules/shared/components/smart/logs/logs.component.spec.ts
+++ b/web/src/app/modules/shared/components/smart/logs/logs.component.spec.ts
@@ -157,12 +157,10 @@ describe('LogsComponent', () => {
     component.filterText = 'Test log';
     fixture.detectChanges();
 
-    const prevButton = fixture.debugElement.nativeElement.querySelector(
-      '#button-prev'
-    );
-    const nextButton = fixture.debugElement.nativeElement.querySelector(
-      '#button-next'
-    );
+    const prevButton =
+      fixture.debugElement.nativeElement.querySelector('#button-prev');
+    const nextButton =
+      fixture.debugElement.nativeElement.querySelector('#button-next');
     const badgeElement: HTMLDivElement = fixture.debugElement.query(
       By.css('.clr-filter-summary')
     ).nativeElement;

--- a/web/src/app/modules/shared/components/smart/logs/logs.component.ts
+++ b/web/src/app/modules/shared/components/smart/logs/logs.component.ts
@@ -35,7 +35,8 @@ import { AbstractViewComponent } from '../../abstract-view/abstract-view.compone
 })
 export class LogsComponent
   extends AbstractViewComponent<LogsView>
-  implements OnInit, OnDestroy, AfterContentChecked, AfterViewChecked {
+  implements OnInit, OnDestroy, AfterContentChecked, AfterViewChecked
+{
   private logStream: PodLogsStreamer;
 
   private containerLogsDiffer: IterableDiffer<LogEntry>;
@@ -228,11 +229,8 @@ export class LogsComponent
       const nextSelection: HTMLElement = this.getHighlightedElement(
         this.currentSelection
       );
-      const {
-        clientHeight,
-        offsetTop,
-        scrollTop,
-      } = this.scrollTarget.nativeElement;
+      const { clientHeight, offsetTop, scrollTop } =
+        this.scrollTarget.nativeElement;
       const top = nextSelection.offsetTop - offsetTop;
 
       if (top > clientHeight + scrollTop || top < scrollTop) {

--- a/web/src/app/modules/shared/components/smart/slider-view/slider-view.component.ts
+++ b/web/src/app/modules/shared/components/smart/slider-view/slider-view.component.ts
@@ -18,7 +18,8 @@ import { AbstractViewComponent } from '../../abstract-view/abstract-view.compone
 })
 export class SliderViewComponent
   extends AbstractViewComponent<ExtensionView>
-  implements OnChanges {
+  implements OnChanges
+{
   style: object = {};
   contentStyle: object = {};
   animationState = 'out';

--- a/web/src/app/modules/shared/components/smart/terminal/terminal.component.ts
+++ b/web/src/app/modules/shared/components/smart/terminal/terminal.component.ts
@@ -30,7 +30,8 @@ import { AbstractViewComponent } from '../../abstract-view/abstract-view.compone
 })
 export class TerminalComponent
   extends AbstractViewComponent<TerminalView>
-  implements OnDestroy, AfterViewInit {
+  implements OnDestroy, AfterViewInit
+{
   @ViewChild('terminal', { static: true }) terminalDiv: ElementRef;
 
   selectedContainer = '';

--- a/web/src/app/modules/shared/components/view/view-container.component.ts
+++ b/web/src/app/modules/shared/components/view/view-container.component.ts
@@ -90,15 +90,13 @@ export class ViewContainerComponent implements OnInit, AfterViewInit {
         component = MissingComponentComponent;
       }
 
-      const componentFactory = this.componentFactoryResolver.resolveComponentFactory(
-        component
-      );
+      const componentFactory =
+        this.componentFactoryResolver.resolveComponentFactory(component);
       const viewContainerRef = this.appView.viewContainerRef;
       viewContainerRef.clear();
 
-      this.componentRef = viewContainerRef.createComponent<Viewer>(
-        componentFactory
-      );
+      this.componentRef =
+        viewContainerRef.createComponent<Viewer>(componentFactory);
     }
     this.componentRef.instance.view = view;
     this.componentRef.instance.viewInit.subscribe(_ => this.viewInit.emit());

--- a/web/src/app/modules/shared/services/kube-context/kube-context.service.ts
+++ b/web/src/app/modules/shared/services/kube-context/kube-context.service.ts
@@ -27,9 +27,8 @@ const emptyKubeContext: KubeContextResponse = {
   providedIn: 'root',
 })
 export class KubeContextService {
-  private contextsSource: BehaviorSubject<
-    ContextDescription[]
-  > = new BehaviorSubject<ContextDescription[]>([]);
+  private contextsSource: BehaviorSubject<ContextDescription[]> =
+    new BehaviorSubject<ContextDescription[]>([]);
   private selectedSource = new BehaviorSubject<string>('');
 
   constructor(private websocketService: WebsocketService) {

--- a/web/src/app/modules/shared/services/navigation/navigation.service.spec.ts
+++ b/web/src/app/modules/shared/services/navigation/navigation.service.spec.ts
@@ -179,8 +179,7 @@ describe('NavigationService', () => {
         result: '/overview/namespace/test/workloads/deployments',
       },
       {
-        url:
-          '/overview/namespace/default/workloads/deployments/nginx-deployment',
+        url: '/overview/namespace/default/workloads/deployments/nginx-deployment',
         namespace: 'test',
         result: '/overview/namespace/test',
       },

--- a/web/src/app/modules/shared/services/navigation/navigation.test.data.ts
+++ b/web/src/app/modules/shared/services/navigation/navigation.test.data.ts
@@ -83,20 +83,17 @@ export const NAVIGATION_MOCK_DATA: NavigationChild[] = [
       },
       {
         title: 'Horizontal Pod Autoscalers',
-        path:
-          'overview/namespace/default/discovery-and-load-balancing/horizontal-pod-autoscalers',
+        path: 'overview/namespace/default/discovery-and-load-balancing/horizontal-pod-autoscalers',
         isLoading: false,
       },
       {
         title: 'Ingresses',
-        path:
-          'overview/namespace/default/discovery-and-load-balancing/ingresses',
+        path: 'overview/namespace/default/discovery-and-load-balancing/ingresses',
         isLoading: false,
       },
       {
         title: 'Services',
-        path:
-          'overview/namespace/default/discovery-and-load-balancing/services',
+        path: 'overview/namespace/default/discovery-and-load-balancing/services',
         isLoading: false,
       },
     ],
@@ -119,8 +116,7 @@ export const NAVIGATION_MOCK_DATA: NavigationChild[] = [
       },
       {
         title: 'Persistent Volume Claims',
-        path:
-          'overview/namespace/default/config-and-storage/persistent-volume-claims',
+        path: 'overview/namespace/default/config-and-storage/persistent-volume-claims',
         isLoading: false,
       },
       {
@@ -222,8 +218,7 @@ export const NAVIGATION_MOCK_DATA: NavigationChild[] = [
       {
         title:
           'antreacontrollerinfos.clusterinformation.antrea.tanzu.vmware.com',
-        path:
-          'cluster-overview/custom-resources/antreacontrollerinfos.clusterinformation.antrea.tanzu.vmware.com',
+        path: 'cluster-overview/custom-resources/antreacontrollerinfos.clusterinformation.antrea.tanzu.vmware.com',
         iconName: 'internal:crd',
         isLoading: false,
       },
@@ -373,10 +368,11 @@ export const expectedSelection = {
     module: 1,
     index: 2,
   },
-  'overview/namespace/default/discovery-and-load-balancing/horizontal-pod-autoscalers': {
-    module: 1,
-    index: 2,
-  },
+  'overview/namespace/default/discovery-and-load-balancing/horizontal-pod-autoscalers':
+    {
+      module: 1,
+      index: 2,
+    },
   'overview/namespace/default/discovery-and-load-balancing/ingresses': {
     module: 1,
     index: 2,
@@ -419,10 +415,11 @@ export const expectedSelection = {
     module: 2,
     index: 2,
   },
-  'cluster-overview/custom-resources/antreacontrollerinfos.clusterinformation.antrea.tanzu.vmware.com': {
-    module: 2,
-    index: 2,
-  },
+  'cluster-overview/custom-resources/antreacontrollerinfos.clusterinformation.antrea.tanzu.vmware.com':
+    {
+      module: 2,
+      index: 2,
+    },
   'cluster-overview/rbac': { module: 2, index: 3 },
   'cluster-overview/rbac/cluster-roles': { module: 2, index: 3 },
   'cluster-overview/rbac/cluster-role-bindings': { module: 2, index: 3 },

--- a/web/src/app/modules/shared/services/preferences/preferences.service.ts
+++ b/web/src/app/modules/shared/services/preferences/preferences.service.ts
@@ -22,9 +22,8 @@ export class PreferencesService implements OnDestroy {
   private kubeConfigFullPath: string;
 
   public preferences: Map<string, PreferencesEntry<any>> = new Map();
-  public preferencesOpened: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(
-    false
-  );
+  public preferencesOpened: BehaviorSubject<boolean> =
+    new BehaviorSubject<boolean>(false);
 
   constructor(private themeService: ThemeService) {
     if (this.isElectron()) {

--- a/web/src/app/modules/sugarloaf/components/smart/container/container.component.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/container/container.component.ts
@@ -56,12 +56,11 @@ export class ContainerComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    this.subscriptionPreferencesOpened = this.preferencesService.preferencesOpened.subscribe(
-      opened => {
+    this.subscriptionPreferencesOpened =
+      this.preferencesService.preferencesOpened.subscribe(opened => {
         this.preferences = this.preferencesService.getPreferences(); // TODO: merge with server side prefs (currently broken)
         this.preferencesOpened = opened;
-      }
-    );
+      });
 
     this.websocketService.open();
     this.localKubeConfigPath = this.helperService

--- a/web/src/app/modules/sugarloaf/components/smart/input-filter/input-filter.component.spec.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/input-filter/input-filter.component.spec.ts
@@ -122,14 +122,16 @@ describe('InputFilterComponent', () => {
       { key: 'test3', value: 'filter3' },
     ]);
     fixture.detectChanges();
-    inputElement = fixture.debugElement.query(By.css('.text-input'))
-      .nativeElement;
+    inputElement = fixture.debugElement.query(
+      By.css('.text-input')
+    ).nativeElement;
     expect(inputElement.placeholder).toMatch(/Filter by labels \(3 applied\)/i);
 
     labelFilterService.filters.next([{ key: 'test1', value: 'filter1' }]);
     fixture.detectChanges();
-    inputElement = fixture.debugElement.query(By.css('.text-input'))
-      .nativeElement;
+    inputElement = fixture.debugElement.query(
+      By.css('.text-input')
+    ).nativeElement;
     expect(inputElement.placeholder).toMatch(/Filter by labels \(1 applied\)/i);
   });
 
@@ -155,8 +157,9 @@ describe('InputFilterComponent', () => {
 
     fixture.whenStable().then(() => {
       fixture.detectChanges();
-      inputNativeElement = fixture.debugElement.query(By.css('.text-input'))
-        .nativeElement;
+      inputNativeElement = fixture.debugElement.query(
+        By.css('.text-input')
+      ).nativeElement;
       expect(inputNativeElement.value).toBe('');
     });
   });

--- a/web/src/app/modules/sugarloaf/components/smart/namespace/namespace.component.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/namespace/namespace.component.ts
@@ -44,19 +44,19 @@ export class NamespaceComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit() {
-    this.namespaceSubscription = this.namespaceService.activeNamespace.subscribe(
-      (namespace: string) => {
+    this.namespaceSubscription =
+      this.namespaceService.activeNamespace.subscribe((namespace: string) => {
         this.currentNamespace = namespace;
         this.cdr.detectChanges();
-      }
-    );
+      });
 
-    this.namespaceSubscription = this.namespaceService.availableNamespaces.subscribe(
-      (namespaces: string[]) => {
-        this.namespaces = namespaces;
-        this.cdr.detectChanges();
-      }
-    );
+    this.namespaceSubscription =
+      this.namespaceService.availableNamespaces.subscribe(
+        (namespaces: string[]) => {
+          this.namespaces = namespaces;
+          this.cdr.detectChanges();
+        }
+      );
 
     this.navigationService.modules.subscribe(modules => {
       this.modules = modules;

--- a/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/navigation/navigation.component.ts
@@ -64,8 +64,8 @@ export class NavigationComponent implements OnInit, OnDestroy {
       }
     );
 
-    this.subscriptionSelectedItem = this.navigationService.selectedItem.subscribe(
-      selection => {
+    this.subscriptionSelectedItem =
+      this.navigationService.selectedItem.subscribe(selection => {
         if (
           this.selectedItem.index !== selection.index ||
           this.selectedItem.module !== selection.module
@@ -74,8 +74,7 @@ export class NavigationComponent implements OnInit, OnDestroy {
           this.currentModule = this.modules[this.selectedItem.module];
           this.cd.markForCheck();
         }
-      }
-    );
+      });
 
     this.subscriptionCollapsed = this.preferencesService.preferences
       .get('navigation.collapsed')

--- a/web/src/app/modules/sugarloaf/components/smart/notifier/notifier.component.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/notifier/notifier.component.ts
@@ -28,8 +28,8 @@ export class NotifierComponent implements OnInit, OnDestroy {
   constructor(private notifierService: NotifierService) {}
 
   ngOnInit() {
-    this.signalSubscription = this.notifierService.globalSignalsStream.subscribe(
-      currentSignals => {
+    this.signalSubscription =
+      this.notifierService.globalSignalsStream.subscribe(currentSignals => {
         const lastLoadingSignal = findLast(currentSignals, {
           type: NotifierSignalType.LOADING,
         });
@@ -60,8 +60,7 @@ export class NotifierComponent implements OnInit, OnDestroy {
           : '';
 
         this.setAlert();
-      }
-    );
+      });
   }
 
   ngOnDestroy(): void {

--- a/web/src/app/modules/sugarloaf/components/smart/quick-switcher/quick-switcher.component.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/quick-switcher/quick-switcher.component.ts
@@ -68,13 +68,11 @@ export class QuickSwitcherComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    this.namespaceSubscription = this.namespaceService.availableNamespaces.subscribe(
-      namespaces => {
-        this.namespaceDestinations = this.buildNamespaceDestinations(
-          namespaces
-        );
-      }
-    );
+    this.namespaceSubscription =
+      this.namespaceService.availableNamespaces.subscribe(namespaces => {
+        this.namespaceDestinations =
+          this.buildNamespaceDestinations(namespaces);
+      });
     this.navigationSubscription = this.navigationService.current.subscribe(
       navigation => {
         this.navigation = navigation;

--- a/web/src/app/modules/sugarloaf/components/smart/theme-switch/theme-switch-button.component.spec.ts
+++ b/web/src/app/modules/sugarloaf/components/smart/theme-switch/theme-switch-button.component.spec.ts
@@ -43,8 +43,9 @@ describe('ThemeSwitchButtonComponent', () => {
   it('should render the right button', () => {
     component.lightThemeEnabled = true;
     fixture.detectChanges();
-    const switchButton = fixture.debugElement.query(By.css('#switchButton'))
-      .nativeElement;
+    const switchButton = fixture.debugElement.query(
+      By.css('#switchButton')
+    ).nativeElement;
 
     expect(switchButton.innerHTML).toContain('dark');
   });

--- a/web/src/app/util/timestamp-comparator.ts
+++ b/web/src/app/util/timestamp-comparator.ts
@@ -8,7 +8,8 @@ import {
 } from '../modules/shared/models/content';
 
 export class TimestampComparator
-  implements ClrDatagridComparatorInterface<TableRowWithMetadata> {
+  implements ClrDatagridComparatorInterface<TableRowWithMetadata>
+{
   compare(a: TableRowWithMetadata, b: TableRowWithMetadata) {
     const rowA = a.data.Age as TimestampView;
     const rowB = b.data.Age as TimestampView;

--- a/web/src/stories/graph/graph.real.data.ts
+++ b/web/src/stories/graph/graph.real.data.ts
@@ -25,8 +25,7 @@ export const REAL_DATA_STATEFUL_SET: NodeDataDef = {
       path: {
         config: {
           value: 'kafka-config',
-          ref:
-            '/overview/namespace/milan/config-and-storage/config-maps/kafka-config',
+          ref: '/overview/namespace/milan/config-and-storage/config-maps/kafka-config',
         },
         metadata: {
           type: 'link',
@@ -45,8 +44,7 @@ export const REAL_DATA_STATEFUL_SET: NodeDataDef = {
       path: {
         config: {
           value: 'kafka-headless',
-          ref:
-            '/overview/namespace/milan/discovery-and-load-balancing/services/kafka-headless',
+          ref: '/overview/namespace/milan/discovery-and-load-balancing/services/kafka-headless',
         },
         metadata: {
           type: 'link',
@@ -65,8 +63,7 @@ export const REAL_DATA_STATEFUL_SET: NodeDataDef = {
       path: {
         config: {
           value: 'default-token-4dln7',
-          ref:
-            '/overview/namespace/milan/config-and-storage/secrets/default-token-4dln7',
+          ref: '/overview/namespace/milan/config-and-storage/secrets/default-token-4dln7',
         },
         metadata: {
           type: 'link',
@@ -107,8 +104,7 @@ export const REAL_DATA_STATEFUL_SET: NodeDataDef = {
       path: {
         config: {
           value: 'default',
-          ref:
-            '/overview/namespace/milan/config-and-storage/service-accounts/default',
+          ref: '/overview/namespace/milan/config-and-storage/service-accounts/default',
         },
         metadata: {
           type: 'link',
@@ -180,8 +176,7 @@ export const REAL_DATA_DAEMON_SET: NodeDataDef = {
       path: {
         config: {
           value: 'hubble-token-smc5q',
-          ref:
-            '/overview/namespace/kube-system/config-and-storage/secrets/hubble-token-smc5q',
+          ref: '/overview/namespace/kube-system/config-and-storage/secrets/hubble-token-smc5q',
         },
         metadata: {
           type: 'link',
@@ -203,8 +198,7 @@ export const REAL_DATA_DAEMON_SET: NodeDataDef = {
       path: {
         config: {
           value: 'hubble-grpc',
-          ref:
-            '/overview/namespace/kube-system/discovery-and-load-balancing/services/hubble-grpc',
+          ref: '/overview/namespace/kube-system/discovery-and-load-balancing/services/hubble-grpc',
         },
         metadata: {
           type: 'link',
@@ -226,8 +220,7 @@ export const REAL_DATA_DAEMON_SET: NodeDataDef = {
       path: {
         config: {
           value: 'hubble',
-          ref:
-            '/overview/namespace/kube-system/config-and-storage/service-accounts/hubble',
+          ref: '/overview/namespace/kube-system/config-and-storage/service-accounts/hubble',
         },
         metadata: {
           type: 'link',
@@ -330,8 +323,7 @@ export const REAL_DATA_DAEMON_SET2: NodeDataDef = {
         },
         config: {
           value: 'metadata-proxy-v0.1',
-          ref:
-            '/overview/namespace/kube-system/workloads/daemon-sets/metadata-proxy-v0.1',
+          ref: '/overview/namespace/kube-system/workloads/daemon-sets/metadata-proxy-v0.1',
         },
       },
       hasChildren: false,
@@ -365,8 +357,7 @@ export const REAL_DATA_DEPLOYMENT: NodeDataDef = {
       path: {
         config: {
           value: 'default-token-4dln7',
-          ref:
-            '/overview/namespace/milan/config-and-storage/secrets/default-token-4dln7',
+          ref: '/overview/namespace/milan/config-and-storage/secrets/default-token-4dln7',
         },
         metadata: {
           type: 'link',
@@ -385,8 +376,7 @@ export const REAL_DATA_DEPLOYMENT: NodeDataDef = {
       path: {
         config: {
           value: 'echo1-56b7744b6c',
-          ref:
-            '/overview/namespace/milan/workloads/replica-sets/echo1-56b7744b6c',
+          ref: '/overview/namespace/milan/workloads/replica-sets/echo1-56b7744b6c',
         },
         metadata: {
           type: 'link',
@@ -408,8 +398,7 @@ export const REAL_DATA_DEPLOYMENT: NodeDataDef = {
       path: {
         config: {
           value: 'default',
-          ref:
-            '/overview/namespace/milan/config-and-storage/service-accounts/default',
+          ref: '/overview/namespace/milan/config-and-storage/service-accounts/default',
         },
         metadata: {
           type: 'link',
@@ -428,8 +417,7 @@ export const REAL_DATA_DEPLOYMENT: NodeDataDef = {
       path: {
         config: {
           value: 'echo1',
-          ref:
-            '/overview/namespace/milan/discovery-and-load-balancing/services/echo1',
+          ref: '/overview/namespace/milan/discovery-and-load-balancing/services/echo1',
         },
         metadata: {
           type: 'link',
@@ -519,8 +507,7 @@ export const REAL_DATA_TWO_REPLICAS: NodeDataDef = {
       path: {
         config: {
           value: 'elasticsearch-dbf4fc4df',
-          ref:
-            '/overview/namespace/milan/workloads/replica-sets/elasticsearch-dbf4fc4df',
+          ref: '/overview/namespace/milan/workloads/replica-sets/elasticsearch-dbf4fc4df',
         },
         metadata: {
           type: 'link',
@@ -542,8 +529,7 @@ export const REAL_DATA_TWO_REPLICAS: NodeDataDef = {
       path: {
         config: {
           value: 'elasticsearch-569cc48595',
-          ref:
-            '/overview/namespace/milan/workloads/replica-sets/elasticsearch-569cc48595',
+          ref: '/overview/namespace/milan/workloads/replica-sets/elasticsearch-569cc48595',
         },
         metadata: {
           type: 'link',
@@ -562,8 +548,7 @@ export const REAL_DATA_TWO_REPLICAS: NodeDataDef = {
       path: {
         config: {
           value: 'default-token-4dln7',
-          ref:
-            '/overview/namespace/milan/config-and-storage/secrets/default-token-4dln7',
+          ref: '/overview/namespace/milan/config-and-storage/secrets/default-token-4dln7',
         },
         metadata: {
           type: 'link',
@@ -604,8 +589,7 @@ export const REAL_DATA_TWO_REPLICAS: NodeDataDef = {
       path: {
         config: {
           value: 'elasticsearch',
-          ref:
-            '/overview/namespace/milan/discovery-and-load-balancing/services/elasticsearch',
+          ref: '/overview/namespace/milan/discovery-and-load-balancing/services/elasticsearch',
         },
         metadata: {
           type: 'link',
@@ -627,8 +611,7 @@ export const REAL_DATA_TWO_REPLICAS: NodeDataDef = {
       path: {
         config: {
           value: 'default',
-          ref:
-            '/overview/namespace/milan/config-and-storage/service-accounts/default',
+          ref: '/overview/namespace/milan/config-and-storage/service-accounts/default',
         },
         metadata: {
           type: 'link',
@@ -708,8 +691,7 @@ export const REAL_DATA_JOB: NodeDataDef = {
       path: {
         config: {
           value: 'contour-certgen-v1.12.0',
-          ref:
-            '/overview/namespace/contour-internal/workloads/jobs/contour-certgen-v1.12.0',
+          ref: '/overview/namespace/contour-internal/workloads/jobs/contour-certgen-v1.12.0',
         },
         metadata: {
           type: 'link',
@@ -728,8 +710,7 @@ export const REAL_DATA_JOB: NodeDataDef = {
       path: {
         config: {
           value: 'contour-certgen-token-5ggj6',
-          ref:
-            '/overview/namespace/contour-internal/config-and-storage/secrets/contour-certgen-token-5ggj6',
+          ref: '/overview/namespace/contour-internal/config-and-storage/secrets/contour-certgen-token-5ggj6',
         },
         metadata: {
           type: 'link',
@@ -751,8 +732,7 @@ export const REAL_DATA_JOB: NodeDataDef = {
       path: {
         config: {
           value: 'contour-certgen',
-          ref:
-            '/overview/namespace/contour-internal/config-and-storage/service-accounts/contour-certgen',
+          ref: '/overview/namespace/contour-internal/config-and-storage/service-accounts/contour-certgen',
         },
         metadata: {
           type: 'link',
@@ -831,8 +811,7 @@ export const REAL_DATA_INGRESS: NodeDataDef = {
       path: {
         config: {
           value: 'web-79d88c97d6',
-          ref:
-            '/overview/namespace/milan/workloads/replica-sets/web-79d88c97d6',
+          ref: '/overview/namespace/milan/workloads/replica-sets/web-79d88c97d6',
         },
         metadata: {
           type: 'link',
@@ -851,8 +830,7 @@ export const REAL_DATA_INGRESS: NodeDataDef = {
       path: {
         config: {
           value: 'default-token-4dln7',
-          ref:
-            '/overview/namespace/milan/config-and-storage/secrets/default-token-4dln7',
+          ref: '/overview/namespace/milan/config-and-storage/secrets/default-token-4dln7',
         },
         metadata: {
           type: 'link',
@@ -871,8 +849,7 @@ export const REAL_DATA_INGRESS: NodeDataDef = {
       path: {
         config: {
           value: 'web',
-          ref:
-            '/overview/namespace/milan/discovery-and-load-balancing/services/web',
+          ref: '/overview/namespace/milan/discovery-and-load-balancing/services/web',
         },
         metadata: {
           type: 'link',
@@ -894,8 +871,7 @@ export const REAL_DATA_INGRESS: NodeDataDef = {
       path: {
         config: {
           value: 'web2',
-          ref:
-            '/overview/namespace/milan/discovery-and-load-balancing/services/web2',
+          ref: '/overview/namespace/milan/discovery-and-load-balancing/services/web2',
         },
         metadata: {
           type: 'link',
@@ -917,8 +893,7 @@ export const REAL_DATA_INGRESS: NodeDataDef = {
       path: {
         config: {
           value: 'default',
-          ref:
-            '/overview/namespace/milan/config-and-storage/service-accounts/default',
+          ref: '/overview/namespace/milan/config-and-storage/service-accounts/default',
         },
         metadata: {
           type: 'link',
@@ -937,8 +912,7 @@ export const REAL_DATA_INGRESS: NodeDataDef = {
       path: {
         config: {
           value: 'example-ingress',
-          ref:
-            '/overview/namespace/milan/discovery-and-load-balancing/ingresses/example-ingress',
+          ref: '/overview/namespace/milan/discovery-and-load-balancing/ingresses/example-ingress',
         },
         metadata: {
           type: 'link',
@@ -1015,8 +989,7 @@ export const REAL_DATA_CRDS: NodeDataDef = {
       path: {
         config: {
           value: 'capi-quickstart-md-0-54w8c',
-          ref:
-            '/overview/namespace/milan/custom-resources/gcpmachines.infrastructure.cluster.x-k8s.io/v1alpha3/capi-quickstart-md-0-54w8c',
+          ref: '/overview/namespace/milan/custom-resources/gcpmachines.infrastructure.cluster.x-k8s.io/v1alpha3/capi-quickstart-md-0-54w8c',
         },
         metadata: {
           type: 'link',
@@ -1040,8 +1013,7 @@ export const REAL_DATA_CRDS: NodeDataDef = {
       path: {
         config: {
           value: 'capi-quickstart-md-0-hswzw',
-          ref:
-            '/overview/namespace/milan/custom-resources/gcpmachines.infrastructure.cluster.x-k8s.io/v1alpha3/capi-quickstart-md-0-hswzw',
+          ref: '/overview/namespace/milan/custom-resources/gcpmachines.infrastructure.cluster.x-k8s.io/v1alpha3/capi-quickstart-md-0-hswzw',
         },
         metadata: {
           type: 'link',
@@ -1063,8 +1035,7 @@ export const REAL_DATA_CRDS: NodeDataDef = {
       path: {
         config: {
           value: 'capi-quickstart-md-0-996bb7685-kgwqk',
-          ref:
-            '/overview/namespace/milan/custom-resources/machines.cluster.x-k8s.io/v1alpha3/capi-quickstart-md-0-996bb7685-kgwqk',
+          ref: '/overview/namespace/milan/custom-resources/machines.cluster.x-k8s.io/v1alpha3/capi-quickstart-md-0-996bb7685-kgwqk',
         },
         metadata: {
           type: 'link',
@@ -1088,8 +1059,7 @@ export const REAL_DATA_CRDS: NodeDataDef = {
       path: {
         config: {
           value: 'capi-quickstart-md-0-pc6tv',
-          ref:
-            '/overview/namespace/milan/custom-resources/gcpmachines.infrastructure.cluster.x-k8s.io/v1alpha3/capi-quickstart-md-0-pc6tv',
+          ref: '/overview/namespace/milan/custom-resources/gcpmachines.infrastructure.cluster.x-k8s.io/v1alpha3/capi-quickstart-md-0-pc6tv',
         },
         metadata: {
           type: 'link',
@@ -1111,8 +1081,7 @@ export const REAL_DATA_CRDS: NodeDataDef = {
       path: {
         config: {
           value: 'capi-quickstart-md-0-996bb7685-lq985',
-          ref:
-            '/overview/namespace/milan/custom-resources/machines.cluster.x-k8s.io/v1alpha3/capi-quickstart-md-0-996bb7685-lq985',
+          ref: '/overview/namespace/milan/custom-resources/machines.cluster.x-k8s.io/v1alpha3/capi-quickstart-md-0-996bb7685-lq985',
         },
         metadata: {
           type: 'link',
@@ -1136,8 +1105,7 @@ export const REAL_DATA_CRDS: NodeDataDef = {
       path: {
         config: {
           value: 'capi-quickstart-md-0-vvklf',
-          ref:
-            '/overview/namespace/milan/custom-resources/kubeadmconfigs.bootstrap.cluster.x-k8s.io/v1alpha3/capi-quickstart-md-0-vvklf',
+          ref: '/overview/namespace/milan/custom-resources/kubeadmconfigs.bootstrap.cluster.x-k8s.io/v1alpha3/capi-quickstart-md-0-vvklf',
         },
         metadata: {
           type: 'link',
@@ -1161,8 +1129,7 @@ export const REAL_DATA_CRDS: NodeDataDef = {
       path: {
         config: {
           value: 'capi-quickstart-md-0',
-          ref:
-            '/overview/namespace/milan/custom-resources/machinedeployments.cluster.x-k8s.io/v1alpha3/capi-quickstart-md-0',
+          ref: '/overview/namespace/milan/custom-resources/machinedeployments.cluster.x-k8s.io/v1alpha3/capi-quickstart-md-0',
         },
         metadata: {
           type: 'link',
@@ -1184,8 +1151,7 @@ export const REAL_DATA_CRDS: NodeDataDef = {
       path: {
         config: {
           value: 'capi-quickstart-md-0-996bb7685',
-          ref:
-            '/overview/namespace/milan/custom-resources/machinesets.cluster.x-k8s.io/v1alpha3/capi-quickstart-md-0-996bb7685',
+          ref: '/overview/namespace/milan/custom-resources/machinesets.cluster.x-k8s.io/v1alpha3/capi-quickstart-md-0-996bb7685',
         },
         metadata: {
           type: 'link',
@@ -1207,8 +1173,7 @@ export const REAL_DATA_CRDS: NodeDataDef = {
       path: {
         config: {
           value: 'capi-quickstart',
-          ref:
-            '/overview/namespace/milan/custom-resources/clusters.cluster.x-k8s.io/v1alpha3/capi-quickstart',
+          ref: '/overview/namespace/milan/custom-resources/clusters.cluster.x-k8s.io/v1alpha3/capi-quickstart',
         },
         metadata: {
           type: 'link',
@@ -1232,8 +1197,7 @@ export const REAL_DATA_CRDS: NodeDataDef = {
       path: {
         config: {
           value: 'capi-quickstart-md-0-4rqgc',
-          ref:
-            '/overview/namespace/milan/custom-resources/kubeadmconfigs.bootstrap.cluster.x-k8s.io/v1alpha3/capi-quickstart-md-0-4rqgc',
+          ref: '/overview/namespace/milan/custom-resources/kubeadmconfigs.bootstrap.cluster.x-k8s.io/v1alpha3/capi-quickstart-md-0-4rqgc',
         },
         metadata: {
           type: 'link',
@@ -1255,8 +1219,7 @@ export const REAL_DATA_CRDS: NodeDataDef = {
       path: {
         config: {
           value: 'capi-quickstart-md-0-996bb7685-wh2tx',
-          ref:
-            '/overview/namespace/milan/custom-resources/machines.cluster.x-k8s.io/v1alpha3/capi-quickstart-md-0-996bb7685-wh2tx',
+          ref: '/overview/namespace/milan/custom-resources/machines.cluster.x-k8s.io/v1alpha3/capi-quickstart-md-0-996bb7685-wh2tx',
         },
         metadata: {
           type: 'link',
@@ -1280,8 +1243,7 @@ export const REAL_DATA_CRDS: NodeDataDef = {
       path: {
         config: {
           value: 'capi-quickstart-md-0-8rwp6',
-          ref:
-            '/overview/namespace/milan/custom-resources/kubeadmconfigs.bootstrap.cluster.x-k8s.io/v1alpha3/capi-quickstart-md-0-8rwp6',
+          ref: '/overview/namespace/milan/custom-resources/kubeadmconfigs.bootstrap.cluster.x-k8s.io/v1alpha3/capi-quickstart-md-0-8rwp6',
         },
         metadata: {
           type: 'link',
@@ -1429,8 +1391,7 @@ export const REAL_DATA_CRDS2: NodeDataDef = {
       path: {
         config: {
           value: 'loader',
-          ref:
-            '/overview/namespace/milan/discovery-and-load-balancing/services/loader',
+          ref: '/overview/namespace/milan/discovery-and-load-balancing/services/loader',
         },
         metadata: {
           type: 'link',
@@ -1449,8 +1410,7 @@ export const REAL_DATA_CRDS2: NodeDataDef = {
       path: {
         config: {
           value: 'elasticsearch-dbf4fc4df',
-          ref:
-            '/overview/namespace/milan/workloads/replica-sets/elasticsearch-dbf4fc4df',
+          ref: '/overview/namespace/milan/workloads/replica-sets/elasticsearch-dbf4fc4df',
         },
         metadata: {
           type: 'link',
@@ -1469,8 +1429,7 @@ export const REAL_DATA_CRDS2: NodeDataDef = {
       path: {
         config: {
           value: 'kafka-config',
-          ref:
-            '/overview/namespace/milan/config-and-storage/config-maps/kafka-config',
+          ref: '/overview/namespace/milan/config-and-storage/config-maps/kafka-config',
         },
         metadata: {
           type: 'link',
@@ -1508,8 +1467,7 @@ export const REAL_DATA_CRDS2: NodeDataDef = {
       path: {
         config: {
           value: 'jobposting-57bd4c8596',
-          ref:
-            '/overview/namespace/milan/workloads/replica-sets/jobposting-57bd4c8596',
+          ref: '/overview/namespace/milan/workloads/replica-sets/jobposting-57bd4c8596',
         },
         metadata: {
           type: 'link',
@@ -1528,8 +1486,7 @@ export const REAL_DATA_CRDS2: NodeDataDef = {
       path: {
         config: {
           value: 'kafka-headless',
-          ref:
-            '/overview/namespace/milan/discovery-and-load-balancing/services/kafka-headless',
+          ref: '/overview/namespace/milan/discovery-and-load-balancing/services/kafka-headless',
         },
         metadata: {
           type: 'link',
@@ -1570,8 +1527,7 @@ export const REAL_DATA_CRDS2: NodeDataDef = {
       path: {
         config: {
           value: 'elasticsearch-569cc48595',
-          ref:
-            '/overview/namespace/milan/workloads/replica-sets/elasticsearch-569cc48595',
+          ref: '/overview/namespace/milan/workloads/replica-sets/elasticsearch-569cc48595',
         },
         metadata: {
           type: 'link',
@@ -1609,8 +1565,7 @@ export const REAL_DATA_CRDS2: NodeDataDef = {
       path: {
         config: {
           value: 'web-79d88c97d6',
-          ref:
-            '/overview/namespace/milan/workloads/replica-sets/web-79d88c97d6',
+          ref: '/overview/namespace/milan/workloads/replica-sets/web-79d88c97d6',
         },
         metadata: {
           type: 'link',
@@ -1632,8 +1587,7 @@ export const REAL_DATA_CRDS2: NodeDataDef = {
       path: {
         config: {
           value: 'default',
-          ref:
-            '/overview/namespace/milan/custom-resources/brokers.eventing.knative.dev/v1/default',
+          ref: '/overview/namespace/milan/custom-resources/brokers.eventing.knative.dev/v1/default',
         },
         metadata: {
           type: 'link',
@@ -1652,8 +1606,7 @@ export const REAL_DATA_CRDS2: NodeDataDef = {
       path: {
         config: {
           value: 'zookeeper-66b5f99f97',
-          ref:
-            '/overview/namespace/milan/workloads/replica-sets/zookeeper-66b5f99f97',
+          ref: '/overview/namespace/milan/workloads/replica-sets/zookeeper-66b5f99f97',
         },
         metadata: {
           type: 'link',
@@ -1672,8 +1625,7 @@ export const REAL_DATA_CRDS2: NodeDataDef = {
       path: {
         config: {
           value: 'default-token-4dln7',
-          ref:
-            '/overview/namespace/milan/config-and-storage/secrets/default-token-4dln7',
+          ref: '/overview/namespace/milan/config-and-storage/secrets/default-token-4dln7',
         },
         metadata: {
           type: 'link',
@@ -1733,8 +1685,7 @@ export const REAL_DATA_CRDS2: NodeDataDef = {
       path: {
         config: {
           value: 'recruiter-54f94f7b87',
-          ref:
-            '/overview/namespace/milan/workloads/replica-sets/recruiter-54f94f7b87',
+          ref: '/overview/namespace/milan/workloads/replica-sets/recruiter-54f94f7b87',
         },
         metadata: {
           type: 'link',
@@ -1753,8 +1704,7 @@ export const REAL_DATA_CRDS2: NodeDataDef = {
       path: {
         config: {
           value: 'web',
-          ref:
-            '/overview/namespace/milan/discovery-and-load-balancing/services/web',
+          ref: '/overview/namespace/milan/discovery-and-load-balancing/services/web',
         },
         metadata: {
           type: 'link',
@@ -1776,8 +1726,7 @@ export const REAL_DATA_CRDS2: NodeDataDef = {
       path: {
         config: {
           value: 'default-kne-trigger',
-          ref:
-            '/overview/namespace/milan/custom-resources/inmemorychannels.messaging.knative.dev/v1/default-kne-trigger',
+          ref: '/overview/namespace/milan/custom-resources/inmemorychannels.messaging.knative.dev/v1/default-kne-trigger',
         },
         metadata: {
           type: 'link',
@@ -1796,8 +1745,7 @@ export const REAL_DATA_CRDS2: NodeDataDef = {
       path: {
         config: {
           value: 'jobposting',
-          ref:
-            '/overview/namespace/milan/discovery-and-load-balancing/services/jobposting',
+          ref: '/overview/namespace/milan/discovery-and-load-balancing/services/jobposting',
         },
         metadata: {
           type: 'link',
@@ -1816,8 +1764,7 @@ export const REAL_DATA_CRDS2: NodeDataDef = {
       path: {
         config: {
           value: 'recruiter',
-          ref:
-            '/overview/namespace/milan/discovery-and-load-balancing/services/recruiter',
+          ref: '/overview/namespace/milan/discovery-and-load-balancing/services/recruiter',
         },
         metadata: {
           type: 'link',
@@ -1836,8 +1783,7 @@ export const REAL_DATA_CRDS2: NodeDataDef = {
       path: {
         config: {
           value: 'zk-headless',
-          ref:
-            '/overview/namespace/milan/discovery-and-load-balancing/services/zk-headless',
+          ref: '/overview/namespace/milan/discovery-and-load-balancing/services/zk-headless',
         },
         metadata: {
           type: 'link',
@@ -1859,8 +1805,7 @@ export const REAL_DATA_CRDS2: NodeDataDef = {
       path: {
         config: {
           value: 'web2',
-          ref:
-            '/overview/namespace/milan/discovery-and-load-balancing/services/web2',
+          ref: '/overview/namespace/milan/discovery-and-load-balancing/services/web2',
         },
         metadata: {
           type: 'link',
@@ -1879,8 +1824,7 @@ export const REAL_DATA_CRDS2: NodeDataDef = {
       path: {
         config: {
           value: 'default-kne-trigger-kn-channel',
-          ref:
-            '/overview/namespace/milan/discovery-and-load-balancing/services/default-kne-trigger-kn-channel',
+          ref: '/overview/namespace/milan/discovery-and-load-balancing/services/default-kne-trigger-kn-channel',
         },
         metadata: {
           type: 'link',
@@ -1899,8 +1843,7 @@ export const REAL_DATA_CRDS2: NodeDataDef = {
       path: {
         config: {
           value: 'elasticsearch',
-          ref:
-            '/overview/namespace/milan/discovery-and-load-balancing/services/elasticsearch',
+          ref: '/overview/namespace/milan/discovery-and-load-balancing/services/elasticsearch',
         },
         metadata: {
           type: 'link',
@@ -1919,8 +1862,7 @@ export const REAL_DATA_CRDS2: NodeDataDef = {
       path: {
         config: {
           value: 'echo1-56b7744b6c',
-          ref:
-            '/overview/namespace/milan/workloads/replica-sets/echo1-56b7744b6c',
+          ref: '/overview/namespace/milan/workloads/replica-sets/echo1-56b7744b6c',
         },
         metadata: {
           type: 'link',
@@ -1961,8 +1903,7 @@ export const REAL_DATA_CRDS2: NodeDataDef = {
       path: {
         config: {
           value: 'default',
-          ref:
-            '/overview/namespace/milan/config-and-storage/service-accounts/default',
+          ref: '/overview/namespace/milan/config-and-storage/service-accounts/default',
         },
         metadata: {
           type: 'link',
@@ -1981,8 +1922,7 @@ export const REAL_DATA_CRDS2: NodeDataDef = {
       path: {
         config: {
           value: 'loader-69fb98c8b5',
-          ref:
-            '/overview/namespace/milan/workloads/replica-sets/loader-69fb98c8b5',
+          ref: '/overview/namespace/milan/workloads/replica-sets/loader-69fb98c8b5',
         },
         metadata: {
           type: 'link',
@@ -2001,8 +1941,7 @@ export const REAL_DATA_CRDS2: NodeDataDef = {
       path: {
         config: {
           value: 'rolling-test-574b87c764',
-          ref:
-            '/overview/namespace/milan/workloads/replica-sets/rolling-test-574b87c764',
+          ref: '/overview/namespace/milan/workloads/replica-sets/rolling-test-574b87c764',
         },
         metadata: {
           type: 'link',
@@ -2083,8 +2022,7 @@ export const REAL_DATA_CRDS2: NodeDataDef = {
       path: {
         config: {
           value: 'echo1',
-          ref:
-            '/overview/namespace/milan/discovery-and-load-balancing/services/echo1',
+          ref: '/overview/namespace/milan/discovery-and-load-balancing/services/echo1',
         },
         metadata: {
           type: 'link',
@@ -2213,8 +2151,7 @@ export const REAL_DATA_CRDS2: NodeDataDef = {
       path: {
         config: {
           value: 'crawler-67cf8bbcdd',
-          ref:
-            '/overview/namespace/milan/workloads/replica-sets/crawler-67cf8bbcdd',
+          ref: '/overview/namespace/milan/workloads/replica-sets/crawler-67cf8bbcdd',
         },
         metadata: {
           type: 'link',
@@ -2233,8 +2170,7 @@ export const REAL_DATA_CRDS2: NodeDataDef = {
       path: {
         config: {
           value: 'example-ingress',
-          ref:
-            '/overview/namespace/milan/discovery-and-load-balancing/ingresses/example-ingress',
+          ref: '/overview/namespace/milan/discovery-and-load-balancing/ingresses/example-ingress',
         },
         metadata: {
           type: 'link',

--- a/web/src/stories/overview.data.ts
+++ b/web/src/stories/overview.data.ts
@@ -66,8 +66,7 @@ export const big_data = {
                 },
                 config: {
                   value: 'kubernetes',
-                  ref:
-                    '/overview/namespace/default/discovery-and-load-balancing/services/kubernetes',
+                  ref: '/overview/namespace/default/discovery-and-load-balancing/services/kubernetes',
                   status: 1,
                   statusDetail: {
                     metadata: { type: 'list' },
@@ -109,8 +108,7 @@ export const big_data = {
                       },
                       confirmation: {
                         title: 'Delete Service',
-                        body:
-                          'Are you sure you want to delete *Service* **kubernetes**? This action is permanent and cannot be recovered.',
+                        body: 'Are you sure you want to delete *Service* **kubernetes**? This action is permanent and cannot be recovered.',
                       },
                       type: 'danger',
                     },
@@ -160,8 +158,7 @@ export const big_data = {
                 },
                 config: {
                   value: 'default-token-k4mp4',
-                  ref:
-                    '/overview/namespace/default/config-and-storage/secrets/default-token-k4mp4',
+                  ref: '/overview/namespace/default/config-and-storage/secrets/default-token-k4mp4',
                   status: 1,
                   statusDetail: {
                     metadata: { type: 'list' },
@@ -195,8 +192,7 @@ export const big_data = {
                       },
                       confirmation: {
                         title: 'Delete Secret',
-                        body:
-                          'Are you sure you want to delete *Secret* **default-token-k4mp4**? This action is permanent and cannot be recovered.',
+                        body: 'Are you sure you want to delete *Secret* **default-token-k4mp4**? This action is permanent and cannot be recovered.',
                       },
                       type: 'danger',
                     },
@@ -246,8 +242,7 @@ export const big_data = {
                 },
                 config: {
                   value: 'default',
-                  ref:
-                    '/overview/namespace/default/config-and-storage/service-accounts/default',
+                  ref: '/overview/namespace/default/config-and-storage/service-accounts/default',
                   status: 1,
                   statusDetail: {
                     metadata: { type: 'list' },
@@ -278,8 +273,7 @@ export const big_data = {
                       },
                       confirmation: {
                         title: 'Delete ServiceAccount',
-                        body:
-                          'Are you sure you want to delete *ServiceAccount* **default**? This action is permanent and cannot be recovered.',
+                        body: 'Are you sure you want to delete *ServiceAccount* **default**? This action is permanent and cannot be recovered.',
                       },
                       type: 'danger',
                     },
@@ -337,8 +331,7 @@ export const big_data = {
                 config: {
                   value:
                     'Node minikube event: Registered Node minikube in Controller',
-                  ref:
-                    '/overview/namespace/default/events/minikube.1619233ef88b9048',
+                  ref: '/overview/namespace/default/events/minikube.1619233ef88b9048',
                 },
               },
               Reason: {
@@ -369,8 +362,7 @@ export const big_data = {
                 },
                 config: {
                   value: 'Starting kube-proxy.',
-                  ref:
-                    '/overview/namespace/default/events/minikube.1619233b5373d195',
+                  ref: '/overview/namespace/default/events/minikube.1619233b5373d195',
                 },
               },
               Reason: {
@@ -401,8 +393,7 @@ export const big_data = {
                 },
                 config: {
                   value: 'Node minikube status is now: NodeHasSufficientPID',
-                  ref:
-                    '/overview/namespace/default/events/minikube.16192335109a3bee',
+                  ref: '/overview/namespace/default/events/minikube.16192335109a3bee',
                 },
               },
               Reason: {
@@ -433,8 +424,7 @@ export const big_data = {
                 },
                 config: {
                   value: 'Node minikube status is now: NodeHasNoDiskPressure',
-                  ref:
-                    '/overview/namespace/default/events/minikube.1619233510993cda',
+                  ref: '/overview/namespace/default/events/minikube.1619233510993cda',
                 },
               },
               Reason: {
@@ -465,8 +455,7 @@ export const big_data = {
                 },
                 config: {
                   value: 'Node minikube status is now: NodeHasSufficientMemory',
-                  ref:
-                    '/overview/namespace/default/events/minikube.161923351097f4ba',
+                  ref: '/overview/namespace/default/events/minikube.161923351097f4ba',
                 },
               },
               Reason: {
@@ -497,8 +486,7 @@ export const big_data = {
                 },
                 config: {
                   value: 'Updated Node Allocatable limit across pods',
-                  ref:
-                    '/overview/namespace/default/events/minikube.161923352af5316a',
+                  ref: '/overview/namespace/default/events/minikube.161923352af5316a',
                 },
               },
               Reason: {
@@ -529,8 +517,7 @@ export const big_data = {
                 },
                 config: {
                   value: 'Starting kubelet.',
-                  ref:
-                    '/overview/namespace/default/events/minikube.16192334f653ead2',
+                  ref: '/overview/namespace/default/events/minikube.16192334f653ead2',
                 },
               },
               Reason: {
@@ -562,8 +549,7 @@ export const big_data = {
                 config: {
                   value:
                     'Node minikube event: Registered Node minikube in Controller',
-                  ref:
-                    '/overview/namespace/default/events/minikube.1618e3199521f52d',
+                  ref: '/overview/namespace/default/events/minikube.1618e3199521f52d',
                 },
               },
               Reason: {


### PR DESCRIPTION
**What this PR does / why we need it**:
prettier update from 2.2 to 2.3.2 added a few additional rules which affects a few parts of our code base (https://github.com/vmware-tanzu/octant/actions/runs/1023763892).

See https://github.com/vmware-tanzu/octant/actions/runs/1023763892 as an example of failure due to this upgrade.

We should consider less optimistic upgrades for such tooling (or maybe we are okay with occasional failures as a forcing function to keep tooling up-to-date).

Signed-off-by: Sam Foo <foos@vmware.com>
