### PR TITLE
fix: Calling the DynamicCache.gvrFromKey method when the gvr is not cached returns an nil object #3177

### DIFF
--- a/internal/objectstore/dynamic_cache.go
+++ b/internal/objectstore/dynamic_cache.go
@@ -498,7 +498,8 @@ func (d *DynamicCache) gvrFromKey(ctx context.Context, key store.Key) (schema.Gr
 
 	v, ok := d.gvrCache.Load(gk)
 	if !ok {
-		gvr, _, err := d.client.Resource(gk)
+		var err error
+		gvr, _, err = d.client.Resource(gk)
 		if err != nil {
 			return schema.GroupVersionResource{}, err
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

fix #3177 

**Which issue(s) this PR fixes**
- Fixes #3177 

**Special notes for your reviewer**:

**Release note**:
```
release-note
```
