### PR TITLE
Fixed `ObjectStatusResponse` to update resource viewer and object tables

### DIFF
--- a/changelogs/unreleased/2651-GuessWhoSamFoo
+++ b/changelogs/unreleased/2651-GuessWhoSamFoo
@@ -1,0 +1,1 @@
+Fixed `ObjectStatusResponse` to update resource viewer and object tables

--- a/cmd/octant-sample-plugin/main.go
+++ b/cmd/octant-sample-plugin/main.go
@@ -115,9 +115,13 @@ func handleStatus(request *service.PrintRequest) (plugin.ObjectStatusResponse, e
 		return plugin.ObjectStatusResponse{}, errors.New("object doesn't exist")
 	}
 
-	// Will add object UID to the Resource Viewer properties table
+	// Will add object UID to the Resource Viewer properties table and status icon details
 	return plugin.ObjectStatusResponse{
 		ObjectStatus: component.PodSummary{
+			// Status: component.NodeStatus,
+			Details: []component.Component{
+				component.NewText("from plugin: " + string(u.GetUID())),
+			},
 			Properties: []component.Property{{
 				Label: "ID (from plugin)",
 				Value: component.NewText(string(u.GetUID())),

--- a/internal/describer/describer.go
+++ b/internal/describer/describer.go
@@ -43,7 +43,7 @@ func (f *ObjectLoaderFactory) LoadObjects(ctx context.Context, namespace string,
 	return LoadObjects(ctx, f.dashConfig.ObjectStore(), f.dashConfig.ErrorStore(), namespace, fields, objectStoreKeys)
 }
 
-// loadObject loads a single object from the object store.
+// LoadObject loads a single object from the object store.
 func LoadObject(ctx context.Context, objectStore store.Store, errorStore oerrors.ErrorStore, namespace string, fields map[string]string, objectStoreKey store.Key) (*unstructured.Unstructured, error) {
 	objectStoreKey.Namespace = namespace
 
@@ -73,7 +73,7 @@ func LoadObject(ctx context.Context, objectStore store.Store, errorStore oerrors
 	return object, nil
 }
 
-// loadObjects loads objects from the object store sorted by their name.
+// LoadObjects loads objects from the object store sorted by their name.
 func LoadObjects(ctx context.Context, objectStore store.Store, errorStore oerrors.ErrorStore, namespace string, fields map[string]string, objectStoreKeys []store.Key) (*unstructured.UnstructuredList, error) {
 	list := &unstructured.UnstructuredList{}
 

--- a/internal/objectstatus/apiservice.go
+++ b/internal/objectstatus/apiservice.go
@@ -43,22 +43,22 @@ func apiService(_ context.Context, object runtime.Object, _ store.Store, _ link.
 	switch {
 	case availableCondition == nil:
 		return ObjectStatus{
-			nodeStatus: component.NodeStatusWarning,
+			NodeStatus: component.NodeStatusWarning,
 			Details:    []component.Component{component.NewText("No available condition for this apiservice")},
 		}, nil
 	case availableCondition.Status == apiregistrationv1.ConditionFalse:
 		return ObjectStatus{
-			nodeStatus: component.NodeStatusError,
+			NodeStatus: component.NodeStatusError,
 			Details:    []component.Component{component.NewTextf("Not available: (%s) %s", availableCondition.Reason, availableCondition.Message)},
 		}, nil
 	case availableCondition.Status == apiregistrationv1.ConditionTrue:
 		return ObjectStatus{
-			nodeStatus: component.NodeStatusOK,
+			NodeStatus: component.NodeStatusOK,
 			Details:    []component.Component{component.NewText("API Service is OK")},
 		}, nil
 	default:
 		return ObjectStatus{
-			nodeStatus: component.NodeStatusWarning,
+			NodeStatus: component.NodeStatusWarning,
 			Details: []component.Component{
 				component.NewTextf("Unknown availability for apiservice")},
 		}, nil

--- a/internal/objectstatus/apiservice_test.go
+++ b/internal/objectstatus/apiservice_test.go
@@ -39,7 +39,7 @@ func Test_apiService(t *testing.T) {
 
 			},
 			expected: ObjectStatus{
-				nodeStatus: component.NodeStatusOK,
+				NodeStatus: component.NodeStatusOK,
 				Details:    []component.Component{component.NewText("API Service is OK")},
 			},
 		},
@@ -51,7 +51,7 @@ func Test_apiService(t *testing.T) {
 
 			},
 			expected: ObjectStatus{
-				nodeStatus: component.NodeStatusError,
+				NodeStatus: component.NodeStatusError,
 				Details:    []component.Component{component.NewText("Not available: (ServiceNotFound) service/metrics-server in \"kube-system\" is not present")},
 			},
 		},
@@ -63,7 +63,7 @@ func Test_apiService(t *testing.T) {
 
 			},
 			expected: ObjectStatus{
-				nodeStatus: component.NodeStatusWarning,
+				NodeStatus: component.NodeStatusWarning,
 				Details:    []component.Component{component.NewText("No available condition for this apiservice")},
 			},
 		},

--- a/internal/objectstatus/cronjob.go
+++ b/internal/objectstatus/cronjob.go
@@ -37,13 +37,13 @@ func cronJob(_ context.Context, object runtime.Object, _ store.Store, _ link.Int
 	if cronjob.Spec.Suspend != nil && *cronjob.Spec.Suspend {
 		properties = append(properties, component.Property{Label: "Suspend", Value: component.NewText(strconv.FormatBool(*cronjob.Spec.Suspend))})
 		return ObjectStatus{
-			nodeStatus: component.NodeStatusWarning,
+			NodeStatus: component.NodeStatusWarning,
 			Details:    []component.Component{component.NewText("Cronjob is suspended")},
 			Properties: properties,
 		}, nil
 	}
 	return ObjectStatus{
-		nodeStatus: component.NodeStatusOK,
+		NodeStatus: component.NodeStatusOK,
 		Details:    []component.Component{component.NewText("batch/v1beta1 CronJob is OK")},
 		Properties: properties,
 	}, nil

--- a/internal/objectstatus/daemonset.go
+++ b/internal/objectstatus/daemonset.go
@@ -45,19 +45,19 @@ func daemonSet(_ context.Context, object runtime.Object, _ store.Store, _ link.I
 	switch {
 	case status.NumberMisscheduled > 0:
 		return ObjectStatus{
-			nodeStatus: component.NodeStatusWarning,
+			NodeStatus: component.NodeStatusWarning,
 			Details:    []component.Component{component.NewText("Daemon Set pods are running on nodes that aren't supposed to run Daemon Set pods")},
 			Properties: properties,
 		}, nil
 	case status.DesiredNumberScheduled != status.NumberReady:
 		return ObjectStatus{
-			nodeStatus: component.NodeStatusWarning,
+			NodeStatus: component.NodeStatusWarning,
 			Details:    []component.Component{component.NewText("Daemon Set pods are not ready")},
 			Properties: properties,
 		}, nil
 	default:
 		return ObjectStatus{
-			nodeStatus: component.NodeStatusOK,
+			NodeStatus: component.NodeStatusOK,
 			Details:    []component.Component{component.NewText("Daemon Set is OK")},
 			Properties: properties,
 		}, nil

--- a/internal/objectstatus/daemonset_test.go
+++ b/internal/objectstatus/daemonset_test.go
@@ -37,7 +37,7 @@ func Test_daemonSet(t *testing.T) {
 
 			},
 			expected: ObjectStatus{
-				nodeStatus: component.NodeStatusOK,
+				NodeStatus: component.NodeStatusOK,
 				Details:    []component.Component{component.NewText("Daemon Set is OK")},
 				Properties: []component.Property{{Label: "Selectors", Value: component.NewSelectors([]component.Selector{component.NewLabelSelector("name", "fluentd")})}},
 			},
@@ -50,7 +50,7 @@ func Test_daemonSet(t *testing.T) {
 
 			},
 			expected: ObjectStatus{
-				nodeStatus: component.NodeStatusWarning,
+				NodeStatus: component.NodeStatusWarning,
 				Details:    []component.Component{component.NewText("Daemon Set pods are running on nodes that aren't supposed to run Daemon Set pods")},
 				Properties: []component.Property{{Label: "Selectors", Value: component.NewSelectors([]component.Selector{component.NewLabelSelector("name", "fluentd")})}},
 			},
@@ -63,7 +63,7 @@ func Test_daemonSet(t *testing.T) {
 
 			},
 			expected: ObjectStatus{
-				nodeStatus: component.NodeStatusWarning,
+				NodeStatus: component.NodeStatusWarning,
 				Details:    []component.Component{component.NewText("Daemon Set pods are not ready")},
 				Properties: []component.Property{{Label: "Selectors", Value: component.NewSelectors([]component.Selector{component.NewLabelSelector("name", "fluentd")})}},
 			},

--- a/internal/objectstatus/deployment.go
+++ b/internal/objectstatus/deployment.go
@@ -40,19 +40,19 @@ func deploymentAppsV1(_ context.Context, object runtime.Object, _ store.Store, _
 	switch {
 	case status.Replicas == status.UnavailableReplicas:
 		return ObjectStatus{
-			nodeStatus: component.NodeStatusError,
+			NodeStatus: component.NodeStatusError,
 			Details:    []component.Component{component.NewText("No replicas exist for this deployment")},
 			Properties: properties,
 		}, nil
 	case status.Replicas == status.AvailableReplicas:
 		return ObjectStatus{
-			nodeStatus: component.NodeStatusOK,
+			NodeStatus: component.NodeStatusOK,
 			Details:    []component.Component{component.NewText("Deployment is OK")},
 			Properties: properties,
 		}, nil
 	default:
 		return ObjectStatus{
-			nodeStatus: component.NodeStatusWarning,
+			NodeStatus: component.NodeStatusWarning,
 			Details: []component.Component{
 				component.NewText(
 					fmt.Sprintf("Expected %d replicas, but %d are available",

--- a/internal/objectstatus/deployment_test.go
+++ b/internal/objectstatus/deployment_test.go
@@ -37,7 +37,7 @@ func Test_deploymentAppsV1(t *testing.T) {
 
 			},
 			expected: ObjectStatus{
-				nodeStatus: component.NodeStatusOK,
+				NodeStatus: component.NodeStatusOK,
 				Details:    []component.Component{component.NewText("Deployment is OK")},
 				Properties: []component.Property{{Label: "Deployment Strategy", Value: component.NewText("RollingUpdate")},
 					{Label: "Selectors", Value: component.NewSelectors([]component.Selector{component.NewLabelSelector("app", "hello-node")})}},
@@ -51,7 +51,7 @@ func Test_deploymentAppsV1(t *testing.T) {
 
 			},
 			expected: ObjectStatus{
-				nodeStatus: component.NodeStatusError,
+				NodeStatus: component.NodeStatusError,
 				Details:    []component.Component{component.NewText("No replicas exist for this deployment")},
 				Properties: []component.Property{{Label: "Deployment Strategy", Value: component.NewText("RollingUpdate")},
 					{Label: "Selectors", Value: component.NewSelectors([]component.Selector{component.NewLabelSelector("app", "hello-node")})}},
@@ -65,7 +65,7 @@ func Test_deploymentAppsV1(t *testing.T) {
 
 			},
 			expected: ObjectStatus{
-				nodeStatus: component.NodeStatusWarning,
+				NodeStatus: component.NodeStatusWarning,
 				Details:    []component.Component{component.NewText("Expected 1 replicas, but 0 are available")},
 				Properties: []component.Property{{Label: "Deployment Strategy", Value: component.NewText("RollingUpdate")},
 					{Label: "Selectors", Value: component.NewSelectors([]component.Selector{component.NewLabelSelector("app", "hello-node")})}},

--- a/internal/objectstatus/ingress_test.go
+++ b/internal/objectstatus/ingress_test.go
@@ -54,7 +54,7 @@ func Test_runIngressStatus(t *testing.T) {
 
 			},
 			expected: ObjectStatus{
-				nodeStatus: component.NodeStatusError,
+				NodeStatus: component.NodeStatusError,
 				Details:    []component.Component{component.NewText("Backend refers to service \"no-such-service\" which doesn't exist")},
 				Properties: []component.Property{{Label: "Default Backend", Value: component.NewText("Not configured")}},
 			},
@@ -67,7 +67,7 @@ func Test_runIngressStatus(t *testing.T) {
 				return testutil.LoadObjectFromFile(t, objectFile)
 			},
 			expected: ObjectStatus{
-				nodeStatus: component.NodeStatusError,
+				NodeStatus: component.NodeStatusError,
 				Details:    []component.Component{component.NewText("Backend for service \"service-wrong-port\" specifies an invalid port")},
 				Properties: []component.Property{{Label: "Default Backend", Value: component.NewText("Not configured")}},
 			},
@@ -83,7 +83,7 @@ func Test_runIngressStatus(t *testing.T) {
 
 			},
 			expected: ObjectStatus{
-				nodeStatus: component.NodeStatusError,
+				NodeStatus: component.NodeStatusError,
 				Details:    []component.Component{component.NewText("No matching TLS host for rule \"not-the-tls-host.com\"")},
 				Properties: []component.Property{{Label: "Default Backend", Value: component.NewText("Not configured")}},
 			},
@@ -116,7 +116,7 @@ func Test_runIngressStatus(t *testing.T) {
 
 			},
 			expected: ObjectStatus{
-				nodeStatus: component.NodeStatusError,
+				NodeStatus: component.NodeStatusError,
 				Details:    []component.Component{component.NewText("Secret \"no-such-secret\" does not exist")},
 				Properties: []component.Property{{Label: "Default Backend", Value: component.NewText("Not configured")}},
 			},

--- a/internal/objectstatus/job_test.go
+++ b/internal/objectstatus/job_test.go
@@ -51,7 +51,7 @@ func Test_runJobStatus(t *testing.T) {
 				return testutil.LoadObjectFromFile(t, objectFile)
 			},
 			expected: ObjectStatus{
-				nodeStatus: component.NodeStatusWarning,
+				NodeStatus: component.NodeStatusWarning,
 				Details: []component.Component{
 					component.NewText("Job has failed 2 times"),
 					component.NewText("Job is in progress"),
@@ -67,7 +67,7 @@ func Test_runJobStatus(t *testing.T) {
 				return testutil.LoadObjectFromFile(t, objectFile)
 			},
 			expected: ObjectStatus{
-				nodeStatus: component.NodeStatusError,
+				NodeStatus: component.NodeStatusError,
 				Details: []component.Component{
 					component.NewText("Job has failed 5 times"),
 					component.NewText("Job has reached the specified backoff limit"),

--- a/internal/objectstatus/objectstatus.go
+++ b/internal/objectstatus/objectstatus.go
@@ -46,7 +46,7 @@ var (
 )
 
 type ObjectStatus struct {
-	nodeStatus component.NodeStatus
+	NodeStatus component.NodeStatus
 	Details    []component.Component
 	Properties []component.Property
 }
@@ -74,21 +74,21 @@ func (os *ObjectStatus) AddDetailf(msg string, args ...interface{}) {
 }
 
 func (os *ObjectStatus) SetError() {
-	os.nodeStatus = component.NodeStatusError
+	os.NodeStatus = component.NodeStatusError
 }
 
 func (os *ObjectStatus) SetWarning() {
-	if os.nodeStatus != component.NodeStatusError {
-		os.nodeStatus = component.NodeStatusWarning
+	if os.NodeStatus != component.NodeStatusError {
+		os.NodeStatus = component.NodeStatusWarning
 	}
 }
 
 func (os *ObjectStatus) Status() component.NodeStatus {
-	switch os.nodeStatus {
+	switch os.NodeStatus {
 	case component.NodeStatusWarning,
 		component.NodeStatusError,
 		component.NodeStatusOK:
-		return os.nodeStatus
+		return os.NodeStatus
 	default:
 		return component.NodeStatusOK
 	}
@@ -114,7 +114,7 @@ func status(ctx context.Context, object runtime.Object, o store.Store, lookup st
 
 	if accessor.GetDeletionTimestamp() != nil {
 		return ObjectStatus{
-			nodeStatus: component.NodeStatusWarning,
+			NodeStatus: component.NodeStatusWarning,
 			Details: []component.Component{
 				component.NewTextf("%s is being deleted", kind),
 			},
@@ -132,7 +132,7 @@ func status(ctx context.Context, object runtime.Object, o store.Store, lookup st
 		oStatus, err = fn(ctx, object, o, link)
 	} else {
 		oStatus = ObjectStatus{
-			nodeStatus: component.NodeStatusOK,
+			NodeStatus: component.NodeStatusOK,
 			Details:    []component.Component{component.NewText(fmt.Sprintf("%s %s is OK", apiVersion, kind))},
 			Properties: []component.Property{},
 		}

--- a/internal/objectstatus/objectstatus_test.go
+++ b/internal/objectstatus/objectstatus_test.go
@@ -29,7 +29,7 @@ import (
 func Test_status(t *testing.T) {
 	deployment := testutil.CreateDeployment("deployment")
 	deployObjectStatus := ObjectStatus{
-		nodeStatus: component.NodeStatusOK,
+		NodeStatus: component.NodeStatusOK,
 		Details:    []component.Component{component.NewText("apps/v1 Deployment is OK")},
 		Properties: []component.Property{{Label: "Namespace", Value: component.NewText("namespace")},
 			{Label: "Created", Value: component.NewTimestamp(deployment.CreationTimestamp.Time)}},

--- a/internal/objectstatus/persistent_volume.go
+++ b/internal/objectstatus/persistent_volume.go
@@ -42,13 +42,13 @@ func persistentVolume(ctx context.Context, object runtime.Object, o store.Store,
 		if pvc == nil || err != nil {
 			claimWarning := fmt.Sprintf("PVC %s/%s cannot be found", claim.Namespace, claim.Name)
 			return ObjectStatus{
-				nodeStatus: component.NodeStatusWarning,
+				NodeStatus: component.NodeStatusWarning,
 				Details:    []component.Component{component.NewText(claimWarning)}}, nil
 		}
 	}
 
 	return ObjectStatus{
-		nodeStatus: component.NodeStatusOK,
+		NodeStatus: component.NodeStatusOK,
 		Details:    []component.Component{component.NewText("v1 PersistentVolume is OK")},
 	}, nil
 }

--- a/internal/objectstatus/pod.go
+++ b/internal/objectstatus/pod.go
@@ -21,7 +21,7 @@ import (
 	"github.com/vmware-tanzu/octant/pkg/view/component"
 )
 
-func pod(ctx context.Context, object runtime.Object, o store.Store, link link.Interface) (ObjectStatus, error) {
+func pod(_ context.Context, object runtime.Object, o store.Store, link link.Interface) (ObjectStatus, error) {
 	if object == nil {
 		return ObjectStatus{}, errors.Errorf("pod is nil")
 	}
@@ -36,19 +36,23 @@ func pod(ctx context.Context, object runtime.Object, o store.Store, link link.In
 
 	switch pod.Status.Phase {
 	case corev1.PodRunning:
-		status.nodeStatus = component.NodeStatusOK
+		status.NodeStatus = component.NodeStatusOK
+		status.Details = []component.Component{component.NewText("Pod is OK")}
 	case corev1.PodUnknown:
-		status.nodeStatus = component.NodeStatusError
+		status.NodeStatus = component.NodeStatusError
+		status.Details = []component.Component{component.NewText("Pod is unhealthy")}
 	default:
-		status.nodeStatus = component.NodeStatusWarning
+		status.NodeStatus = component.NodeStatusWarning
+		status.Details = []component.Component{component.NewText("Pod may require additional action")}
 	}
 
-	status.Details = []component.Component{
-		component.NewText(pod.Status.Message),
+	if pod.Status.Message != "" {
+		status.Details = []component.Component{
+			component.NewText(pod.Status.Message),
+		}
 	}
-
 	if len(pod.Spec.EphemeralContainers) > 0 {
-		status.nodeStatus = component.NodeStatusWarning
+		status.NodeStatus = component.NodeStatusWarning
 		status.Details = append(status.Details, component.NewText("Ephemeral container is running"))
 	}
 

--- a/internal/objectstatus/pod_test.go
+++ b/internal/objectstatus/pod_test.go
@@ -36,9 +36,9 @@ func Test_pod(t *testing.T) {
 				return testutil.LoadObjectFromFile(t, objectFile)
 			},
 			expected: ObjectStatus{
-				nodeStatus: component.NodeStatusOK,
+				NodeStatus: component.NodeStatusOK,
 				Details: []component.Component{
-					component.NewText(""),
+					component.NewText("Pod is OK"),
 				},
 				Properties: []component.Property{{Label: "ServiceAccount", Value: component.NewLink("", "ServiceAccount", "some-url/service-account")},
 					{Label: "Node", Value: component.NewLink("", "Node", "some-url/node")},
@@ -52,9 +52,9 @@ func Test_pod(t *testing.T) {
 				return testutil.LoadObjectFromFile(t, objectFile)
 			},
 			expected: ObjectStatus{
-				nodeStatus: component.NodeStatusError,
+				NodeStatus: component.NodeStatusError,
 				Details: []component.Component{
-					component.NewText(""),
+					component.NewText("Pod is unhealthy"),
 				},
 				Properties: []component.Property{{Label: "ServiceAccount", Value: component.NewLink("", "ServiceAccount", "some-url/service-account")},
 					{Label: "Node", Value: component.NewLink("", "Node", "some-url/node")},
@@ -68,9 +68,9 @@ func Test_pod(t *testing.T) {
 				return testutil.LoadObjectFromFile(t, objectFile)
 			},
 			expected: ObjectStatus{
-				nodeStatus: component.NodeStatusWarning,
+				NodeStatus: component.NodeStatusWarning,
 				Details: []component.Component{
-					component.NewText(""),
+					component.NewText("Pod may require additional action"),
 				},
 				Properties: []component.Property{{Label: "ServiceAccount", Value: component.NewLink("", "ServiceAccount", "some-url/service-account")},
 					{Label: "Node", Value: component.NewLink("", "Node", "some-url/node")},
@@ -98,9 +98,9 @@ func Test_pod(t *testing.T) {
 				return testutil.LoadObjectFromFile(t, objectFile)
 			},
 			expected: ObjectStatus{
-				nodeStatus: component.NodeStatusWarning,
+				NodeStatus: component.NodeStatusWarning,
 				Details: []component.Component{
-					component.NewText(""),
+					component.NewText("Pod is OK"),
 					component.NewText("Ephemeral container is running"),
 				},
 				Properties: []component.Property{{Label: "ServiceAccount", Value: component.NewLink("", "ServiceAccount", "some-url/service-account")},

--- a/internal/objectstatus/replicaset.go
+++ b/internal/objectstatus/replicaset.go
@@ -47,18 +47,18 @@ func replicaSetAppsV1(_ context.Context, object runtime.Object, _ store.Store, _
 	switch {
 	case status.Replicas == 0 && specReplicas != 0:
 		return ObjectStatus{
-			nodeStatus: component.NodeStatusError,
+			NodeStatus: component.NodeStatusError,
 			Details:    []component.Component{component.NewText("Replica Set has no replicas available")},
 			Properties: properties,
 		}, nil
 	case status.Replicas == status.AvailableReplicas:
-		return ObjectStatus{nodeStatus: component.NodeStatusOK,
+		return ObjectStatus{NodeStatus: component.NodeStatusOK,
 			Details:    []component.Component{component.NewText("Replica Set is OK")},
 			Properties: properties,
 		}, nil
 	default:
 		return ObjectStatus{
-			nodeStatus: component.NodeStatusWarning,
+			NodeStatus: component.NodeStatusWarning,
 			Details:    []component.Component{component.NewText(fmt.Sprintf("Expected %d replicas, but %d are available", status.Replicas, status.AvailableReplicas))},
 			Properties: properties,
 		}, nil

--- a/internal/objectstatus/replicaset_test.go
+++ b/internal/objectstatus/replicaset_test.go
@@ -37,7 +37,7 @@ func Test_replicaSetAppsV1(t *testing.T) {
 
 			},
 			expected: ObjectStatus{
-				nodeStatus: component.NodeStatusOK,
+				NodeStatus: component.NodeStatusOK,
 				Details:    []component.Component{component.NewText("Replica Set is OK")},
 				Properties: []component.Property{{Label: "Current Replicas", Value: component.NewText("1")},
 					{Label: "Desired Replicas", Value: component.NewText("1")}},
@@ -51,7 +51,7 @@ func Test_replicaSetAppsV1(t *testing.T) {
 
 			},
 			expected: ObjectStatus{
-				nodeStatus: component.NodeStatusError,
+				NodeStatus: component.NodeStatusError,
 				Details:    []component.Component{component.NewText("Replica Set has no replicas available")},
 				Properties: []component.Property{{Label: "Current Replicas", Value: component.NewText("1")},
 					{Label: "Desired Replicas", Value: component.NewText("1")}},
@@ -65,7 +65,7 @@ func Test_replicaSetAppsV1(t *testing.T) {
 
 			},
 			expected: ObjectStatus{
-				nodeStatus: component.NodeStatusOK,
+				NodeStatus: component.NodeStatusOK,
 				Details:    []component.Component{component.NewText("Replica Set is OK")},
 				Properties: []component.Property{{Label: "Current Replicas", Value: component.NewText("0")},
 					{Label: "Desired Replicas", Value: component.NewText("0")}},
@@ -79,7 +79,7 @@ func Test_replicaSetAppsV1(t *testing.T) {
 
 			},
 			expected: ObjectStatus{
-				nodeStatus: component.NodeStatusWarning,
+				NodeStatus: component.NodeStatusWarning,
 				Details:    []component.Component{component.NewText("Expected 1 replicas, but 0 are available")},
 				Properties: []component.Property{{Label: "Current Replicas", Value: component.NewText("1")},
 					{Label: "Desired Replicas", Value: component.NewText("1")}},

--- a/internal/objectstatus/replicationcontroller.go
+++ b/internal/objectstatus/replicationcontroller.go
@@ -35,12 +35,12 @@ func replicationController(_ context.Context, object runtime.Object, _ store.Sto
 	switch {
 	case status.ReadyReplicas != status.Replicas:
 		return ObjectStatus{
-			nodeStatus: component.NodeStatusWarning,
+			NodeStatus: component.NodeStatusWarning,
 			Details:    []component.Component{component.NewText("Replication Controller pods are not ready")},
 		}, nil
 	default:
 		return ObjectStatus{
-			nodeStatus: component.NodeStatusOK,
+			NodeStatus: component.NodeStatusOK,
 			Details:    []component.Component{component.NewText("Replication Controller is OK")},
 		}, nil
 	}

--- a/internal/objectstatus/replicationcontroller_test.go
+++ b/internal/objectstatus/replicationcontroller_test.go
@@ -37,7 +37,7 @@ func Test_replicationController(t *testing.T) {
 
 			},
 			expected: ObjectStatus{
-				nodeStatus: component.NodeStatusOK,
+				NodeStatus: component.NodeStatusOK,
 				Details:    []component.Component{component.NewText("Replication Controller is OK")},
 			},
 		},
@@ -49,7 +49,7 @@ func Test_replicationController(t *testing.T) {
 
 			},
 			expected: ObjectStatus{
-				nodeStatus: component.NodeStatusWarning,
+				NodeStatus: component.NodeStatusWarning,
 				Details:    []component.Component{component.NewText("Replication Controller pods are not ready")},
 			},
 		},

--- a/internal/objectstatus/service.go
+++ b/internal/objectstatus/service.go
@@ -47,7 +47,7 @@ func service(ctx context.Context, object runtime.Object, o store.Store, _ link.I
 
 		if !found {
 			return ObjectStatus{
-				nodeStatus: component.NodeStatusWarning,
+				NodeStatus: component.NodeStatusWarning,
 				Details:    []component.Component{component.NewText("Service has no endpoints")},
 			}, nil
 		}
@@ -60,7 +60,7 @@ func service(ctx context.Context, object runtime.Object, o store.Store, _ link.I
 
 		if addressCount == 0 {
 			return ObjectStatus{
-				nodeStatus: component.NodeStatusWarning,
+				NodeStatus: component.NodeStatusWarning,
 				Details:    []component.Component{component.NewText("Service has no endpoint addresses")},
 			}, nil
 		}
@@ -69,7 +69,7 @@ func service(ctx context.Context, object runtime.Object, o store.Store, _ link.I
 		{Label: "Session Affinity", Value: component.NewText(string(service.Spec.SessionAffinity))}}
 
 	return ObjectStatus{
-		nodeStatus: component.NodeStatusOK,
+		NodeStatus: component.NodeStatusOK,
 		Details:    []component.Component{component.NewText("Service is OK")},
 		Properties: properties,
 	}, nil

--- a/internal/objectstatus/service_test.go
+++ b/internal/objectstatus/service_test.go
@@ -50,7 +50,7 @@ func Test_service(t *testing.T) {
 
 			},
 			expected: ObjectStatus{
-				nodeStatus: component.NodeStatusOK,
+				NodeStatus: component.NodeStatusOK,
 				Details:    []component.Component{component.NewText("Service is OK")},
 				Properties: []component.Property{{Label: "Type", Value: component.NewText("ClusterIP")},
 					{Label: "Session Affinity", Value: component.NewText("None")}},
@@ -63,7 +63,7 @@ func Test_service(t *testing.T) {
 				return testutil.LoadObjectFromFile(t, objectFile)
 			},
 			expected: ObjectStatus{
-				nodeStatus: component.NodeStatusOK,
+				NodeStatus: component.NodeStatusOK,
 				Details:    []component.Component{component.NewText("Service is OK")},
 				Properties: []component.Property{{Label: "Type", Value: component.NewText("ExternalName")},
 					{Label: "Session Affinity", Value: component.NewText("")}},
@@ -89,7 +89,7 @@ func Test_service(t *testing.T) {
 
 			},
 			expected: ObjectStatus{
-				nodeStatus: component.NodeStatusWarning,
+				NodeStatus: component.NodeStatusWarning,
 				Details:    []component.Component{component.NewText("Service has no endpoint addresses")},
 			},
 		},

--- a/internal/objectstatus/statefulset.go
+++ b/internal/objectstatus/statefulset.go
@@ -41,13 +41,13 @@ func statefulSet(_ context.Context, object runtime.Object, _ store.Store, _ link
 	switch {
 	case status.ReadyReplicas != status.Replicas:
 		return ObjectStatus{
-			nodeStatus: component.NodeStatusWarning,
+			NodeStatus: component.NodeStatusWarning,
 			Details:    []component.Component{component.NewText("Stateful Set pods are not ready")},
 			Properties: properties,
 		}, nil
 	default:
 		return ObjectStatus{
-			nodeStatus: component.NodeStatusOK,
+			NodeStatus: component.NodeStatusOK,
 			Details:    []component.Component{component.NewText("Stateful Set is OK")},
 			Properties: properties,
 		}, nil

--- a/internal/objectstatus/statefulset_test.go
+++ b/internal/objectstatus/statefulset_test.go
@@ -37,7 +37,7 @@ func Test_statefulSet(t *testing.T) {
 
 			},
 			expected: ObjectStatus{
-				nodeStatus: component.NodeStatusOK,
+				NodeStatus: component.NodeStatusOK,
 				Details:    []component.Component{component.NewText("Stateful Set is OK")},
 				Properties: []component.Property{{Label: "Replicas", Value: component.NewText("3 Desired / 3 Total")},
 					{Label: "Pod Management Policy", Value: component.NewText("OrderedReady")}},
@@ -51,7 +51,7 @@ func Test_statefulSet(t *testing.T) {
 
 			},
 			expected: ObjectStatus{
-				nodeStatus: component.NodeStatusWarning,
+				NodeStatus: component.NodeStatusWarning,
 				Details:    []component.Component{component.NewText("Stateful Set pods are not ready")},
 				Properties: []component.Property{{Label: "Replicas", Value: component.NewText("3 Desired / 3 Total")},
 					{Label: "Pod Management Policy", Value: component.NewText("OrderedReady")}},

--- a/internal/octant/workload.go
+++ b/internal/octant/workload.go
@@ -105,7 +105,7 @@ func (w *Workload) Pods() *unstructured.UnstructuredList {
 	return list
 }
 
-// AddStatus adds a pod status to the workload.
+// AddPodStatus adds a pod status to the workload.
 func (w *Workload) AddPodStatus(status component.NodeStatus, object *unstructured.Unstructured, resourceList corev1.ResourceList) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
@@ -327,7 +327,7 @@ type ClusterWorkloadLoader struct {
 	PodMetricsLoader PodMetricsLoader
 }
 
-// NewWorkloadLoader creates an instance of ClusterWorkloadLoader.
+// NewClusterWorkloadLoader creates an instance of ClusterWorkloadLoader.
 func NewClusterWorkloadLoader(objectStore store.Store, pml PodMetricsLoader, options ...ClusterWorkloadLoaderOption) (*ClusterWorkloadLoader, error) {
 	wl := &ClusterWorkloadLoader{
 		ObjectStatuser:   objectstatus.Status,

--- a/internal/printer/apiservice.go
+++ b/internal/printer/apiservice.go
@@ -25,6 +25,7 @@ func APIServiceListHandler(ctx context.Context, list *apiregistrationv1.APIServi
 
 	cols := component.NewTableCols("Name", "Service", "Age")
 	ot := NewObjectTable("API Services", "We couldn't find any api services!", cols, options.DashConfig.ObjectStore())
+	ot.EnablePluginStatus(options.DashConfig.PluginManager())
 
 	for _, apiService := range list.Items {
 		row := component.TableRow{}

--- a/internal/printer/apiservice_test.go
+++ b/internal/printer/apiservice_test.go
@@ -42,6 +42,8 @@ func Test_APIServiceListHandler(t *testing.T) {
 	now := testutil.Time()
 
 	ctx := context.Background()
+	tpo.pluginManager.EXPECT().ObjectStatus(ctx, object)
+
 	got, err := APIServiceListHandler(ctx, list, printOptions)
 	require.NoError(t, err)
 
@@ -82,6 +84,8 @@ func Test_APIServiceListHandler_local(t *testing.T) {
 	now := testutil.Time()
 
 	ctx := context.Background()
+	tpo.pluginManager.EXPECT().ObjectStatus(ctx, object)
+
 	got, err := APIServiceListHandler(ctx, list, printOptions)
 	require.NoError(t, err)
 

--- a/internal/printer/clusterrole.go
+++ b/internal/printer/clusterrole.go
@@ -25,7 +25,7 @@ func ClusterRoleListHandler(ctx context.Context, list *rbacv1.ClusterRoleList, o
 
 	cols := component.NewTableCols("Name", "Age")
 	ot := NewObjectTable("Cluster Roles", "We couldn't find any cluster roles!", cols, options.DashConfig.ObjectStore())
-
+	ot.EnablePluginStatus(options.DashConfig.PluginManager())
 	for _, clusterRole := range list.Items {
 		row := component.TableRow{}
 		nameLink, err := options.Link.ForObject(&clusterRole, clusterRole.Name)

--- a/internal/printer/clusterrole_test.go
+++ b/internal/printer/clusterrole_test.go
@@ -37,6 +37,7 @@ func Test_ClusterRoleListHandler(t *testing.T) {
 	now := testutil.Time()
 
 	ctx := context.Background()
+	tpo.pluginManager.EXPECT().ObjectStatus(ctx, object)
 	got, err := ClusterRoleListHandler(ctx, list, printOptions)
 	require.NoError(t, err)
 

--- a/internal/printer/clusterrolebinding.go
+++ b/internal/printer/clusterrolebinding.go
@@ -23,7 +23,7 @@ func ClusterRoleBindingListHandler(ctx context.Context, clusterRoleBindingList *
 
 	columns := component.NewTableCols("Name", "Labels", "Age", "Role kind", "Role name")
 	ot := NewObjectTable("Cluster Role Bindings", "We couldn't find any cluster role bindings!", columns, options.DashConfig.ObjectStore())
-
+	ot.EnablePluginStatus(options.DashConfig.PluginManager())
 	for _, roleBinding := range clusterRoleBindingList.Items {
 		row := component.TableRow{}
 

--- a/internal/printer/clusterrolebinding_test.go
+++ b/internal/printer/clusterrolebinding_test.go
@@ -47,6 +47,7 @@ func Test_ClusterRoleBindingListHandler(t *testing.T) {
 	tpo.PathForGVK("", "rbac.authorization.k8s.io/v1", "Role", "role-name", "role-name", "/cluster-role-path")
 
 	ctx := context.Background()
+	tpo.pluginManager.EXPECT().ObjectStatus(ctx, clusterRoleBinding)
 	observed, err := ClusterRoleBindingListHandler(ctx, roleBindingList, printOptions)
 	require.NoError(t, err)
 

--- a/internal/printer/configmap.go
+++ b/internal/printer/configmap.go
@@ -27,7 +27,7 @@ func ConfigMapListHandler(ctx context.Context, list *corev1.ConfigMapList, opts 
 	// Data column
 	cols := component.NewTableCols("Name", "Labels", "Data", "Age")
 	ot := NewObjectTable("ConfigMaps", "We couldn't find any config maps!", cols, opts.DashConfig.ObjectStore())
-
+	ot.EnablePluginStatus(opts.DashConfig.PluginManager())
 	for _, c := range list.Items {
 		row := component.TableRow{}
 

--- a/internal/printer/configmap_test.go
+++ b/internal/printer/configmap_test.go
@@ -46,6 +46,7 @@ func Test_ConfigMapListHandler(t *testing.T) {
 	}
 
 	ctx := context.Background()
+	tpo.pluginManager.EXPECT().ObjectStatus(ctx, configMap)
 	got, err := ConfigMapListHandler(ctx, object, printOptions)
 	require.NoError(t, err)
 

--- a/internal/printer/cronjob.go
+++ b/internal/printer/cronjob.go
@@ -29,7 +29,7 @@ func CronJobListHandler(ctx context.Context, list *batchv1beta1.CronJobList, opt
 
 	cols := component.NewTableCols("Name", "Labels", "Schedule", "Age")
 	ot := NewObjectTable("CronJobs", "We couldn't find any cron jobs!", cols, opts.DashConfig.ObjectStore())
-
+	ot.EnablePluginStatus(opts.DashConfig.PluginManager())
 	for _, c := range list.Items {
 		row := component.TableRow{}
 

--- a/internal/printer/cronjob_test.go
+++ b/internal/printer/cronjob_test.go
@@ -65,6 +65,7 @@ func Test_CronJobListHandler(t *testing.T) {
 	}
 
 	ctx := context.Background()
+	tpo.pluginManager.EXPECT().ObjectStatus(ctx, cronJob)
 	got, err := CronJobListHandler(ctx, object, printOptions)
 	require.NoError(t, err)
 
@@ -229,6 +230,7 @@ func Test_createJobListView(t *testing.T) {
 	}
 
 	tpo.PathForObject(job, job.Name, "/job")
+	tpo.pluginManager.EXPECT().ObjectStatus(ctx, job)
 
 	jobList := &unstructured.UnstructuredList{}
 	for _, j := range jobs.Items {

--- a/internal/printer/customresourcedefinition.go
+++ b/internal/printer/customresourcedefinition.go
@@ -41,7 +41,7 @@ func CustomResourceDefinitionListHandler(
 		"We couldn't find any custom resource definitions!",
 		cols,
 		opts.DashConfig.ObjectStore())
-
+	ot.EnablePluginStatus(opts.DashConfig.PluginManager())
 	for _, crd := range list.Items {
 		row := component.TableRow{}
 

--- a/internal/printer/daemonset.go
+++ b/internal/printer/daemonset.go
@@ -25,7 +25,7 @@ func DaemonSetListHandler(ctx context.Context, list *appsv1.DaemonSetList, opts 
 	cols := component.NewTableCols("Name", "Labels", "Desired", "Current", "Ready",
 		"Up-To-Date", "Age", "Node Selector")
 	ot := NewObjectTable("Daemon Sets", "We couldn't find any daemon sets!", cols, opts.DashConfig.ObjectStore())
-
+	ot.EnablePluginStatus(opts.DashConfig.PluginManager())
 	for _, daemonSet := range list.Items {
 		row := component.TableRow{}
 		nameLink, err := opts.Link.ForObject(&daemonSet, daemonSet.Name)

--- a/internal/printer/daemonset_test.go
+++ b/internal/printer/daemonset_test.go
@@ -46,6 +46,7 @@ func Test_DaemonSetListHandler(t *testing.T) {
 	}
 
 	ctx := context.Background()
+	tpo.pluginManager.EXPECT().ObjectStatus(ctx, object)
 	got, err := DaemonSetListHandler(ctx, list, printOptions)
 	require.NoError(t, err)
 
@@ -169,7 +170,6 @@ func Test_DaemonSetPods(t *testing.T) {
 	tpo.link.EXPECT().
 		ForGVK("", "v1", "Node", "node", "node").
 		Return(nodeLink, nil).AnyTimes()
-
 	daemonSet := testutil.CreateDaemonSet("daemonset")
 
 	pod := testutil.CreatePod("fluentd-elasticsearch-dvskv")
@@ -193,6 +193,7 @@ func Test_DaemonSetPods(t *testing.T) {
 			},
 		},
 	}
+	tpo.pluginManager.EXPECT().ObjectStatus(ctx, pod)
 
 	pods := &corev1.PodList{
 		Items: []corev1.Pod{*pod},
@@ -222,7 +223,7 @@ func Test_DaemonSetPods(t *testing.T) {
 	expected := component.NewTable("Pods", "We couldn't find any pods!", cols)
 	expected.Add(component.TableRow{
 		"Name": component.NewLink("", "fluentd-elasticsearch-dvskv", "/pod",
-			genObjectStatus(component.TextStatusWarning, []string{""})),
+			genObjectStatus(component.TextStatusWarning, []string{"Pod may require additional action"})),
 		"Ready":    component.NewText("0/1"),
 		"Phase":    component.NewText("Pending"),
 		"Restarts": component.NewText("0"),

--- a/internal/printer/deployment.go
+++ b/internal/printer/deployment.go
@@ -33,7 +33,7 @@ func DeploymentListHandler(ctx context.Context, list *appsv1.DeploymentList, opt
 
 	cols := component.NewTableCols("Name", "Labels", "Status", "Age", "Containers", "Selector")
 	ot := NewObjectTable("Deployments", "We couldn't find any deployments!", cols, opts.DashConfig.ObjectStore())
-
+	ot.EnablePluginStatus(opts.DashConfig.PluginManager())
 	for _, d := range list.Items {
 		row := component.TableRow{}
 		nameLink, err := opts.Link.ForObject(&d, d.Name)

--- a/internal/printer/deployment_test.go
+++ b/internal/printer/deployment_test.go
@@ -90,6 +90,7 @@ func Test_DeploymentListHandler(t *testing.T) {
 	}
 
 	ctx := context.Background()
+	tpo.pluginManager.EXPECT().ObjectStatus(ctx, object)
 	got, err := DeploymentListHandler(ctx, list, printOptions)
 	require.NoError(t, err)
 
@@ -334,6 +335,7 @@ func Test_DeploymentPods(t *testing.T) {
 		Return(testutil.ToUnstructuredList(t, pod), false, nil)
 
 	ctx := context.Background()
+	tpo.pluginManager.EXPECT().ObjectStatus(ctx, pod)
 
 	replicaSets, err := listReplicaSetsAsObjects(ctx, deployment, printOptions)
 	require.NoError(t, err)
@@ -344,7 +346,7 @@ func Test_DeploymentPods(t *testing.T) {
 	expected := component.NewTableWithRows("Pods", "We couldn't find any pods!", podColsWithOutLabels, []component.TableRow{
 		{
 			"Name": component.NewLink("", pod.Name, "/pod",
-				genObjectStatus(component.TextStatusOK, []string{""})),
+				genObjectStatus(component.TextStatusOK, []string{"Pod is OK"})),
 			"Age":      component.NewTimestamp(now),
 			"Ready":    component.NewText("1/1"),
 			"Restarts": component.NewText("0"),

--- a/internal/printer/horizontalpodautoscaler.go
+++ b/internal/printer/horizontalpodautoscaler.go
@@ -32,7 +32,7 @@ func HorizontalPodAutoscalerListHandler(ctx context.Context, list *autoscalingv1
 	cols := component.NewTableCols("Name", "Labels", "Targets", "Minimum Pods", "Maximum Pods", "Replicas", "Age")
 	ot := NewObjectTable("Horizontal Pod Autoscalers",
 		"We couldn't find any horizontal pod autoscalers", cols, options.DashConfig.ObjectStore())
-
+	ot.EnablePluginStatus(options.DashConfig.PluginManager())
 	for _, horizontalPodAutoscaler := range list.Items {
 		row := component.TableRow{}
 		nameLink, err := options.Link.ForObject(&horizontalPodAutoscaler, horizontalPodAutoscaler.Name)

--- a/internal/printer/horizontalpodautoscaler_test.go
+++ b/internal/printer/horizontalpodautoscaler_test.go
@@ -73,6 +73,7 @@ func Test_HorizontalPodAutoscalerListHandler(t *testing.T) {
 	}
 
 	ctx := context.Background()
+	tpo.pluginManager.EXPECT().ObjectStatus(ctx, object)
 	got, err := HorizontalPodAutoscalerListHandler(ctx, list, printOptions)
 	require.NoError(t, err)
 

--- a/internal/printer/ingress.go
+++ b/internal/printer/ingress.go
@@ -27,7 +27,7 @@ func IngressListHandler(ctx context.Context, list *networkingv1.IngressList, opt
 
 	cols := component.NewTableCols("Name", "Labels", "Hosts", "Address", "Ports", "Age")
 	ot := NewObjectTable("Ingresses", "We couldn't find any ingresses!", cols, options.DashConfig.ObjectStore())
-
+	ot.EnablePluginStatus(options.DashConfig.PluginManager())
 	for _, ingress := range list.Items {
 		ports := "80"
 		if len(ingress.Spec.TLS) > 0 {

--- a/internal/printer/ingress_test.go
+++ b/internal/printer/ingress_test.go
@@ -240,12 +240,14 @@ func Test_IngressListHandler(t *testing.T) {
 			controller := gomock.NewController(t)
 			defer controller.Finish()
 
+			ctx := context.Background()
+
 			tpo := newTestPrinterOptions(controller)
 			printOptions := tpo.ToOptions()
 
 			if tc.list != nil {
 				tpo.PathForObject(&tc.list.Items[0], tc.list.Items[0].Name, "/ingress")
-
+				tpo.pluginManager.EXPECT().ObjectStatus(ctx, &tc.list.Items[0])
 			}
 
 			tpo.objectStore.EXPECT().
@@ -265,7 +267,6 @@ func Test_IngressListHandler(t *testing.T) {
 				Return(secret, nil).
 				AnyTimes()
 
-			ctx := context.Background()
 			got, err := IngressListHandler(ctx, tc.list, printOptions)
 			if tc.isErr {
 				require.Error(t, err)

--- a/internal/printer/job.go
+++ b/internal/printer/job.go
@@ -31,7 +31,7 @@ func JobListHandler(ctx context.Context, list *batchv1.JobList, opts Options) (c
 	}
 
 	ot := NewObjectTable("Jobs", "We couldn't find any jobs!", JobCols, opts.DashConfig.ObjectStore())
-
+	ot.EnablePluginStatus(opts.DashConfig.PluginManager())
 	for _, job := range list.Items {
 		row := component.TableRow{}
 		nameLink, err := opts.Link.ForObject(&job, job.Name)

--- a/internal/printer/job_test.go
+++ b/internal/printer/job_test.go
@@ -59,6 +59,7 @@ func Test_JobListHandler(t *testing.T) {
 	tpo.PathForObject(validJob, validJob.Name, "/job")
 
 	ctx := context.Background()
+	tpo.pluginManager.EXPECT().ObjectStatus(ctx, validJob)
 	got, err := JobListHandler(ctx, validJobList, printOptions)
 	require.NoError(t, err)
 

--- a/internal/printer/mutatingwebhookconfiguration.go
+++ b/internal/printer/mutatingwebhookconfiguration.go
@@ -24,7 +24,7 @@ func MutatingWebhookConfigurationListHandler(ctx context.Context, list *admissio
 
 	cols := component.NewTableCols("Name", "Age")
 	ot := NewObjectTable("Mutating Webhook Configurations", "We couldn't find any mutating webhook configurations!", cols, options.DashConfig.ObjectStore())
-
+	ot.EnablePluginStatus(options.DashConfig.PluginManager())
 	for _, mutatingWebhookConfiguration := range list.Items {
 		row := component.TableRow{}
 		nameLink, err := options.Link.ForObject(&mutatingWebhookConfiguration, mutatingWebhookConfiguration.Name)

--- a/internal/printer/mutatingwebhookconfiguration_test.go
+++ b/internal/printer/mutatingwebhookconfiguration_test.go
@@ -38,6 +38,7 @@ func Test_MutatingWebhookConfigurationListHandler(t *testing.T) {
 	now := testutil.Time()
 
 	ctx := context.Background()
+	tpo.pluginManager.EXPECT().ObjectStatus(ctx, object)
 	got, err := MutatingWebhookConfigurationListHandler(ctx, list, printOptions)
 	require.NoError(t, err)
 

--- a/internal/printer/namespace.go
+++ b/internal/printer/namespace.go
@@ -31,7 +31,7 @@ func NamespaceListHandler(ctx context.Context, list *corev1.NamespaceList, optio
 	}
 
 	ot := NewObjectTable("Namespaces", "We couldn't find any namespaces!", namespaceListCols, options.DashConfig.ObjectStore())
-
+	ot.EnablePluginStatus(options.DashConfig.PluginManager())
 	for _, namespace := range list.Items {
 		row := component.TableRow{}
 		p := path.Join("/cluster-overview/namespaces", namespace.Name)
@@ -39,6 +39,7 @@ func NamespaceListHandler(ctx context.Context, list *corev1.NamespaceList, optio
 		row["Labels"] = component.NewLabels(namespace.Labels)
 		row["Status"] = component.NewText(string(namespace.Status.Phase))
 		row["Age"] = component.NewTimestamp(namespace.CreationTimestamp.Time)
+
 		if err := ot.AddRowForObject(ctx, &namespace, row); err != nil {
 			return nil, fmt.Errorf("add row for object: %w", err)
 		}

--- a/internal/printer/namespace_test.go
+++ b/internal/printer/namespace_test.go
@@ -39,6 +39,7 @@ func Test_NamespaceListHandler(t *testing.T) {
 	}
 
 	ctx := context.Background()
+	tpo.pluginManager.EXPECT().ObjectStatus(ctx, namespace)
 	got, err := NamespaceListHandler(ctx, list, printOptions)
 	require.NoError(t, err)
 

--- a/internal/printer/networkpolicy.go
+++ b/internal/printer/networkpolicy.go
@@ -32,7 +32,7 @@ func NetworkPolicyListHandler(ctx context.Context, list *networkingv1.NetworkPol
 
 	cols := component.NewTableCols("Name", "Labels", "Age")
 	ot := NewObjectTable("Network Policies", "We couldn't find any network policies!", cols, options.DashConfig.ObjectStore())
-
+	ot.EnablePluginStatus(options.DashConfig.PluginManager())
 	for _, networkPolicy := range list.Items {
 		row := component.TableRow{}
 		nameLink, err := options.Link.ForObject(&networkPolicy, networkPolicy.Name)

--- a/internal/printer/networkpolicy_test.go
+++ b/internal/printer/networkpolicy_test.go
@@ -76,6 +76,7 @@ func Test_NetworkPolicyListHandler(t *testing.T) {
 
 			if tc.list != nil {
 				tpo.PathForObject(&tc.list.Items[0], tc.list.Items[0].Name, "/networkPolicy")
+				tpo.pluginManager.EXPECT().ObjectStatus(ctx, object)
 			}
 
 			got, err := NetworkPolicyListHandler(ctx, tc.list, printOptions)

--- a/internal/printer/persistentvolume.go
+++ b/internal/printer/persistentvolume.go
@@ -23,7 +23,7 @@ func PersistentVolumeListHandler(ctx context.Context, list *corev1.PersistentVol
 
 	cols := component.NewTableCols("Name", "Capacity", "Access Modes", "Reclaim Policy", "Status", "Claim", "Storage Class", "Reason", "Age")
 	ot := NewObjectTable("Persistent Volumes", "We couldn't find any persistent volumes!", cols, options.DashConfig.ObjectStore())
-
+	ot.EnablePluginStatus(options.DashConfig.PluginManager())
 	for _, pv := range list.Items {
 		row := component.TableRow{}
 		nameLink, err := options.Link.ForObject(&pv, pv.Name)

--- a/internal/printer/persistentvolume_test.go
+++ b/internal/printer/persistentvolume_test.go
@@ -128,6 +128,7 @@ func Test_PersistentVolumeListHandler(t *testing.T) {
 
 				claimText := fmt.Sprintf("%s/%s", pvcObject.Namespace, pvcObject.Name)
 				tpo.PathForGVK(pvcObject.Namespace, pvcObject.APIVersion, pvcObject.Kind, pvcObject.Name, claimText, "/pvc")
+				tpo.pluginManager.EXPECT().ObjectStatus(ctx, &tc.list.Items[0])
 			}
 			got, err := PersistentVolumeListHandler(ctx, tc.list, printOptions)
 			if tc.isErr {

--- a/internal/printer/persistentvolumeclaim.go
+++ b/internal/printer/persistentvolumeclaim.go
@@ -28,7 +28,7 @@ func PersistentVolumeClaimListHandler(ctx context.Context, list *corev1.Persiste
 	cols := component.NewTableCols("Name", "Status", "Volume", "Capacity", "Access Modes", "Storage Class", "Age")
 	ot := NewObjectTable("Persistent Volume Claims",
 		"We couldn't find any persistent volume claims!", cols, options.DashConfig.ObjectStore())
-
+	ot.EnablePluginStatus(options.DashConfig.PluginManager())
 	for _, persistentVolumeClaim := range list.Items {
 		row := component.TableRow{}
 

--- a/internal/printer/persistentvolumeclaim_test.go
+++ b/internal/printer/persistentvolumeclaim_test.go
@@ -104,6 +104,7 @@ func Test_PersistentVolumeClaimListHandler(t *testing.T) {
 			table := component.NewTable("Persistent Volume Claims", "We couldn't find any persistent volume claims!", cols)
 
 			tpo.PathForObject(object, object.Name, "/pvc")
+			tpo.pluginManager.EXPECT().ObjectStatus(ctx, object)
 
 			if tc.persistentvolume != nil {
 				tpo.PathForObject(tc.persistentvolume, tc.persistentvolume.GetName(), fmt.Sprintf("/%s", tc.persistentvolume.GetName()))
@@ -297,6 +298,7 @@ func Test_PersistentVolumeClaimMountedPodsList(t *testing.T) {
 	}
 
 	tpo.PathForObject(pod, pod.Name, "/pod")
+	tpo.pluginManager.EXPECT().ObjectStatus(ctx, pod)
 
 	podList := &unstructured.UnstructuredList{}
 	for _, p := range pods.Items {
@@ -320,7 +322,7 @@ func Test_PersistentVolumeClaimMountedPodsList(t *testing.T) {
 	expected := component.NewTable("Pods", "We couldn't find any pods!", cols)
 	expected.Add(component.TableRow{
 		"Name": component.NewLink("", "wordpress-mysql-67565bd57-8fzbh", "/pod",
-			genObjectStatus(component.TextStatusOK, []string{""})),
+			genObjectStatus(component.TextStatusOK, []string{"Pod is OK"})),
 
 		"Ready":    component.NewText("1/1"),
 		"Phase":    component.NewText("Running"),

--- a/internal/printer/pod.go
+++ b/internal/printer/pod.go
@@ -44,6 +44,7 @@ func PodListHandler(ctx context.Context, list *corev1.PodList, opts Options) (co
 
 	ot := NewObjectTable("Pods", "We couldn't find any pods!", cols, opts.DashConfig.ObjectStore())
 	ot.AddFilters(podTableFilters())
+	ot.EnablePluginStatus(opts.DashConfig.PluginManager())
 
 	for i := range list.Items {
 		row := component.TableRow{}

--- a/internal/printer/pod_test.go
+++ b/internal/printer/pod_test.go
@@ -78,6 +78,7 @@ func Test_PodListHandler(t *testing.T) {
 	tpo.PathForObject(pod, pod.Name, "/pod")
 
 	ctx := context.Background()
+	tpo.pluginManager.EXPECT().ObjectStatus(ctx, pod)
 	got, err := PodListHandler(ctx, object, printOptions)
 	require.NoError(t, err)
 
@@ -86,7 +87,7 @@ func Test_PodListHandler(t *testing.T) {
 	expected.Add(component.TableRow{
 		"Name": component.NewLink("", "pod", "/pod",
 			genObjectStatus(component.TextStatusWarning, []string{
-				"",
+				"Pod may require additional action",
 			})),
 		"Labels":   component.NewLabels(labels),
 		"Ready":    component.NewText("1/2"),
@@ -145,6 +146,7 @@ func Test_PodListHandlerNoLabel(t *testing.T) {
 	tpo.PathForObject(pod, pod.Name, "/pi-7xpxr")
 
 	ctx := context.Background()
+	tpo.pluginManager.EXPECT().ObjectStatus(ctx, pod)
 	got, err := PodListHandler(ctx, object, printOptions)
 	require.NoError(t, err)
 
@@ -152,7 +154,7 @@ func Test_PodListHandlerNoLabel(t *testing.T) {
 	expected := component.NewTable("Pods", "We couldn't find any pods!", cols)
 	expected.Add(component.TableRow{
 		"Name": component.NewLink("", "pi-7xpxr", "/pi-7xpxr",
-			genObjectStatus(component.TextStatusWarning, []string{""})),
+			genObjectStatus(component.TextStatusWarning, []string{"Pod may require additional action"})),
 		"Ready":    component.NewText("0/1"),
 		"Phase":    component.NewText("Succeeded"),
 		"Restarts": component.NewText("0"),
@@ -188,6 +190,9 @@ func TestPodListHandler_sorted(t *testing.T) {
 	tpo.PathForObject(pod2, pod2.Name, "/pod2")
 
 	ctx := context.Background()
+	tpo.pluginManager.EXPECT().ObjectStatus(ctx, pod1)
+	tpo.pluginManager.EXPECT().ObjectStatus(ctx, pod2)
+
 	got, err := PodListHandler(ctx, list, printOptions)
 	require.NoError(t, err)
 
@@ -195,7 +200,7 @@ func TestPodListHandler_sorted(t *testing.T) {
 	expected := component.NewTable("Pods", "We couldn't find any pods!", cols)
 	expected.Add(component.TableRow{
 		"Name": component.NewLink("", "pod1", "/pod1",
-			genObjectStatus(component.TextStatusWarning, []string{""})),
+			genObjectStatus(component.TextStatusWarning, []string{"Pod may require additional action"})),
 		"Labels":   component.NewLabels(make(map[string]string)),
 		"Ready":    component.NewText("0/0"),
 		"Phase":    component.NewText(""),
@@ -208,7 +213,7 @@ func TestPodListHandler_sorted(t *testing.T) {
 	})
 	expected.Add(component.TableRow{
 		"Name": component.NewLink("", "pod2", "/pod2",
-			genObjectStatus(component.TextStatusWarning, []string{""})),
+			genObjectStatus(component.TextStatusWarning, []string{"Pod may require additional action"})),
 		"Labels":   component.NewLabels(make(map[string]string)),
 		"Ready":    component.NewText("0/0"),
 		"Phase":    component.NewText(""),

--- a/internal/printer/replicaset.go
+++ b/internal/printer/replicaset.go
@@ -28,7 +28,7 @@ func ReplicaSetListHandler(ctx context.Context, list *appsv1.ReplicaSetList, opt
 
 	cols := component.NewTableCols("Name", "Labels", "Status", "Age", "Containers", "Selector")
 	ot := NewObjectTable("ReplicaSets", "We couldn't find any replica sets!", cols, opts.DashConfig.ObjectStore())
-
+	ot.EnablePluginStatus(opts.DashConfig.PluginManager())
 	for _, rs := range list.Items {
 		row := component.TableRow{}
 		nameLink, err := opts.Link.ForObject(&rs, rs.Name)

--- a/internal/printer/replicaset_test.go
+++ b/internal/printer/replicaset_test.go
@@ -83,6 +83,7 @@ func Test_ReplicaSetListHandler(t *testing.T) {
 	tpo.PathForObject(&object.Items[0], object.Items[0].Name, "/replica-set")
 
 	ctx := context.Background()
+	tpo.pluginManager.EXPECT().ObjectStatus(ctx, &object.Items[0])
 	got, err := ReplicaSetListHandler(ctx, object, printOptions)
 	require.NoError(t, err)
 
@@ -297,6 +298,7 @@ func Test_ReplicaSetPods(t *testing.T) {
 	}
 
 	tpo.PathForObject(pod, pod.Name, "/pod")
+	tpo.pluginManager.EXPECT().ObjectStatus(ctx, pod)
 
 	podList := &unstructured.UnstructuredList{}
 	for _, p := range pods.Items {
@@ -320,7 +322,7 @@ func Test_ReplicaSetPods(t *testing.T) {
 	expected := component.NewTable("Pods", "We couldn't find any pods!", cols)
 	expected.Add(component.TableRow{
 		"Name": component.NewLink("", "nginx-deployment-59478d9757-nfqbk", "/pod",
-			genObjectStatus(component.TextStatusWarning, []string{""})),
+			genObjectStatus(component.TextStatusWarning, []string{"Pod may require additional action"})),
 		"Ready":    component.NewText("0/1"),
 		"Phase":    component.NewText("Pending"),
 		"Restarts": component.NewText("0"),

--- a/internal/printer/replicationcontroller.go
+++ b/internal/printer/replicationcontroller.go
@@ -28,7 +28,7 @@ func ReplicationControllerListHandler(ctx context.Context, list *corev1.Replicat
 	cols := component.NewTableCols("Name", "Labels", "Status", "Age", "Containers", "Selector")
 	ot := NewObjectTable("ReplicationControllers",
 		"We couldn't find any replication controllers!", cols, options.DashConfig.ObjectStore())
-
+	ot.EnablePluginStatus(options.DashConfig.PluginManager())
 	for _, rc := range list.Items {
 		row := component.TableRow{}
 		nameLink, err := options.Link.ForObject(&rc, rc.Name)

--- a/internal/printer/replicationcontroller_test.go
+++ b/internal/printer/replicationcontroller_test.go
@@ -77,6 +77,7 @@ func Test_ReplicationControllerListHandler(t *testing.T) {
 	tpo.PathForObject(validReplicationController, validReplicationController.Name, "/rc")
 
 	ctx := context.Background()
+	tpo.pluginManager.EXPECT().ObjectStatus(ctx, validReplicationController)
 	got, err := ReplicationControllerListHandler(ctx, validReplicationControllerList, printOptions)
 	require.NoError(t, err)
 
@@ -270,6 +271,7 @@ func Test_ReplicationControllerPods(t *testing.T) {
 	}
 
 	tpo.PathForObject(pod, pod.Name, "/pod")
+	tpo.pluginManager.EXPECT().ObjectStatus(ctx, pod)
 
 	podList := &unstructured.UnstructuredList{}
 	for _, p := range pods.Items {
@@ -293,7 +295,7 @@ func Test_ReplicationControllerPods(t *testing.T) {
 	expected := component.NewTable("Pods", "We couldn't find any pods!", cols)
 	expected.Add(component.TableRow{
 		"Name": component.NewLink("", "nginx-hv4qs", "/pod",
-			genObjectStatus(component.TextStatusWarning, []string{""})),
+			genObjectStatus(component.TextStatusWarning, []string{"Pod may require additional action"})),
 		"Ready":    component.NewText("0/1"),
 		"Phase":    component.NewText("Pending"),
 		"Restarts": component.NewText("0"),

--- a/internal/printer/role.go
+++ b/internal/printer/role.go
@@ -24,7 +24,7 @@ func RoleListHandler(ctx context.Context, roleList *rbacv1.RoleList, options Opt
 
 	columns := component.NewTableCols("Name", "Age")
 	ot := NewObjectTable("Roles", "We couldn't find any roles!", columns, options.DashConfig.ObjectStore())
-
+	ot.EnablePluginStatus(options.DashConfig.PluginManager())
 	for _, role := range roleList.Items {
 		row := component.TableRow{}
 		nameLink, err := options.Link.ForObject(&role, role.Name)

--- a/internal/printer/role_test.go
+++ b/internal/printer/role_test.go
@@ -38,6 +38,7 @@ func Test_RoleListHandler(t *testing.T) {
 	tpo.PathForObject(role, role.Name, "/role")
 
 	ctx := context.Background()
+	tpo.pluginManager.EXPECT().ObjectStatus(ctx, role)
 	observed, err := RoleListHandler(ctx, roleList, printOptions)
 	require.NoError(t, err)
 

--- a/internal/printer/rolebinding.go
+++ b/internal/printer/rolebinding.go
@@ -23,7 +23,7 @@ func RoleBindingListHandler(ctx context.Context, roleBindingList *rbacv1.RoleBin
 
 	columns := component.NewTableCols("Name", "Age", "Role kind", "Role name")
 	ot := NewObjectTable("Role Bindings", "We couldn't find any role bindings!", columns, opts.DashConfig.ObjectStore())
-
+	ot.EnablePluginStatus(opts.DashConfig.PluginManager())
 	for _, roleBinding := range roleBindingList.Items {
 		row := component.TableRow{}
 		nameLink, err := opts.Link.ForObject(&roleBinding, roleBinding.Name)

--- a/internal/printer/rolebinding_test.go
+++ b/internal/printer/rolebinding_test.go
@@ -40,6 +40,7 @@ func Test_RoleBindingListHandler(t *testing.T) {
 	tpo.PathForGVK(roleBinding.Namespace, rbacAPIVersion, "Role", "pod-reader", "pod-reader", "/role")
 
 	ctx := context.Background()
+	tpo.pluginManager.EXPECT().ObjectStatus(ctx, roleBinding)
 	observed, err := RoleBindingListHandler(ctx, roleBindingList, printOptions)
 	require.NoError(t, err)
 

--- a/internal/printer/secret.go
+++ b/internal/printer/secret.go
@@ -27,7 +27,7 @@ func SecretListHandler(ctx context.Context, list *corev1.SecretList, options Opt
 	}
 
 	ot := NewObjectTable("Secrets", "We couldn't find any secrets!", secretTableCols, options.DashConfig.ObjectStore())
-
+	ot.EnablePluginStatus(options.DashConfig.PluginManager())
 	for _, secret := range list.Items {
 		row := component.TableRow{}
 		nameLink, err := options.Link.ForObject(&secret, secret.Name)

--- a/internal/printer/secret_test.go
+++ b/internal/printer/secret_test.go
@@ -57,6 +57,7 @@ func Test_SecretListHandler(t *testing.T) {
 	tpo.PathForObject(&object.Items[0], object.Items[0].Name, "/secret")
 
 	ctx := context.Background()
+	tpo.pluginManager.EXPECT().ObjectStatus(ctx, &object.Items[0])
 	got, err := SecretListHandler(ctx, object, printOptions)
 	require.NoError(t, err)
 

--- a/internal/printer/service.go
+++ b/internal/printer/service.go
@@ -31,7 +31,7 @@ func ServiceListHandler(ctx context.Context, list *corev1.ServiceList, options O
 
 	cols := component.NewTableCols("Name", "Labels", "Type", "Cluster IP", "External IP", "Ports", "Age", "Selector")
 	ot := NewObjectTable("Services", "We couldn't find any services!", cols, options.DashConfig.ObjectStore())
-
+	ot.EnablePluginStatus(options.DashConfig.PluginManager())
 	for _, s := range list.Items {
 		row := component.TableRow{}
 		nameLink, err := options.Link.ForObject(&s, s.Name)

--- a/internal/printer/service_test.go
+++ b/internal/printer/service_test.go
@@ -99,6 +99,7 @@ func Test_ServiceListHandler(t *testing.T) {
 	tpo.PathForObject(&object.Items[0], object.Items[0].Name, "/service")
 
 	ctx := context.Background()
+	tpo.pluginManager.EXPECT().ObjectStatus(ctx, &object.Items[0])
 	got, err := ServiceListHandler(ctx, object, printOptions)
 	require.NoError(t, err)
 

--- a/internal/printer/serviceaccount.go
+++ b/internal/printer/serviceaccount.go
@@ -29,7 +29,7 @@ func ServiceAccountListHandler(ctx context.Context, list *corev1.ServiceAccountL
 	cols := component.NewTableCols("Name", "Labels", "Secrets", "Age")
 	ot := NewObjectTable("Service Accounts",
 		"We couldn't find any service accounts!", cols, options.DashConfig.ObjectStore())
-
+	ot.EnablePluginStatus(options.DashConfig.PluginManager())
 	for _, serviceAccount := range list.Items {
 		row := component.TableRow{}
 		nameLink, err := options.Link.ForObject(&serviceAccount, serviceAccount.Name)

--- a/internal/printer/serviceaccount_test.go
+++ b/internal/printer/serviceaccount_test.go
@@ -48,6 +48,7 @@ func Test_ServiceAccountListHandler(t *testing.T) {
 	}
 
 	ctx := context.Background()
+	tpo.pluginManager.EXPECT().ObjectStatus(ctx, object)
 	got, err := ServiceAccountListHandler(ctx, list, printOptions)
 	require.NoError(t, err)
 

--- a/internal/printer/statefulset.go
+++ b/internal/printer/statefulset.go
@@ -27,7 +27,7 @@ func StatefulSetListHandler(ctx context.Context, list *appsv1.StatefulSetList, o
 
 	cols := component.NewTableCols("Name", "Labels", "Desired", "Current", "Age", "Selector")
 	ot := NewObjectTable("StatefulSets", "We couldn't find any stateful sets!", cols, options.DashConfig.ObjectStore())
-
+	ot.EnablePluginStatus(options.DashConfig.PluginManager())
 	for _, statefulSet := range list.Items {
 		row := component.TableRow{}
 		nameLink, err := options.Link.ForObject(&statefulSet, statefulSet.Name)

--- a/internal/printer/statefulset_test.go
+++ b/internal/printer/statefulset_test.go
@@ -78,6 +78,7 @@ func Test_StatefulSetListHandler(t *testing.T) {
 	}
 
 	ctx := context.Background()
+	tpo.pluginManager.EXPECT().ObjectStatus(ctx, statefulSet)
 	got, err := StatefulSetListHandler(ctx, object, printOptions)
 	require.NoError(t, err)
 
@@ -331,6 +332,7 @@ func Test_StatefulSetPods(t *testing.T) {
 	}
 
 	tpo.objectStore.EXPECT().List(gomock.Any(), gomock.Eq(key)).Return(podList, false, nil)
+	tpo.pluginManager.EXPECT().ObjectStatus(ctx, pod)
 
 	printOptions := tpo.ToOptions()
 	printOptions.DisableLabels = false
@@ -342,7 +344,7 @@ func Test_StatefulSetPods(t *testing.T) {
 	expected := component.NewTable("Pods", "We couldn't find any pods!", cols)
 	expected.Add(component.TableRow{
 		"Name": component.NewLink("", "web-0", "/pod",
-			genObjectStatus(component.TextStatusWarning, []string{""})),
+			genObjectStatus(component.TextStatusWarning, []string{"Pod may require additional action"})),
 		"Ready":    component.NewText("1/1"),
 		"Phase":    component.NewText("Pending"),
 		"Restarts": component.NewText("0"),

--- a/internal/printer/storageclass.go
+++ b/internal/printer/storageclass.go
@@ -25,7 +25,7 @@ func StorageClassListHandler(ctx context.Context, list *storagev1.StorageClassLi
 
 	cols := component.NewTableCols("Name", "Provisioner", "Age")
 	ot := NewObjectTable("Storage Class", "We couldn't find any storage class!", cols, options.DashConfig.ObjectStore())
-
+	ot.EnablePluginStatus(options.DashConfig.PluginManager())
 	for _, sc := range list.Items {
 		row := component.TableRow{}
 		nameLink, err := options.Link.ForObject(&sc, sc.Name)

--- a/internal/printer/storageclass_test.go
+++ b/internal/printer/storageclass_test.go
@@ -81,6 +81,7 @@ func Test_StorageClassListHandler(t *testing.T) {
 					Kind:       object.Kind,
 					Name:       object.Name,
 				}).Return(testutil.ToUnstructured(t, object), nil).AnyTimes()
+				tpo.pluginManager.EXPECT().ObjectStatus(ctx, object)
 			}
 			got, err := StorageClassListHandler(ctx, tc.list, printOptions)
 			if tc.isErr {

--- a/internal/printer/validatingwebhookconfiguration.go
+++ b/internal/printer/validatingwebhookconfiguration.go
@@ -24,7 +24,7 @@ func ValidatingWebhookConfigurationListHandler(ctx context.Context, list *admiss
 
 	cols := component.NewTableCols("Name", "Age")
 	ot := NewObjectTable("Validating Webhook Configurations", "We couldn't find any validating webhook configurations!", cols, options.DashConfig.ObjectStore())
-
+	ot.EnablePluginStatus(options.DashConfig.PluginManager())
 	for _, validatingWebhookConfiguration := range list.Items {
 		row := component.TableRow{}
 		nameLink, err := options.Link.ForObject(&validatingWebhookConfiguration, validatingWebhookConfiguration.Name)

--- a/internal/printer/validatingwebhookconfiguration_test.go
+++ b/internal/printer/validatingwebhookconfiguration_test.go
@@ -38,6 +38,7 @@ func Test_ValidatingWebhookConfigurationListHandler(t *testing.T) {
 	now := testutil.Time()
 
 	ctx := context.Background()
+	tpo.pluginManager.EXPECT().ObjectStatus(ctx, object)
 	got, err := ValidatingWebhookConfigurationListHandler(ctx, list, printOptions)
 	require.NoError(t, err)
 

--- a/internal/resourceviewer/handler.go
+++ b/internal/resourceviewer/handler.go
@@ -433,18 +433,22 @@ func NewHandlerObjectStatus(objectStore store.Store, pluginManager plugin.Manage
 }
 
 func (h *HandlerObjectStatus) Status(ctx context.Context, object runtime.Object, link link.Interface) (*objectstatus.ObjectStatus, error) {
-	status, err := objectstatus.Status(ctx, object, h.objectStore, link)
+	pluginStatus, err := h.pluginManager.ObjectStatus(ctx, object)
 	if err != nil {
 		return nil, err
 	}
 
-	pluginStatus, err := h.pluginManager.ObjectStatus(ctx, object)
+	status, err := objectstatus.Status(ctx, object, h.objectStore, link)
 	if err != nil {
 		return nil, err
 	}
 
 	status.Details = append(status.Details, pluginStatus.ObjectStatus.Details...)
 	status.Properties = append(status.Properties, pluginStatus.ObjectStatus.Properties...)
+
+	if pluginStatus.ObjectStatus.Status != "" {
+		status.NodeStatus = pluginStatus.ObjectStatus.Status
+	}
 
 	return &status, nil
 }

--- a/web/src/stories/docs/plugins/GoPluginsIntro.story.mdx
+++ b/web/src/stories/docs/plugins/GoPluginsIntro.story.mdx
@@ -181,22 +181,41 @@ func handleTab(dashboardClient service.Dashboard, object runtime.Object) (*compo
 
 ## Object Status
 
-An `ObjectStatusResponse` has an `ObjectStatus` which currently maps to a `PodSummary` and contains a list of Details and a NodeStatus (ok, warning, error). Details can be any of the various components found in [reference](/docs/reference).
+An `ObjectStatusResponse` has an `ObjectStatus` which contains a list of Properties, Details, and a Status (ok, warning, error). Details can be any of the various components found in [reference](/docs/reference).
+
+A resource viewer shows the property labels and their respective components inside a table. Details can be seen in datagrid tables by clicking the icon.
 
 ```go
-func handleObjectStatus(dashboardClient service.Dashboard, object runtime.Object) (plugin.ObjectStatusResponse, error) {
-	if object == nil {
-		return plugin.ObjectStatusResponse{}, errors.New("object is nil")
+func handleStatus(request *service.PrintRequest) (plugin.ObjectStatusResponse, error) {
+	if request.Object == nil {
+		return plugin.ObjectStatusResponse{}, errors.Errorf("object is nil")
 	}
 
-	objectStatusResp := plugin.ObjectStatusResponse{
+	key, err := store.KeyFromObject(request.Object)
+	if err != nil {
+		return plugin.ObjectStatusResponse{}, err
+	}
+	u, err := request.DashboardClient.Get(request.Context(), key)
+	if err != nil {
+		return plugin.ObjectStatusResponse{}, err
+	}
+
+	if u == nil {
+		return plugin.ObjectStatusResponse{}, errors.New("object doesn't exist")
+	}
+
+	return plugin.ObjectStatusResponse{
 		ObjectStatus: component.PodSummary{
-			Details: []component.Component{component.NewText("plugin-name: added status")},
-			Status:  component.NodeStatusOK,
+			Status: component.NodeStatusError,
+			Details: []component.Component{
+				component.NewText("from plugin: " + string(u.GetUID())),
+			},
+			Properties: []component.Property{{
+				Label: "ID (from plugin)",
+				Value: component.NewText(string(u.GetUID())),
+			}},
 		},
-	}
-
-	return objectStatusResp, nil
+	}, nil
 }
 ```
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR allows a plugin author to:

Add components to the signpost over a status icon:
![image](https://user-images.githubusercontent.com/10288252/126575014-c9907001-64db-4810-9e29-9304207c9bc0.png)

Decide what status to be shown in a resource viewer:
![image](https://user-images.githubusercontent.com/10288252/126575103-f241471a-6ea0-486d-a496-2759747c9db6.png)

Notes:
 - Details are not shown for pods as the heptagons are preferred
 - Properties (the table inside the right panel of a resource viewer) has always been working

**Which issue(s) this PR fixes**
- Fixes #2651 

Signed-off-by: Sam Foo <foos@vmware.com>
