### PR TITLE
Fix disabled Clarity buttons

### DIFF
--- a/changelogs/unreleased/3057-GuessWhoSamFoo
+++ b/changelogs/unreleased/3057-GuessWhoSamFoo
@@ -1,0 +1,1 @@
+Fixed disabled buttons

--- a/web/src/app/modules/shared/components/presentation/button/button.component.html
+++ b/web/src/app/modules/shared/components/presentation/button/button.component.html
@@ -2,7 +2,7 @@
   action="{{ style }}"
   status="{{ status }}"
   size="{{ size }}"
-  disabled="{{ disabled }}"
+  [attr.disabled]="disabled"
   block="{{ block }}"
   (click)="onClick(v?.config?.payload, v?.config?.confirmation, v?.config?.modal)">
   {{ v?.config?.name }}


### PR DESCRIPTION
**What this PR does / why we need it**:
All buttons were disabled - see storybook.

**Which issue(s) this PR fixes**
- Fixes #3057 

Signed-off-by: Sam Foo <foos@vmware.com>
