### PR TITLE
Hide plugin windows

### DIFF
--- a/changelogs/unreleased/2143-wwitzel3
+++ b/changelogs/unreleased/2143-wwitzel3
@@ -1,0 +1,1 @@
+fixed Go plugins spawning terminals under Windows

--- a/pkg/plugin/manager.go
+++ b/pkg/plugin/manager.go
@@ -12,7 +12,6 @@ package plugin
 import (
 	"context"
 	"fmt"
-	"os/exec"
 	"path/filepath"
 	"sort"
 	"sync"
@@ -60,10 +59,12 @@ func (f *DefaultClientFactory) Init(ctx context.Context, cmd string) Client {
 		dashLogger: log.From(ctx),
 	}
 
+	c := pluginCmd(cmd)
+
 	return plugin.NewClient(&plugin.ClientConfig{
 		HandshakeConfig: Handshake,
 		Plugins:         pluginMap,
-		Cmd:             exec.Command(cmd),
+		Cmd:             c,
 		AllowedProtocols: []plugin.Protocol{
 			plugin.ProtocolGRPC,
 		},

--- a/pkg/plugin/plugincmd_unix.go
+++ b/pkg/plugin/plugincmd_unix.go
@@ -1,4 +1,4 @@
-// build !windows
+// +build !windows
 
 /*
 Copyright (c) 2019 the Octant contributors. All Rights Reserved.

--- a/pkg/plugin/plugincmd_unix.go
+++ b/pkg/plugin/plugincmd_unix.go
@@ -1,0 +1,17 @@
+// build !windows
+
+/*
+Copyright (c) 2019 the Octant contributors. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package plugin
+
+import (
+	"os/exec"
+)
+
+func pluginCmd(cmd string) *exec.Cmd {
+	pluginCmd := exec.Command(cmd)
+	return pluginCmd
+}

--- a/pkg/plugin/plugincmd_windows.go
+++ b/pkg/plugin/plugincmd_windows.go
@@ -1,0 +1,19 @@
+// build +windows
+
+/*
+Copyright (c) 2019 the Octant contributors. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package plugin
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func pluginCmd(cmd string) *exec.Cmd {
+	pluginCmd := exec.Command(cmd)
+	pluginCmd.SysProcAttr := &syscall.SysProcAttr{HideWindow: true}
+	return pluginCmd
+}

--- a/pkg/plugin/plugincmd_windows.go
+++ b/pkg/plugin/plugincmd_windows.go
@@ -1,4 +1,4 @@
-// build +windows
+// +build windows
 
 /*
 Copyright (c) 2019 the Octant contributors. All Rights Reserved.
@@ -14,6 +14,6 @@ import (
 
 func pluginCmd(cmd string) *exec.Cmd {
 	pluginCmd := exec.Command(cmd)
-	pluginCmd.SysProcAttr := &syscall.SysProcAttr{HideWindow: true}
+	pluginCmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
 	return pluginCmd
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Resolves terminal windows from plugins on Windows

**Which issue(s) this PR fixes**
- Fixes #2143
