### PR TITLE
Added status column to Pod list

### DIFF
--- a/changelogs/unreleased/201-ftovaro
+++ b/changelogs/unreleased/201-ftovaro
@@ -1,0 +1,1 @@
+Added status column to Pod list

--- a/internal/printer/daemonset_test.go
+++ b/internal/printer/daemonset_test.go
@@ -190,6 +190,14 @@ func Test_DaemonSetPods(t *testing.T) {
 				Image:        "fluentd:1.7",
 				RestartCount: 0,
 				Ready:        false,
+				State: corev1.ContainerState{
+					Waiting: &corev1.ContainerStateWaiting{
+						Reason:  "ContainerCreating",
+						Message: "",
+					},
+					Running:    nil,
+					Terminated: nil,
+				},
 			},
 		},
 	}
@@ -218,13 +226,14 @@ func Test_DaemonSetPods(t *testing.T) {
 	got, err := createPodListView(ctx, daemonSet, printOptions)
 	require.NoError(t, err)
 
-	cols := component.NewTableCols("Name", "Ready", "Phase", "Restarts", "Node", "Age")
+	cols := component.NewTableCols("Name", "Ready", "Phase", "Status", "Restarts", "Node", "Age")
 	expected := component.NewTable("Pods", "We couldn't find any pods!", cols)
 	expected.Add(component.TableRow{
 		"Name": component.NewLink("", "fluentd-elasticsearch-dvskv", "/pod",
 			genObjectStatus(component.TextStatusWarning, []string{""})),
 		"Ready":    component.NewText("0/1"),
 		"Phase":    component.NewText("Pending"),
+		"Status":   component.NewText("ContainerCreating"),
 		"Restarts": component.NewText("0"),
 		"Node":     nodeLink,
 		"Age":      component.NewTimestamp(now),

--- a/internal/printer/persistentvolumeclaim_test.go
+++ b/internal/printer/persistentvolumeclaim_test.go
@@ -278,6 +278,11 @@ func Test_PersistentVolumeClaimMountedPodsList(t *testing.T) {
 				Image:        "mysql:5.6",
 				RestartCount: 0,
 				Ready:        true,
+				State: corev1.ContainerState{
+					Waiting:    nil,
+					Running:    &corev1.ContainerStateRunning{StartedAt: metav1.Time{Time: now}},
+					Terminated: nil,
+				},
 			},
 		},
 	}
@@ -316,7 +321,7 @@ func Test_PersistentVolumeClaimMountedPodsList(t *testing.T) {
 	got, err := createMountedPodListView(ctx, pvc.Namespace, pvc.Name, printOptions)
 	require.NoError(t, err)
 
-	cols := component.NewTableCols("Name", "Ready", "Phase", "Restarts", "Node", "Age")
+	cols := component.NewTableCols("Name", "Ready", "Phase", "Status", "Restarts", "Node", "Age")
 	expected := component.NewTable("Pods", "We couldn't find any pods!", cols)
 	expected.Add(component.TableRow{
 		"Name": component.NewLink("", "wordpress-mysql-67565bd57-8fzbh", "/pod",
@@ -324,6 +329,7 @@ func Test_PersistentVolumeClaimMountedPodsList(t *testing.T) {
 
 		"Ready":    component.NewText("1/1"),
 		"Phase":    component.NewText("Running"),
+		"Status":   component.NewText("Running"),
 		"Restarts": component.NewText("0"),
 		"Node":     nodeLink,
 		"Age":      component.NewTimestamp(now),

--- a/internal/printer/pod.go
+++ b/internal/printer/pod.go
@@ -26,8 +26,8 @@ import (
 )
 
 var (
-	podColsWithLabels    = component.NewTableCols("Name", "Labels", "Ready", "Phase", "Restarts", "Node", "Age")
-	podColsWithOutLabels = component.NewTableCols("Name", "Ready", "Phase", "Restarts", "Node", "Age")
+	podColsWithLabels    = component.NewTableCols("Name", "Labels", "Ready", "Phase", "Status", "Restarts", "Node", "Age")
+	podColsWithOutLabels = component.NewTableCols("Name", "Ready", "Phase", "Status", "Restarts", "Node", "Age")
 	podResourceCols      = component.NewTableCols("Container", "Request: Memory", "Request: CPU", "Limit: Memory", "Limit: CPU")
 )
 
@@ -69,6 +69,22 @@ func PodListHandler(ctx context.Context, list *corev1.PodList, opts Options) (co
 		row["Ready"] = component.NewText(ready)
 
 		row["Phase"] = component.NewText(string(pod.Status.Phase))
+
+		if len(pod.Status.ContainerStatuses) > 0 {
+			lastStatus := pod.Status.ContainerStatuses[len(pod.Status.ContainerStatuses)-1]
+
+			if state := lastStatus.State.Waiting; state != nil {
+				row["Status"] = component.NewText(lastStatus.State.Waiting.Reason)
+			} else if state := lastStatus.State.Running; state != nil {
+				row["Status"] = component.NewText("Running")
+			}
+
+			if pod.DeletionTimestamp != nil && lastStatus.State.Terminated == nil {
+				row["Status"] = component.NewText("Terminating")
+			}
+		} else {
+			row["Status"] = component.NewText("")
+		}
 
 		restartCounter := 0
 		for _, c := range pod.Status.ContainerStatuses {

--- a/internal/printer/replicaset_test.go
+++ b/internal/printer/replicaset_test.go
@@ -288,6 +288,14 @@ func Test_ReplicaSetPods(t *testing.T) {
 				Image:        "nginx:1.15",
 				RestartCount: 0,
 				Ready:        false,
+				State: corev1.ContainerState{
+					Waiting: &corev1.ContainerStateWaiting{
+						Reason:  "ContainerCreating",
+						Message: "",
+					},
+					Running:    nil,
+					Terminated: nil,
+				},
 			},
 		},
 	}
@@ -316,13 +324,14 @@ func Test_ReplicaSetPods(t *testing.T) {
 	got, err := createPodListView(ctx, replicaSet, printOptions)
 	require.NoError(t, err)
 
-	cols := component.NewTableCols("Name", "Ready", "Phase", "Restarts", "Node", "Age")
+	cols := component.NewTableCols("Name", "Ready", "Phase", "Status", "Restarts", "Node", "Age")
 	expected := component.NewTable("Pods", "We couldn't find any pods!", cols)
 	expected.Add(component.TableRow{
 		"Name": component.NewLink("", "nginx-deployment-59478d9757-nfqbk", "/pod",
 			genObjectStatus(component.TextStatusWarning, []string{""})),
 		"Ready":    component.NewText("0/1"),
 		"Phase":    component.NewText("Pending"),
+		"Status":   component.NewText("ContainerCreating"),
 		"Restarts": component.NewText("0"),
 		"Node":     nodeLink,
 		"Age":      component.NewTimestamp(now),

--- a/internal/printer/replicationcontroller_test.go
+++ b/internal/printer/replicationcontroller_test.go
@@ -261,6 +261,14 @@ func Test_ReplicationControllerPods(t *testing.T) {
 				Image:        "nginx:1.15",
 				RestartCount: 0,
 				Ready:        false,
+				State: corev1.ContainerState{
+					Waiting: &corev1.ContainerStateWaiting{
+						Reason:  "ContainerCreating",
+						Message: "",
+					},
+					Running:    nil,
+					Terminated: nil,
+				},
 			},
 		},
 	}
@@ -289,13 +297,14 @@ func Test_ReplicationControllerPods(t *testing.T) {
 	got, err := createPodListView(ctx, rc, printOptions)
 	require.NoError(t, err)
 
-	cols := component.NewTableCols("Name", "Ready", "Phase", "Restarts", "Node", "Age")
+	cols := component.NewTableCols("Name", "Ready", "Phase", "Status", "Restarts", "Node", "Age")
 	expected := component.NewTable("Pods", "We couldn't find any pods!", cols)
 	expected.Add(component.TableRow{
 		"Name": component.NewLink("", "nginx-hv4qs", "/pod",
 			genObjectStatus(component.TextStatusWarning, []string{""})),
 		"Ready":    component.NewText("0/1"),
 		"Phase":    component.NewText("Pending"),
+		"Status":   component.NewText("ContainerCreating"),
 		"Restarts": component.NewText("0"),
 		"Node":     nodeLink,
 		"Age":      component.NewTimestamp(now),

--- a/internal/printer/statefulset_test.go
+++ b/internal/printer/statefulset_test.go
@@ -310,6 +310,14 @@ func Test_StatefulSetPods(t *testing.T) {
 				Image:        "nginx:1.15",
 				RestartCount: 0,
 				Ready:        true,
+				State: corev1.ContainerState{
+					Waiting: &corev1.ContainerStateWaiting{
+						Reason:  "ContainerCreating",
+						Message: "",
+					},
+					Running:    nil,
+					Terminated: nil,
+				},
 			},
 		},
 	}
@@ -338,13 +346,14 @@ func Test_StatefulSetPods(t *testing.T) {
 	got, err := createPodListView(ctx, statefulSet, printOptions)
 	require.NoError(t, err)
 
-	cols := component.NewTableCols("Name", "Ready", "Phase", "Restarts", "Node", "Age")
+	cols := component.NewTableCols("Name", "Ready", "Phase", "Status", "Restarts", "Node", "Age")
 	expected := component.NewTable("Pods", "We couldn't find any pods!", cols)
 	expected.Add(component.TableRow{
 		"Name": component.NewLink("", "web-0", "/pod",
 			genObjectStatus(component.TextStatusWarning, []string{""})),
 		"Ready":    component.NewText("1/1"),
 		"Phase":    component.NewText("Pending"),
+		"Status":   component.NewText("ContainerCreating"),
 		"Restarts": component.NewText("0"),
 		"Node":     nodeLink,
 		"Age":      component.NewTimestamp(now),


### PR DESCRIPTION
Signed-off-by: ftovaro <f.tovar12@gmail.com>


**What this PR does / why we need it**:
Adds a new column called Status that reflects the status of a Pod in addition to the Phase that is already on the table.

![image](https://user-images.githubusercontent.com/4805305/126788620-5862eeb6-35c0-497d-9833-30ed56ac4112.png)

![image](https://user-images.githubusercontent.com/4805305/126788638-e938a7bd-6694-4cec-9cbc-49642564d3a5.png)

![image](https://user-images.githubusercontent.com/4805305/126788652-edcb8517-d453-4ead-96d1-0b5ba6769252.png)


**Which issue(s) this PR fixes**
- Fixes #201 

**Special notes for your reviewer**:

**Release note**:
```
release-note
```
