### PR TITLE
Reconciles unmarshal and base code differences

### DIFF
--- a/changelogs/unreleased/2669-liamrathke
+++ b/changelogs/unreleased/2669-liamrathke
@@ -1,0 +1,1 @@
+Fixes issues preventing complex custom resource viewer graphs from being displayed in TypeScript-based plugins

--- a/pkg/view/component/base.go
+++ b/pkg/view/component/base.go
@@ -10,6 +10,8 @@ const (
 	TypeAccordion = "accordion"
 	// TypeAnnotations is an annotations component.
 	TypeAnnotations = "annotations"
+	// TypeButton is a Button component.
+	TypeButton = "button"
 	// TypeButtonGroup is a button group component.
 	TypeButtonGroup = "buttonGroup"
 	// TypeCard is a card component.
@@ -42,6 +44,8 @@ const (
 	TypeGraphviz = "graphviz"
 	// TypeGridActions is a grid actions component.
 	TypeGridActions = "gridActions"
+	// TypeIcon is a Icon component.
+	TypeIcon = "icon"
 	// TypeIFrame is an iframe component.
 	TypeIFrame = "iframe"
 	// TypeJSONEditor is a JSON Editor component.
@@ -74,6 +78,8 @@ const (
 	TypeSelectFile = "selectFile"
 	// TypeSelectors is a selectors component.
 	TypeSelectors = "selectors"
+	// TypeSignpost is a SignPost component.
+	TypeSignpost = "signpost"
 	// TypeSingleStat is a single stat component.
 	TypeSingleStat = "singleStat"
 	// TypeStepper is a stepper component.
@@ -82,6 +88,8 @@ const (
 	TypeSummary = "summary"
 	// TypeTable is a table component.
 	TypeTable = "table"
+	// TypeTabsView is a Tab component.
+	TypeTabsView = "tabsView"
 	// TypeTerminal is a terminal component.
 	TypeTerminal = "terminal"
 	// TypeText is a text component.
@@ -92,14 +100,6 @@ const (
 	TypeTimestamp = "timestamp"
 	// TypeYAML is a YAML component.
 	TypeYAML = "yaml"
-	// TypeIcon is a Icon component.
-	TypeIcon = "icon"
-	// TypeSignpost is a SignPost component.
-	TypeSignpost = "signpost"
-	// TypeButton is a Button component.
-	TypeButton = "button"
-	// TypeTabsView is a Tab component.
-	TypeTabsView = "tabsView"
 )
 
 // Base is an abstract base for components..

--- a/pkg/view/component/unmarshal.go
+++ b/pkg/view/component/unmarshal.go
@@ -84,7 +84,7 @@ func unmarshal(to TypedObject) (Component, error) {
 	case TypeExtension:
 		t := &Extension{Base: Base{Metadata: to.Metadata}}
 		err = errors.Wrapf(json.Unmarshal(to.Config, &t.Config),
-			"unmarshal expandable row detail config")
+			"unmarshal extension config")
 		o = t
 	case TypeExpressionSelector:
 		t := &ExpressionSelector{Base: Base{Metadata: to.Metadata}}
@@ -169,12 +169,12 @@ func unmarshal(to TypedObject) (Component, error) {
 	case TypePort:
 		t := &Port{Base: Base{Metadata: to.Metadata}}
 		err = errors.Wrapf(json.Unmarshal(to.Config, &t.Config),
-			"unmarshal loading config")
+			"unmarshal port config")
 		o = t
 	case TypePorts:
 		t := &Ports{Base: Base{Metadata: to.Metadata}}
 		err = errors.Wrapf(json.Unmarshal(to.Config, &t.Config),
-			"unmarshal loading config")
+			"unmarshal ports config")
 		o = t
 	case TypeQuadrant:
 		t := &Quadrant{Base: Base{Metadata: to.Metadata}}
@@ -229,7 +229,7 @@ func unmarshal(to TypedObject) (Component, error) {
 	case TypeTerminal:
 		t := &Terminal{Base: Base{Metadata: to.Metadata}}
 		err = errors.Wrapf(json.Unmarshal(to.Config, &t.Config),
-			"unmarshal tabs config")
+			"unmarshal terminal config")
 		o = t
 	case TypeText:
 		t := &Text{Base: Base{Metadata: to.Metadata}}
@@ -249,7 +249,7 @@ func unmarshal(to TypedObject) (Component, error) {
 	case TypeYAML:
 		t := &YAML{Base: Base{Metadata: to.Metadata}}
 		err = errors.Wrapf(json.Unmarshal(to.Config, &t.Config),
-			"unmarshal timestamp config")
+			"unmarshal YAML config")
 		o = t
 	default:
 		return nil, errors.Errorf("unknown view component %q", to.Metadata.Type)

--- a/pkg/view/component/unmarshal.go
+++ b/pkg/view/component/unmarshal.go
@@ -76,15 +76,20 @@ func unmarshal(to TypedObject) (Component, error) {
 		err = errors.Wrapf(json.Unmarshal(to.Config, &t.Config),
 			"unmarshal error config")
 		o = t
-	case TypeExpressionSelector:
-		t := &ExpressionSelector{Base: Base{Metadata: to.Metadata}}
-		err = errors.Wrapf(json.Unmarshal(to.Config, &t.Config),
-			"unmarshal expressionSelector config")
-		o = t
 	case TypeExpandableRowDetail:
 		t := &ExpandableRowDetail{Base: Base{Metadata: to.Metadata}}
 		err = errors.Wrapf(json.Unmarshal(to.Config, &t.Config),
 			"unmarshal expandable row detail config")
+		o = t
+	case TypeExtension:
+		t := &Extension{Base: Base{Metadata: to.Metadata}}
+		err = errors.Wrapf(json.Unmarshal(to.Config, &t.Config),
+			"unmarshal expandable row detail config")
+		o = t
+	case TypeExpressionSelector:
+		t := &ExpressionSelector{Base: Base{Metadata: to.Metadata}}
+		err = errors.Wrapf(json.Unmarshal(to.Config, &t.Config),
+			"unmarshal expressionSelector config")
 		o = t
 	case TypeFlexLayout:
 		t := &FlexLayout{Base: Base{Metadata: to.Metadata}}
@@ -106,6 +111,11 @@ func unmarshal(to TypedObject) (Component, error) {
 		err = errors.Wrapf(json.Unmarshal(to.Config, &t.Config),
 			"unmarshal gridActions config")
 		o = t
+	case TypeIcon:
+		t := &Icon{Base: Base{Metadata: to.Metadata}}
+		err = errors.Wrapf(json.Unmarshal(to.Config, &t.Config),
+			"unmarshal icon config")
+		o = t
 	case TypeIFrame:
 		t := &IFrame{Base: Base{Metadata: to.Metadata}}
 		err = errors.Wrapf(json.Unmarshal(to.Config, &t.Config),
@@ -126,11 +136,6 @@ func unmarshal(to TypedObject) (Component, error) {
 		err = errors.Wrapf(json.Unmarshal(to.Config, &t.Config),
 			"unmarshal labelSelector config")
 		o = t
-	case TypeLoading:
-		t := &Loading{Base: Base{Metadata: to.Metadata}}
-		err = errors.Wrapf(json.Unmarshal(to.Config, &t.Config),
-			"unmarshal loading config")
-		o = t
 	case TypeLink:
 		t := &Link{Base: Base{Metadata: to.Metadata}}
 		err = errors.Wrapf(json.Unmarshal(to.Config, &t.Config),
@@ -146,10 +151,30 @@ func unmarshal(to TypedObject) (Component, error) {
 		err = errors.Wrapf(json.Unmarshal(to.Config, &t.Config),
 			"unmarshal logs config")
 		o = t
+	case TypeLoading:
+		t := &Loading{Base: Base{Metadata: to.Metadata}}
+		err = errors.Wrapf(json.Unmarshal(to.Config, &t.Config),
+			"unmarshal loading config")
+		o = t
 	case TypeModal:
 		t := &Modal{Base: Base{Metadata: to.Metadata}}
 		err = errors.Wrapf(json.Unmarshal(to.Config, &t.Config),
 			"unmarshal modal config")
+		o = t
+	case TypePodStatus:
+		t := &PodStatus{Base: Base{Metadata: to.Metadata}}
+		err = errors.Wrapf(json.Unmarshal(to.Config, &t.Config),
+			"unmarshal pod status config")
+		o = t
+	case TypePort:
+		t := &Port{Base: Base{Metadata: to.Metadata}}
+		err = errors.Wrapf(json.Unmarshal(to.Config, &t.Config),
+			"unmarshal loading config")
+		o = t
+	case TypePorts:
+		t := &Ports{Base: Base{Metadata: to.Metadata}}
+		err = errors.Wrapf(json.Unmarshal(to.Config, &t.Config),
+			"unmarshal loading config")
 		o = t
 	case TypeQuadrant:
 		t := &Quadrant{Base: Base{Metadata: to.Metadata}}
@@ -171,6 +196,11 @@ func unmarshal(to TypedObject) (Component, error) {
 		err = errors.Wrapf(json.Unmarshal(to.Config, &t.Config),
 			"unmarshal selectors config")
 		o = t
+	case TypeSignpost:
+		t := &Signpost{Base: Base{Metadata: to.Metadata}}
+		err = errors.Wrapf(json.Unmarshal(to.Config, &t.Config),
+			"unmarshal signpost config")
+		o = t
 	case TypeSingleStat:
 		t := &SingleStat{Base: Base{Metadata: to.Metadata}}
 		err = errors.Wrapf(json.Unmarshal(to.Config, &t.Config),
@@ -191,6 +221,16 @@ func unmarshal(to TypedObject) (Component, error) {
 		err = errors.Wrapf(json.Unmarshal(to.Config, &t.Config),
 			"unmarshal table config")
 		o = t
+	case TypeTabsView:
+		t := &TabsView{Base: Base{Metadata: to.Metadata}}
+		err = errors.Wrapf(json.Unmarshal(to.Config, &t.Config),
+			"unmarshal tabs config")
+		o = t
+	case TypeTerminal:
+		t := &Terminal{Base: Base{Metadata: to.Metadata}}
+		err = errors.Wrapf(json.Unmarshal(to.Config, &t.Config),
+			"unmarshal tabs config")
+		o = t
 	case TypeText:
 		t := &Text{Base: Base{Metadata: to.Metadata}}
 		err = errors.Wrapf(json.Unmarshal(to.Config, &t.Config),
@@ -206,20 +246,10 @@ func unmarshal(to TypedObject) (Component, error) {
 		err = errors.Wrapf(json.Unmarshal(to.Config, &t.Config),
 			"unmarshal timestamp config")
 		o = t
-	case TypeIcon:
-		t := &Icon{Base: Base{Metadata: to.Metadata}}
+	case TypeYAML:
+		t := &YAML{Base: Base{Metadata: to.Metadata}}
 		err = errors.Wrapf(json.Unmarshal(to.Config, &t.Config),
-			"unmarshal icon config")
-		o = t
-	case TypeSignpost:
-		t := &Signpost{Base: Base{Metadata: to.Metadata}}
-		err = errors.Wrapf(json.Unmarshal(to.Config, &t.Config),
-			"unmarshal signpost config")
-		o = t
-	case TypeTabsView:
-		t := &TabsView{Base: Base{Metadata: to.Metadata}}
-		err = errors.Wrapf(json.Unmarshal(to.Config, &t.Config),
-			"unmarshal tabs config")
+			"unmarshal timestamp config")
 		o = t
 	default:
 		return nil, errors.Errorf("unknown view component %q", to.Metadata.Type)


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, complex resource viewer graphs sent to Octant via a TypeScript plugin cannot be displayed, as Octant's `unmarshal.go` is unaware of what to do with certain resource viewer components. This PR updates `unmarshal.go` to handle all current component type constants handled in `base.go`, and reorders the content of both files alphabetically.

Kudos to @mklanjsek for debugging and helping me find the solution!

**Testing steps**:

To test this example, we'll use a [sample TypeScript plugin that displays data in an Octant resource viewer](https://github.com/liamrathke/octant-example-plugins/tree/master/typescript/resource-viewer-sample)

1. Follow the installation instructions in the repo to install the plugin 
2. Run Octant off this branch, verify that all custom resource viewer graphs appear correctly

**Release note**:
```
Fixes issues preventing complex custom resource viewer graphs from being displayed in TypeScript-based plugins
Improves component infrastructure 
```
