### PR TITLE
Change node view to use object tables

### DIFF
--- a/changelogs/unreleased/2665-GuessWhoSamFoo
+++ b/changelogs/unreleased/2665-GuessWhoSamFoo
@@ -1,0 +1,1 @@
+Changed node view to use object tables

--- a/internal/printer/node_test.go
+++ b/internal/printer/node_test.go
@@ -35,17 +35,25 @@ func TestNodeListHandler(t *testing.T) {
 	}
 
 	ctx := context.Background()
+	tpo.pluginManager.EXPECT().ObjectStatus(ctx, node)
+
 	got, err := NodeListHandler(ctx, list, printOptions)
 	require.NoError(t, err)
 
 	expected := component.NewTableWithRows("Nodes", "We couldn't find any nodes!", nodeListColumns, []component.TableRow{
 		{
-			"Age":     component.NewTimestamp(node.CreationTimestamp.Time),
-			"Name":    component.NewLink("", "node-1", "/node"),
+			"Age": component.NewTimestamp(node.CreationTimestamp.Time),
+			"Name": component.NewLink("", "node-1", "/node",
+				genObjectStatus(component.TextStatusOK, []string{
+					"v1 Node is OK",
+				})),
 			"Labels":  component.NewLabels(make(map[string]string)),
 			"Version": component.NewText("1.15.1"),
 			"Status":  component.NewText("Unknown"),
 			"Roles":   component.NewText("<none>"),
+			component.GridActionKey: gridActionsFactory([]component.GridAction{
+				buildObjectDeleteAction(t, node),
+			}),
 		},
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Pending #2673 - the object table should have `ot.EnablePluginStatus(options.DashConfig.PluginManager())`

**Which issue(s) this PR fixes**
- Fixes #2665 

Signed-off-by: Sam Foo <foos@vmware.com>

