### PR TITLE
Support Secret with binary data

### DIFF
--- a/internal/printer/secret.go
+++ b/internal/printer/secret.go
@@ -7,7 +7,9 @@ package printer
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
+	"unicode/utf8"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -106,7 +108,11 @@ func describeSecretData(secret corev1.Secret) (*component.Table, error) {
 	for key, value := range secret.Data {
 		row := component.TableRow{}
 		keyText := component.NewText(key)
-		keyText.AddClipboard(string(value))
+		if utf8.Valid(value) {
+			keyText.AddClipboard(string(value))
+		} else {
+			keyText.AddClipboard(base64.StdEncoding.EncodeToString(value))
+		}
 		row["Key"] = keyText
 		table.Add(row)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Support for `Secret` containing binary data, for example:

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: binary-secret
type: Opaque
data:
  data.bin: ////
```

Before this fix, the page fails to render with the error:
```
ERROR	websockets/websocket_client.go:295	Unhandled websocket error	{"component": "websocket-client", "client-id": "4b1ba621-7393-11ec-9629-fa2adfb26a7d", "err": "websocket: close 1002 (protocol error): Invalid UTF-8 in text frame"}
```

**Release note**:
```
Support Secret with binary data
```
