### PR TITLE
Add styling for octant.dev tables

### DIFF
--- a/site/themes/octant/assets/scss/_components.scss
+++ b/site/themes/octant/assets/scss/_components.scss
@@ -439,6 +439,27 @@
     strong {
       font-family: $metropolis-medium;
     }
+
+    table {
+      border-collapse: collapse;
+      border-spacing: 0;
+      width: 100%;
+      border: 1px solid #dee2e6;
+    }
+
+    thead {
+      background-color: #f2f2f2;
+    }
+
+    th, td {
+      text-align: left;
+      padding: 16px;
+      border-bottom: 1px solid #dee2e6;
+    }
+
+    tr:nth-child(even) {
+      background-color: #f2f2f2;
+    }
   }
 }
 


### PR DESCRIPTION
Probably could use bootstrap in the near future. Or even better, standardize themes across velero.io and projectcontour.io

Signed-off-by: Sam Foo <foos@vmware.com>
