### PR TITLE
Fix link to octant's references page and Update Electron's doc

### DIFF
--- a/changelogs/unreleased/2902-ftovaro
+++ b/changelogs/unreleased/2902-ftovaro
@@ -1,0 +1,1 @@
+Update documentation and fix link to octant's references page

--- a/site/themes/octant/layouts/partials/getting-started.html
+++ b/site/themes/octant/layouts/partials/getting-started.html
@@ -5,7 +5,11 @@
 			<p>To help you get started, see the documentation.</p>
 		</div>
 		<div class="right-side">
-			<a href="/docs/" class="button">Documentation</a>
+			{{ if eq (path.Dir .Page.File.Path) "docs" }}
+				<a href="https://reference.octant.dev" target="_blank" class="button">Documentation</a>
+			{{ else }}
+				<a href="/docs/" class="button">Documentation</a>
+			{{ end }}
 		</div>
 	</div>
 </div>

--- a/web/src/stories/docs/hacking/Electron.story.mdx
+++ b/web/src/stories/docs/hacking/Electron.story.mdx
@@ -20,8 +20,11 @@ mode.
 Octant is still primarily a browser-based application. To run the
 Electron application, the Angular frontend must be running first.
 
-`$ go run build.go build-electron-dev`
+`$ go run build.go build-electron`
 
-An application will be generated in `cmd/octant-electron/output`. Currently,
-the application is configured to proxy the frontend to a separately running
-Angular frontend (at 127.0.0.1:4200).
+After, move to `/web` and run `npm run electron:local`
+
+An Electron application will be opened
+
+Currently, the application is configured to proxy the frontend to a
+separately running Angular frontend (at 127.0.0.1:4200).


### PR DESCRIPTION
**What this PR does / why we need it**:

- Fix link to octant's references page

![Untitled_ Sep 27, 2021 8_58 AM](https://user-images.githubusercontent.com/4805305/134923529-f2c750fb-1242-4778-a5f6-234d9fd953de.gif)

- Update Electron's doc

**Which issue(s) this PR fixes**
- Fixes #

**Special notes for your reviewer**:

**Release note**:
```
release-note
```
